### PR TITLE
Fixed alpha channel check for hqNx upscaling mode

### DIFF
--- a/src/gl/textures/gl_hqresize.cpp
+++ b/src/gl/textures/gl_hqresize.cpp
@@ -289,8 +289,8 @@ unsigned char *gl_CreateUpsampledTextureBuffer ( const FTexture *inputTexture, u
 		outWidth = inWidth;
 		outHeight = inHeight;
 #ifdef HAVE_MMX
-		// ASM-hqNx does not preserve the alpha channel so fall back to C-version for such textures
-		if (!hasAlpha && type > 6 && type <= 9)
+		// hqNx MMX does not preserve the alpha channel so fall back to C-version for such textures
+		if (hasAlpha && type > 6 && type <= 9)
 		{
 			type -= 3;
 		}


### PR DESCRIPTION
Now it's the initial check with the adjustment in mode indices only, as old hqNx MMX indices (4..6) are now occupied by generic hqNx implementation
See http://forum.drdteam.org/viewtopic.php?t=6872