### PR TITLE
<stdlib.h> has replaced <malloc.h> on FreeBSD as well

### DIFF
--- a/src/gl/system/gl_system.h
+++ b/src/gl/system/gl_system.h
@@ -49,7 +49,7 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <signal.h>
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <malloc.h>
 #endif
 #include <time.h>


### PR DESCRIPTION
Fix compilation on FreeBSD -- I hope to some day be able to actually run gzdoom. =)