### PR TITLE
Flat, Wall, and Roll Sprites v2

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -875,7 +875,7 @@ public:
 // NOTE: The first member variable *must* be x.
 	fixed_t	 		x,y,z;
 	AActor			*snext, **sprev;	// links in sector (if needed)
-	angle_t			angle;
+	angle_t			angle, flatangle;
 	WORD			sprite;				// used to find patch_t and flip value
 	BYTE			frame;				// sprite frame to draw
 	fixed_t			scaleX, scaleY;		// Scaling values; FRACUNIT is normal size

--- a/src/actor.h
+++ b/src/actor.h
@@ -400,12 +400,13 @@ enum ActorRenderFlag
 	RF_SPRITETYPEMASK	= 0x7000,	// ---Different sprite types, not all implemented
 	RF_FACESPRITE		= 0x0000,	// Face sprite
 	RF_WALLSPRITE		= 0x1000,	// Wall sprite
-	RF_FLOORSPRITE		= 0x2000,	// Floor sprite
+	RF_FLATSPRITE		= 0x2000,	// Floor sprite
 	RF_VOXELSPRITE		= 0x3000,	// Voxel object
 	RF_INVISIBLE		= 0x8000,	// Don't bother drawing this actor
 
 	RF_FORCEYBILLBOARD		= 0x10000,	// [BB] OpenGL only: draw with y axis billboard, i.e. anchored to the floor (overrides gl_billboard_mode setting)
 	RF_FORCEXYBILLBOARD		= 0x20000,	// [BB] OpenGL only: draw with xy axis billboard, i.e. unanchored (overrides gl_billboard_mode setting)
+	RF_ROLLSPRITE			= 0x40000,	// [marrub] roll the sprite billboard
 };
 
 #define TRANSLUC25			(FRACUNIT/4)

--- a/src/actor.h
+++ b/src/actor.h
@@ -402,6 +402,7 @@ enum ActorRenderFlag
 	RF_WALLSPRITE		= 0x1000,	// Wall sprite
 	RF_FLATSPRITE		= 0x2000,	// Floor sprite
 	RF_VOXELSPRITE		= 0x3000,	// Voxel object
+	RF_PITCHFLATSPRITE  = 0x4000,	// [MC] OpenGL only: tilt the sprite up and down based on pitch.
 	RF_INVISIBLE		= 0x8000,	// Don't bother drawing this actor
 
 	RF_FORCEYBILLBOARD		= 0x10000,	// [BB] OpenGL only: draw with y axis billboard, i.e. anchored to the floor (overrides gl_billboard_mode setting)

--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -252,11 +252,13 @@ void GLSprite::Draw(int pass)
 			float angleRad = DEG2RAD(270. - float(GLRenderer->mAngles.Yaw));
 
 			// [fgsfds] calculate yaw vectors
-			float yawvecX, yawvecY;
+			float yawvecX, yawvecY, FlatAngle;
+			
 			if (isFlatSprite)
 			{
 				yawvecX = FIXED2FLOAT(finecosine[actor->angle >> ANGLETOFINESHIFT]);
 				yawvecY = FIXED2FLOAT(finesine[actor->angle >> ANGLETOFINESHIFT]);
+				FlatAngle = FIXED2FLOAT((actor->flatangle)/180);
 			}
 
 			Matrix3x4 mat;
@@ -276,7 +278,8 @@ void GLSprite::Draw(int pass)
 			{
 				angle_t pitchDegrees = 360.0 * (1.0 + (((angle_t)actor->pitch >> 16) / (float)(65536)));
 				fixed_t rollDegrees = 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536)));
-				mat.Rotate(-yawvecY, 0, yawvecX, pitchDegrees); 
+				mat.Rotate(0, 1, 0, -FlatAngle);
+				mat.Rotate(-yawvecY, 0, yawvecX, pitchDegrees);
 				mat.Rotate(yawvecX, 0, yawvecY, rollDegrees);
 			}
 			else if (spritetype == RF_FLATSPRITE)
@@ -286,7 +289,8 @@ void GLSprite::Draw(int pass)
 			// [fgsfds] Rotate the sprite about the sight vector (roll) 
 			else if (spritetype == RF_WALLSPRITE)
 			{
-				mat.Rotate(yawvecX, yawvecY, 0, 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
+				mat.Rotate(yawvecX, 0, yawvecY, 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
+				mat.Rotate(0, 1, 0, -FlatAngle);
 			}
 			else if (drawRollSpriteActor)
 			{

--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -223,6 +223,9 @@ void GLSprite::Draw(int pass)
 		const bool drawWithXYBillboard = ( (particle && gl_billboard_particles) || (!(actor && actor->renderflags & RF_FORCEYBILLBOARD)
 		                                   //&& GLRenderer->mViewActor != NULL
 		                                   && (gl_billboard_mode == 1 || (actor && actor->renderflags & RF_FORCEXYBILLBOARD ))) );
+		// [Nash] has +ROLLSPRITE
+		const bool drawRollSpriteActor = (actor != NULL && actor->renderflags & RF_ROLLSPRITE);
+
 		gl_RenderState.Apply();
 
 		Vector v1;
@@ -230,7 +233,15 @@ void GLSprite::Draw(int pass)
 		Vector v3;
 		Vector v4;
 
-		if (drawWithXYBillboard)
+		// [fgsfds] check sprite type mask
+		DWORD spritetype = (DWORD)-1;
+		if (actor != NULL) spritetype = actor->renderflags & RF_SPRITETYPEMASK;
+
+		// [Nash] is a flat sprite
+		const bool isFlatSprite = (spritetype == RF_WALLSPRITE || spritetype == RF_FLATSPRITE);
+
+		// [Nash] check for special sprite drawing modes
+		if (drawWithXYBillboard || drawRollSpriteActor || isFlatSprite)
 		{
 			// Rotate the sprite about the vector starting at the center of the sprite
 			// triangle strip and with direction orthogonal to where the player is looking
@@ -240,16 +251,55 @@ void GLSprite::Draw(int pass)
 			float zcenter = (z1 + z2)*0.5;
 			float angleRad = DEG2RAD(270. - float(GLRenderer->mAngles.Yaw));
 
+			// [fgsfds] calculate yaw vectors
+			float yawvecX, yawvecY;
+			if (isFlatSprite)
+			{
+				yawvecX = FIXED2FLOAT(finecosine[actor->angle >> ANGLETOFINESHIFT]);
+				yawvecY = FIXED2FLOAT(finesine[actor->angle >> ANGLETOFINESHIFT]);
+			}
+
 			Matrix3x4 mat;
 			mat.MakeIdentity();
 			mat.Translate(xcenter, zcenter, ycenter);
-			mat.Rotate(-sin(angleRad), 0, cos(angleRad), -GLRenderer->mAngles.Pitch);
+
+			// [MC] This is the only thing that I changed in Nash's submission which 
+			// was constantly applying roll to everything. That was wrong. Flat sprites
+			// with roll literally look like paper thing space ships trying to swerve.
+			// However, it does well with wall sprites.
+			// Also, renamed FLOORSPRITE to FLATSPRITE because that's technically incorrect.
+			// I plan on adding proper FLOORSPRITEs which can actually curve along sloped
+			// 3D floors later... if possible.
+
+			// Here we need some form of priority in order to work.
+			if (spritetype == RF_FLATSPRITE)
+			{ // [fgsfds] rotate the sprite so it faces upwards/downwards
+				mat.Rotate(-yawvecY, 0, yawvecX, -90.f);
+			}
+			// [fgsfds] Rotate the sprite about the sight vector (roll) 
+			else if (spritetype == RF_WALLSPRITE)
+			{
+				mat.Rotate(yawvecX, yawvecY, 0, 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
+			}
+			else if (drawRollSpriteActor)
+			{
+				mat.Rotate(cos(angleRad), 0, sin(angleRad), 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
+			}
+			// [Nash] XY Billboard
+			else if (drawWithXYBillboard)
+			{
+				mat.Rotate(-sin(angleRad), 0, cos(angleRad), -GLRenderer->mAngles.Pitch);
+			}			
+
+			// apply the transform
 			mat.Translate(-xcenter, -zcenter, -ycenter);
 			v1 = mat * Vector(x1, z1, y1);
 			v2 = mat * Vector(x2, z1, y2);
 			v3 = mat * Vector(x1, z2, y1);
 			v4 = mat * Vector(x2, z2, y2);
 		}
+
+		// [Nash] just draw the sprite normally
 		else
 		{
 			v1 = Vector(x1, z1, y1);
@@ -581,14 +631,24 @@ void GLSprite::Process(AActor* thing,sector_t * sector)
 	
 
 	x = FIXED2FLOAT(thingx);
-	z = FIXED2FLOAT(thingz-thing->floorclip);
 	y = FIXED2FLOAT(thingy);
 
-	// [RH] Make floatbobbing a renderer-only effect.
-	if (thing->flags2 & MF2_FLOATBOB)
+	// sprite adjustment
+	DWORD spritetype = thing->renderflags & RF_SPRITETYPEMASK;
+	switch (spritetype)
 	{
-		float fz = FIXED2FLOAT(thing->GetBobOffset(r_TicFrac));
-		z += fz;
+	case RF_FLATSPRITE:
+			z = FIXED2FLOAT(thingz);
+			break;
+		default:
+			// [RH] Make floatbobbing a renderer-only effect.
+			z = FIXED2FLOAT(thingz - thing->floorclip);
+			if (thing->flags2 & MF2_FLOATBOB)
+			{
+				float fz = FIXED2FLOAT(thing->GetBobOffset(r_TicFrac));
+				z += fz;
+			}
+			break;
 	}
 	
 	modelframe = gl_FindModelFrame(RUNTIME_TYPE(thing), spritenum, thing->frame, !!(thing->flags & MF_DROPPED));
@@ -636,7 +696,7 @@ void GLSprite::Process(AActor* thing,sector_t * sector)
 
 		float viewvecX;
 		float viewvecY;
-		switch (thing->renderflags & RF_SPRITETYPEMASK)
+		switch (spritetype)
 		{
 		case RF_FACESPRITE:
 			viewvecX = GLRenderer->mViewVector.X;
@@ -649,6 +709,7 @@ void GLSprite::Process(AActor* thing,sector_t * sector)
 			break;
 
 		case RF_WALLSPRITE:
+		case RF_FLATSPRITE:
 			viewvecX = FIXED2FLOAT(finecosine[thing->angle >> ANGLETOFINESHIFT]);
 			viewvecY = FIXED2FLOAT(finesine[thing->angle >> ANGLETOFINESHIFT]);
 
@@ -970,6 +1031,5 @@ void GLSprite::ProcessParticle (particle_t *particle, sector_t *sector)//, int s
 	PutSprite(hw_styleflags != STYLEHW_Solid);
 	rendered_sprites++;
 }
-
 
 

--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -274,7 +274,10 @@ void GLSprite::Draw(int pass)
 			// Here we need some form of priority in order to work.
 			if (spritetype == RF_PITCHFLATSPRITE)
 			{
-				mat.Rotate(-yawvecY, 0, yawvecX, -360.0 * (1.0 - (((angle_t)actor->pitch >> 16) / (float)(65536))));
+				angle_t pitchDegrees = 360.0 * (1.0 + (((angle_t)actor->pitch >> 16) / (float)(65536)));
+				fixed_t rollDegrees = 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536)));
+				mat.Rotate(-yawvecY, 0, yawvecX, pitchDegrees); 
+				mat.Rotate(yawvecX, 0, yawvecY, rollDegrees);
 			}
 			else if (spritetype == RF_FLATSPRITE)
 			{ // [fgsfds] rotate the sprite so it faces upwards/downwards

--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -277,10 +277,13 @@ void GLSprite::Draw(int pass)
 			if (spritetype == RF_PITCHFLATSPRITE)
 			{
 				angle_t pitchDegrees = 360.0 * (1.0 + (((angle_t)actor->pitch >> 16) / (float)(65536)));
-				fixed_t rollDegrees = 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536)));
 				mat.Rotate(0, 1, 0, -FlatAngle);
 				mat.Rotate(-yawvecY, 0, yawvecX, pitchDegrees);
-				mat.Rotate(yawvecX, 0, yawvecY, rollDegrees);
+				if (drawRollSpriteActor)
+				{
+					fixed_t rollDegrees = 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536)));
+					mat.Rotate(yawvecX, 0, yawvecY, rollDegrees);
+				}
 			}
 			else if (spritetype == RF_FLATSPRITE)
 			{ // [fgsfds] rotate the sprite so it faces upwards/downwards
@@ -289,11 +292,16 @@ void GLSprite::Draw(int pass)
 			// [fgsfds] Rotate the sprite about the sight vector (roll) 
 			else if (spritetype == RF_WALLSPRITE)
 			{
-				mat.Rotate(yawvecX, 0, yawvecY, 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
 				mat.Rotate(0, 1, 0, -FlatAngle);
+				if (drawRollSpriteActor)
+					mat.Rotate(yawvecX, 0, yawvecY, 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
 			}
 			else if (drawRollSpriteActor)
 			{
+				if (drawWithXYBillboard)
+				{
+					mat.Rotate(-sin(angleRad), 0, cos(angleRad), -GLRenderer->mAngles.Pitch);
+				}
 				mat.Rotate(cos(angleRad), 0, sin(angleRad), 360.0 * (1.0 - ((actor->roll >> 16) / (float)(65536))));
 			}
 			// [Nash] XY Billboard

--- a/src/namedef.h
+++ b/src/namedef.h
@@ -301,6 +301,7 @@ xx(Sqrt)
 xx(CheckClass)
 xx(IsPointerEqual)
 xx(Pick)
+xx(FlatAngle)
 
 // Various actor names which are used internally
 xx(MapSpot)

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -344,6 +344,10 @@ void AActor::Serialize (FArchive &arc)
 			<< RipLevelMin
 			<< RipLevelMax;
 	}
+	if (SaveVersion >= 4525)
+	{
+		arc << flatangle;
+	}
 
 	{
 		FString tagstr;

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -344,7 +344,7 @@ void AActor::Serialize (FArchive &arc)
 			<< RipLevelMin
 			<< RipLevelMax;
 	}
-	if (SaveVersion >= 4525)
+	if (SaveVersion >= 4529)
 	{
 		arc << flatangle;
 	}

--- a/src/thingdef/thingdef_codeptr.cpp
+++ b/src/thingdef/thingdef_codeptr.cpp
@@ -3983,6 +3983,29 @@ DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetAngle)
 	}
 	ref->SetAngle(angle, !!(flags & SPF_INTERPOLATE));
 }
+//===========================================================================
+//
+// A_SetFlatAngle
+//
+// Set actor's flat angle (in degrees).
+//
+//===========================================================================
+DEFINE_ACTION_FUNCTION_PARAMS(AActor, A_SetFlatAngle)
+{
+	ACTION_PARAM_START(2);
+	ACTION_PARAM_ANGLE(flatangle, 0);
+	ACTION_PARAM_INT(ptr, 1);
+
+	AActor *ref = COPY_AAPTR(self, ptr);
+
+	if (!ref)
+	{
+		ACTION_SET_RESULT(false);
+		return;
+	}
+	
+	ref->flatangle = flatangle;
+}
 
 //===========================================================================
 //

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -271,6 +271,7 @@ static FFlagDef ActorFlagDefs[]=
 	// [fgsfds] Flat sprites
 	DEFINE_FLAG(RF, FLATSPRITE, AActor, renderflags),
 	DEFINE_FLAG(RF, WALLSPRITE, AActor, renderflags),
+	DEFINE_FLAG(RF, PITCHFLATSPRITE, AActor, renderflags),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),

--- a/src/thingdef/thingdef_data.cpp
+++ b/src/thingdef/thingdef_data.cpp
@@ -267,6 +267,10 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF, INVISIBLE, AActor, renderflags),
 	DEFINE_FLAG(RF, FORCEYBILLBOARD, AActor, renderflags),
 	DEFINE_FLAG(RF, FORCEXYBILLBOARD, AActor, renderflags),
+	DEFINE_FLAG(RF, ROLLSPRITE, AActor, renderflags), // [marrub] roll the sprite billboard 
+	// [fgsfds] Flat sprites
+	DEFINE_FLAG(RF, FLATSPRITE, AActor, renderflags),
+	DEFINE_FLAG(RF, WALLSPRITE, AActor, renderflags),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),
@@ -677,4 +681,3 @@ void InitThingdef()
 		qsort(&variables[0], variables.Size(), sizeof(variables[0]), varcmp);
 	}
 }
-

--- a/src/thingdef/thingdef_expression.cpp
+++ b/src/thingdef/thingdef_expression.cpp
@@ -90,6 +90,7 @@ DEFINE_MEMBER_VARIABLE(reactiontime, AActor)
 DEFINE_MEMBER_VARIABLE(meleerange, AActor)
 DEFINE_MEMBER_VARIABLE(Speed, AActor)
 DEFINE_MEMBER_VARIABLE(roll, AActor)
+DEFINE_MEMBER_VARIABLE(flatangle, AActor)
 
 
 //==========================================================================

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4524
+#define SAVEVER 4525
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/src/version.h
+++ b/src/version.h
@@ -76,7 +76,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4525
+#define SAVEVER 4530
 
 #define SAVEVERSTRINGIFY2(x) #x
 #define SAVEVERSTRINGIFY(x) SAVEVERSTRINGIFY2(x)

--- a/wadsrc/static/actors/actor.txt
+++ b/wadsrc/static/actors/actor.txt
@@ -38,6 +38,7 @@ ACTOR Actor native //: Thinker
 	// Variables must be native.
 	native fixed_t alpha;
 	native angle_t angle;
+	native angle_t flatangle;
 	native int args[5];
 	native fixed_t ceilingz;
 	native fixed_t floorz;
@@ -290,6 +291,7 @@ ACTOR Actor native //: Thinker
 	action native A_PigPain ();
 	action native A_MonsterRefire(int chance, state label);
 	action native A_SetAngle(float angle = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
+	action native A_SetFlatAngle(float flatangle = 0, int ptr = AAPTR_DEFAULT);
 	action native A_SetPitch(float pitch, int flags = 0, int ptr = AAPTR_DEFAULT);
 	action native A_SetRoll(float roll, int flags = 0, int ptr = AAPTR_DEFAULT);
 	action native A_ScaleVelocity(float scale, int ptr = AAPTR_DEFAULT);


### PR DESCRIPTION
- Added Nash's, marrub's, and fgsfds's OpenGL sprite changes, and changed them per Randi's instructions.
- FLATSPRITE: renamed from FLOORSPRITE as FLATSPRITE does not stick to the ground and can be on the ceiling.
- Flat sprites also do not form to any curvature and are purely flat. True FLOORSPRITES are planned next.
- WALLSPRITE: Flattens a sprite from its sides. Incorporates ROLLSPRITE.
- ROLLSPRITE: Applies roll to the actor sprite.
- PITCHFLATSPRITE: allows the sprite to rotate based on pitch, supports rolling.
- Flat Angles can be set with A_SetFlatAngle. Use this to rotate to which degree the actor becomes flat against (so 90 will make the actor visible from the side and completely quashed from up front, etc.)