### PR TITLE
Two other easy-to-implement 3D modes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1189,6 +1189,7 @@ add_executable( zdoom WIN32 MACOSX_BUNDLE
 	gl/stereo3d/gl_stereo_leftright.cpp
 	gl/stereo3d/scoped_view_shifter.cpp
 	gl/stereo3d/gl_anaglyph.cpp
+	gl/stereo3d/gl_quadstereo.cpp
 	gl/dynlights/gl_dynlight.cpp
 	gl/dynlights/gl_glow.cpp
 	gl/dynlights/gl_dynlight1.cpp

--- a/src/gl/stereo3d/gl_anaglyph.cpp
+++ b/src/gl/stereo3d/gl_anaglyph.cpp
@@ -61,4 +61,12 @@ const RedCyan& RedCyan::getInstance(FLOATTYPE ipd)
 }
 
 
+/* static */
+const AmberBlue& AmberBlue::getInstance(FLOATTYPE ipd)
+{
+	static AmberBlue instance(ipd);
+	return instance;
+}
+
+
 } /* namespace s3d */

--- a/src/gl/stereo3d/gl_anaglyph.h
+++ b/src/gl/stereo3d/gl_anaglyph.h
@@ -115,6 +115,14 @@ public:
 	GreenMagenta(float ipd) : MaskAnaglyph(ColorMask(false, true, false), ipd) {}
 };
 
+class AmberBlue : public MaskAnaglyph
+{
+public:
+	static const AmberBlue& getInstance(float ipd);
+
+	AmberBlue(float ipd) : MaskAnaglyph(ColorMask(true, true, false), ipd) {}
+};
+
 // TODO matrix anaglyph
 
 

--- a/src/gl/stereo3d/gl_quadstereo.cpp
+++ b/src/gl/stereo3d/gl_quadstereo.cpp
@@ -1,0 +1,64 @@
+/*
+** gl_quadstereo.cpp
+** Quad-buffered OpenGL stereoscopic 3D mode for GZDoom
+**
+**---------------------------------------------------------------------------
+** Copyright 2015 Christopher Bruns
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions
+** are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+** 2. Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in the
+**    documentation and/or other materials provided with the distribution.
+** 3. The name of the author may not be used to endorse or promote products
+**    derived from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+** IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+** OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+** IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+** INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+** NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+** THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**---------------------------------------------------------------------------
+**
+**
+*/
+
+#include "gl_quadstereo.h"
+
+namespace s3d {
+
+QuadStereo::QuadStereo(double ipdMeters)
+	: leftEye(ipdMeters), rightEye(ipdMeters)
+{
+	// Check whether quad-buffered stereo is supported in the current context
+	GLboolean supportsStereo, supportsBuffered;
+	glGetBooleanv(GL_STEREO, &supportsStereo);
+	glGetBooleanv(GL_DOUBLEBUFFER, &supportsBuffered);
+	bool bQuadStereoSupported = supportsStereo && supportsBuffered;
+	leftEye.bQuadStereoSupported = bQuadStereoSupported;
+	rightEye.bQuadStereoSupported = bQuadStereoSupported;
+
+	eye_ptrs.Push(&leftEye);
+	// If stereo is not supported, just draw scene once
+	if (bQuadStereoSupported)
+		eye_ptrs.Push(&rightEye);
+}
+
+/* static */
+const QuadStereo& QuadStereo::getInstance(float ipd)
+{
+	static QuadStereo instance(ipd);
+	return instance;
+}
+
+} /* namespace s3d */

--- a/src/gl/stereo3d/gl_quadstereo.cpp
+++ b/src/gl/stereo3d/gl_quadstereo.cpp
@@ -41,6 +41,8 @@ QuadStereo::QuadStereo(double ipdMeters)
 	: leftEye(ipdMeters), rightEye(ipdMeters)
 {
 	// Check whether quad-buffered stereo is supported in the current context
+	// We are assuming the OpenGL context is already current at this point,
+	// i.e. this constructor is called "just in time".
 	GLboolean supportsStereo, supportsBuffered;
 	glGetBooleanv(GL_STEREO, &supportsStereo);
 	glGetBooleanv(GL_DOUBLEBUFFER, &supportsBuffered);
@@ -49,9 +51,10 @@ QuadStereo::QuadStereo(double ipdMeters)
 	rightEye.bQuadStereoSupported = bQuadStereoSupported;
 
 	eye_ptrs.Push(&leftEye);
-	// If stereo is not supported, just draw scene once
-	if (bQuadStereoSupported)
+	// If stereo is not supported, just draw scene once (left eye view only)
+	if (bQuadStereoSupported) {
 		eye_ptrs.Push(&rightEye);
+	}
 }
 
 /* static */

--- a/src/gl/stereo3d/gl_quadstereo.h
+++ b/src/gl/stereo3d/gl_quadstereo.h
@@ -73,6 +73,13 @@ public:
 	bool bQuadStereoSupported;
 };
 
+// To use Quad-buffered stereo mode with nvidia 3d vision glasses, 
+// you must either:
+// A) be using a Quadro series video card, OR
+//
+// B) be using nvidia driver version 314.07 or later
+//    AND have your monitor set to 120 Hz refresh rate
+//    AND have gzdoom in true full screen mode
 class QuadStereo : public Stereo3DMode
 {
 public:

--- a/src/gl/stereo3d/gl_quadstereo.h
+++ b/src/gl/stereo3d/gl_quadstereo.h
@@ -1,9 +1,9 @@
 /*
-** gl_anaglyph.h
-** Color mask based stereoscopic 3D modes for GZDoom
+** gl_quadstereo.h
+** Quad-buffered OpenGL stereoscopic 3D mode for GZDoom
 **
 **---------------------------------------------------------------------------
-** Copyright 2015 Christopher Bruns
+** Copyright 2016 Christopher Bruns
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -33,100 +33,58 @@
 **
 */
 
-#ifndef GL_ANAGLYPH_H_
-#define GL_ANAGLYPH_H_
+#ifndef GL_QUADSTEREO_H_
+#define GL_QUADSTEREO_H_
 
 #include "gl_stereo3d.h"
 #include "gl_stereo_leftright.h"
 #include "gl/system/gl_system.h"
-#include "gl/renderer/gl_renderstate.h"
-
 
 namespace s3d {
 
 
-class ColorMask
+class QuadStereoLeftPose : public LeftEyePose
 {
 public:
-	ColorMask(bool r, bool g, bool b) : r(r), g(g), b(b) {}
-	ColorMask inverse() const { return ColorMask(!r, !g, !b); }
-
-	bool r;
-	bool g;
-	bool b;
-};
-
-
-class AnaglyphLeftPose : public LeftEyePose
-{
-public:
-	AnaglyphLeftPose(const ColorMask& colorMask, float ipd) : LeftEyePose(ipd), colorMask(colorMask) {}
-	virtual void SetUp() const { 
-		gl_RenderState.SetColorMask(colorMask.r, colorMask.g, colorMask.b, true);
-		gl_RenderState.ApplyColorMask();
+	QuadStereoLeftPose(float ipd) : LeftEyePose(ipd), bQuadStereoSupported(false) {}
+	virtual void SetUp() const {
+		if (bQuadStereoSupported)
+			glDrawBuffer(GL_BACK_LEFT);
 	}
 	virtual void TearDown() const { 
-		gl_RenderState.ResetColorMask();
-		gl_RenderState.ApplyColorMask();
+		if (bQuadStereoSupported)
+			glDrawBuffer(GL_BACK);
 	}
-private:
-	ColorMask colorMask;
+	bool bQuadStereoSupported;
 };
 
-class AnaglyphRightPose : public RightEyePose
+class QuadStereoRightPose : public RightEyePose
 {
 public:
-	AnaglyphRightPose(const ColorMask& colorMask, float ipd) : RightEyePose(ipd), colorMask(colorMask) {}
+	QuadStereoRightPose(float ipd) : RightEyePose(ipd), bQuadStereoSupported(false){}
 	virtual void SetUp() const { 
-		gl_RenderState.SetColorMask(colorMask.r, colorMask.g, colorMask.b, true);
-		gl_RenderState.ApplyColorMask();
+		if (bQuadStereoSupported)
+			glDrawBuffer(GL_BACK_RIGHT);
 	}
 	virtual void TearDown() const { 
-		gl_RenderState.ResetColorMask();
-		gl_RenderState.ApplyColorMask();
+		if (bQuadStereoSupported)
+			glDrawBuffer(GL_BACK);
 	}
+	bool bQuadStereoSupported;
+};
+
+class QuadStereo : public Stereo3DMode
+{
+public:
+	QuadStereo(double ipdMeters);
+	static const QuadStereo& QuadStereo::getInstance(float ipd);
 private:
-	ColorMask colorMask;
+	QuadStereoLeftPose leftEye;
+	QuadStereoRightPose rightEye;
 };
-
-class MaskAnaglyph : public Stereo3DMode
-{
-public:
-	MaskAnaglyph(const ColorMask& leftColorMask, double ipdMeters);
-private:
-	AnaglyphLeftPose leftEye;
-	AnaglyphRightPose rightEye;
-};
-
-
-class RedCyan : public MaskAnaglyph
-{
-public:
-	static const RedCyan& getInstance(float ipd);
-
-	RedCyan(float ipd) : MaskAnaglyph(ColorMask(true, false, false), ipd) {}
-};
-
-class GreenMagenta : public MaskAnaglyph
-{
-public:
-	static const GreenMagenta& getInstance(float ipd);
-
-	GreenMagenta(float ipd) : MaskAnaglyph(ColorMask(false, true, false), ipd) {}
-};
-
-class AmberBlue : public MaskAnaglyph
-{
-public:
-	static const AmberBlue& getInstance(float ipd);
-
-	AmberBlue(float ipd) : MaskAnaglyph(ColorMask(true, true, false), ipd) {}
-};
-
-// TODO matrix anaglyph
 
 
 } /* namespace s3d */
 
 
-#endif /* GL_ANAGLYPH_H_ */
+#endif /* GL_QUADSTEREO_H_ */

--- a/src/gl/stereo3d/gl_stereo_cvars.cpp
+++ b/src/gl/stereo3d/gl_stereo_cvars.cpp
@@ -80,6 +80,10 @@ const Stereo3DMode& Stereo3DMode::getCurrentMode()
 	case 6:
 		setCurrentMode(RightEyeView::getInstance(vr_ipd));
 		break;
+	// TODO: 8: Oculus Rift
+	case 9:
+		setCurrentMode(AmberBlue::getInstance(vr_ipd));
+		break;
 	case 0:
 	default:
 		setCurrentMode(MonoView::getInstance());

--- a/src/gl/stereo3d/gl_stereo_cvars.cpp
+++ b/src/gl/stereo3d/gl_stereo_cvars.cpp
@@ -36,6 +36,7 @@
 #include "gl/stereo3d/gl_stereo3d.h"
 #include "gl/stereo3d/gl_stereo_leftright.h"
 #include "gl/stereo3d/gl_anaglyph.h"
+#include "gl/stereo3d/gl_quadstereo.h"
 #include "gl/system/gl_cvars.h"
 
 // Set up 3D-specific console variables:
@@ -80,7 +81,10 @@ const Stereo3DMode& Stereo3DMode::getCurrentMode()
 	case 6:
 		setCurrentMode(RightEyeView::getInstance(vr_ipd));
 		break;
-	// TODO: 8: Oculus Rift
+	case 7:
+		setCurrentMode(QuadStereo::getInstance(vr_ipd));
+		break;
+		// TODO: 8: Oculus Rift
 	case 9:
 		setCurrentMode(AmberBlue::getInstance(vr_ipd));
 		break;

--- a/src/win32/win32gliface.cpp
+++ b/src/win32/win32gliface.cpp
@@ -620,7 +620,7 @@ bool Win32GLVideo::SetupPixelFormat(int multisample)
 {
 	int colorDepth;
 	HDC deskDC;
-	int attributes[26];
+	int attributes[28];
 	int pixelFormat;
 	unsigned int numFormats;
 	float attribsFloat[] = {0.0f, 0.0f};
@@ -650,27 +650,31 @@ bool Win32GLVideo::SetupPixelFormat(int multisample)
 		attributes[15]	=	true;
 		attributes[16]	=	WGL_DOUBLE_BUFFER_ARB;
 		attributes[17]	=	true;
-	
-		attributes[18]	=	WGL_ACCELERATION_ARB;	//required to be FULL_ACCELERATION_ARB
-		attributes[19]	=	WGL_FULL_ACCELERATION_ARB;
+		// [BB] Starting with driver version 314.07, NVIDIA GeForce cards support OpenGL quad buffered
+		// stereo rendering with 3D Vision hardware. Select the corresponding attribute here.
+		attributes[18] = WGL_STEREO_ARB;
+		attributes[19] = true;
+
+		attributes[20]	=	WGL_ACCELERATION_ARB;	//required to be FULL_ACCELERATION_ARB
+		attributes[21]	=	WGL_FULL_ACCELERATION_ARB;
 	
 		if (multisample > 0)
 		{
-			attributes[20]	=	WGL_SAMPLE_BUFFERS_ARB;
-			attributes[21]	=	true;
-			attributes[22]	=	WGL_SAMPLES_ARB;
-			attributes[23]	=	multisample;
+			attributes[22]	=	WGL_SAMPLE_BUFFERS_ARB;
+			attributes[23]	=	true;
+			attributes[24]	=	WGL_SAMPLES_ARB;
+			attributes[25]	=	multisample;
 		}
 		else
 		{
-			attributes[20]	=	0;
-			attributes[21]	=	0;
 			attributes[22]	=	0;
 			attributes[23]	=	0;
+			attributes[24]	=	0;
+			attributes[25]	=	0;
 		}
 	
-		attributes[24]	=	0;
-		attributes[25]	=	0;
+		attributes[26]	=	0;
+		attributes[27]	=	0;
 	
 		if (!myWglChoosePixelFormatARB(m_hDC, attributes, attribsFloat, 1, &pixelFormat, &numFormats))
 		{
@@ -691,7 +695,7 @@ bool Win32GLVideo::SetupPixelFormat(int multisample)
 		static PIXELFORMATDESCRIPTOR pfd = {
 			sizeof(PIXELFORMATDESCRIPTOR),
 				1,
-				PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+				PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER | PFD_STEREO,
 				PFD_TYPE_RGBA,
 				32, // color depth
 				0, 0, 0, 0, 0, 0,

--- a/wadsrc/static/menudef.z
+++ b/wadsrc/static/menudef.z
@@ -135,6 +135,7 @@ OptionValue VRMode
 	9, "Amber/Blue"
 	5, "Left Eye"
 	6, "Right Eye"
+	7, "Quad-buffered"
 }
 
 OptionMenu "GLTextureGLOptions"

--- a/wadsrc/static/menudef.z
+++ b/wadsrc/static/menudef.z
@@ -132,6 +132,7 @@ OptionValue VRMode
 	0, "Normal"
 	1, "Green/Magenta"
 	2, "Red/Cyan"
+	9, "Amber/Blue"
 	5, "Left Eye"
 	6, "Right Eye"
 }


### PR DESCRIPTION
Adds two new stereoscopic 3D modes:
a) Amber/blue anaglyph.
b) Quad buffered, for nvidia 3D vision glasses.

This completes phase 2 of the roadmap at http://forum.zdoom.org/viewtopic.php?f=35&t=50349
