### PR TITLE
Fixed wrong starting frame for wipe animation

### DIFF
--- a/src/gl/system/gl_wipe.cpp
+++ b/src/gl/system/gl_wipe.cpp
@@ -153,7 +153,11 @@ bool OpenGLFrameBuffer::WipeStartScreen(int type)
 	GLRenderer->mSamplerManager->Bind(1, CLAMP_NONE);
 	glFinish();
 	wipestartscreen->Bind(0, false, false);
+	GLint readbuffer = 0;
+	glGetIntegerv(GL_READ_BUFFER, &readbuffer);
+	glReadBuffer(GL_FRONT);
 	glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, Width, Height);
+	glReadBuffer(readbuffer);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 


### PR DESCRIPTION
Menu graphics appeared in starting frame with hardware renderer only
Software renderer was not affected as it reads pixels from front buffer instead of back buffer like OpenGL counterpart did
See http://forum.drdteam.org/viewtopic.php?t=6857