### PR TITLE
Implemented roll-related features:

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -785,6 +785,7 @@ public:
 	// These also set CF_INTERPVIEW for players.
 	void SetPitch(int p, bool interpolate);
 	void SetAngle(angle_t ang, bool interpolate);
+	void SetRoll(angle_t r, bool interpolate);
 
 	const PClass *GetBloodType(int type = 0) const
 	{

--- a/src/gl/scene/gl_scene.cpp
+++ b/src/gl/scene/gl_scene.cpp
@@ -783,6 +783,9 @@ sector_t * FGLRenderer::RenderViewpoint (AActor * camera, GL_IRECT * bounds, flo
 
 	mAngles.Pitch = (float)RAD2DEG(asin(angy / alen));
 
+	// roll the camera
+	mAngles.Roll = (float)(camera->roll>>ANGLETOFINESHIFT)*360.0f/FINEANGLES;
+
 	// Scroll the sky
 	mSky1Pos = (float)fmod(gl_frameMS * level.skyspeed1, 1024.f) * 90.f/256.f;
 	mSky2Pos = (float)fmod(gl_frameMS * level.skyspeed2, 1024.f) * 90.f/256.f;

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -4440,6 +4440,9 @@ enum EACSFunctions
 	ACSF_CanRaiseActor,
 	ACSF_SetActorTeleFog,		// 86
 	ACSF_SwapActorTeleFog,
+	ACSF_SetActorRoll,
+	ACSF_ChangeActorRoll,
+	ACSF_GetActorRoll,
 
 	/* Zandronum's - these must be skipped when we reach 99!
 	-100:ResetMap(0),
@@ -4747,6 +4750,27 @@ static void SetActorPitch(AActor *activator, int tid, int angle, bool interpolat
 		while ((actor = iterator.Next()))
 		{
 			actor->SetPitch(angle << 16, interpolate);
+		}
+	}
+}
+
+static void SetActorRoll(AActor *activator, int tid, int angle, bool interpolate)
+{
+	if (tid == 0)
+	{
+		if (activator != NULL)
+		{
+			activator->SetRoll(angle << 16, interpolate);
+		}
+	}
+	else
+	{
+		FActorIterator iterator(tid);
+		AActor *actor;
+
+		while ((actor = iterator.Next()))
+		{
+			actor->SetRoll(angle << 16, interpolate);
 		}
 	}
 }
@@ -5831,6 +5855,26 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				return !canraiseall;
 			}
 			break;
+
+		// [Nash] actor rolling functions
+		case ACSF_SetActorRoll:
+			actor = SingleActorFromTID(args[0], activator);
+			if (actor != NULL)
+			{
+				actor->SetRoll(args[1] << 16, false);
+			}
+			return 0;
+
+		case ACSF_ChangeActorRoll:
+			if (argCount >= 2)
+			{
+				SetActorRoll(activator, args[0], args[1], argCount > 2 ? !!args[2] : false);
+			}
+			break;
+
+		case ACSF_GetActorRoll:
+			actor = SingleActorFromTID(args[0], activator);
+			return actor != NULL? actor->roll >> 16 : 0;
 
 		default:
 			break;

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -3077,6 +3077,18 @@ void AActor::SetAngle(angle_t ang, bool interpolate)
 	}
 }
 
+void AActor::SetRoll(angle_t r, bool interpolate) // [Nash] actor roll
+{
+	if (r != roll)
+	{
+		roll = r;
+		if (player != NULL && interpolate)
+		{
+			player->cheats |= CF_INTERPVIEW;
+		}
+	}
+}
+
 //
 // P_MobjThinker
 //

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -3971,6 +3971,22 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetPitch)
 
 //===========================================================================
 //
+// [Nash] A_SetRoll
+//
+// Set actor's roll (in degrees).
+//
+//===========================================================================
+
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetRoll)
+{
+	ACTION_PARAM_START(2);
+	ACTION_PARAM_ANGLE(roll, 0);
+	ACTION_PARAM_INT(flags, 1);
+	self->SetRoll(roll, !!(flags & SPF_INTERPOLATE));
+}
+
+//===========================================================================
+//
 // A_ScaleVelocity
 //
 // Scale actor's velocity.

--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -89,6 +89,7 @@ DEFINE_MEMBER_VARIABLE(radius, AActor)
 DEFINE_MEMBER_VARIABLE(reactiontime, AActor)
 DEFINE_MEMBER_VARIABLE(meleerange, AActor)
 DEFINE_MEMBER_VARIABLE(Speed, AActor)
+DEFINE_MEMBER_VARIABLE(roll, AActor) // [Nash] actor roll
 
 
 //==========================================================================

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -68,6 +68,7 @@ ACTOR Actor native //: Thinker
 	native int reactiontime;
 	native fixed_t meleerange;
 	native fixed_t speed;
+	native angle_t roll;
 
 	// Meh, MBF redundant functions. Only for DeHackEd support.
 	action native A_Turn(float angle = 0);
@@ -290,6 +291,7 @@ ACTOR Actor native //: Thinker
 	action native A_MonsterRefire(int chance, state label);
 	action native A_SetAngle(float angle = 0, int flags = 0);
 	action native A_SetPitch(float pitch, int flags = 0);
+	action native A_SetRoll(float roll, int flags = 0);
 	action native A_ScaleVelocity(float scale);
 	action native A_ChangeVelocity(float x = 0, float y = 0, float z = 0, int flags = 0);
 	action native A_SetArg(int pos, int value);

--- a/wadsrc/static/actors/constants.txt
+++ b/wadsrc/static/actors/constants.txt
@@ -346,7 +346,7 @@ Const Int WARPF_TESTONLY = 0x200;
 Const Int WAPRF_ABSOLUTEPOSITION = 0x400;
 Const Int WARPF_ABSOLUTEPOSITION = 0x400;
 
-// flags for A_SetPitch/SetAngle
+// flags for A_SetPitch/SetAngle/SetRoll
 const int SPF_FORCECLAMP = 1;
 const int SPF_INTERPOLATE = 2;
 


### PR DESCRIPTION
- DECORATE A_SetRoll code pointer.
- DECORATE "roll" variable.
- ACS SetActorRoll, GetActorRoll.
- Add roll support to the camera in OpenGL.

These currently don't really do anything in the software renderer. Only GZDoom's models will be affected if they have the InheritActorRoll flag in their MODELDEFS... or, if used on the player; the player's view will roll appropriately.