### PR TITLE
Fixes incomplete multisample framebuffer error on Mac

### DIFF
--- a/src/gl/renderer/gl_renderbuffers.cpp
+++ b/src/gl/renderer/gl_renderbuffers.cpp
@@ -183,12 +183,12 @@ void FGLRenderBuffers::CreateScene(int width, int height, int samples)
 	{
 		mSceneDepth = CreateRenderBuffer(GL_DEPTH_COMPONENT24, samples, width, height);
 		mSceneStencil = CreateRenderBuffer(GL_STENCIL_INDEX8, samples, width, height);
-		mSceneFB = CreateFrameBuffer(samples > 1 ? mSceneMultisample : mSceneTexture, mSceneDepth, mSceneStencil);
+		mSceneFB = CreateFrameBuffer(samples > 1 ? mSceneMultisample : mSceneTexture, mSceneDepth, mSceneStencil, samples > 1);
 	}
 	else
 	{
 		mSceneDepthStencil = CreateRenderBuffer(GL_DEPTH24_STENCIL8, samples, width, height);
-		mSceneFB = CreateFrameBuffer(samples > 1 ? mSceneMultisample : mSceneTexture, mSceneDepthStencil);
+		mSceneFB = CreateFrameBuffer(samples > 1 ? mSceneMultisample : mSceneTexture, mSceneDepthStencil, samples > 1);
 	}
 }
 
@@ -327,23 +327,29 @@ GLuint FGLRenderBuffers::CreateFrameBuffer(GLuint colorbuffer)
 	return handle;
 }
 
-GLuint FGLRenderBuffers::CreateFrameBuffer(GLuint colorbuffer, GLuint depthstencil)
+GLuint FGLRenderBuffers::CreateFrameBuffer(GLuint colorbuffer, GLuint depthstencil, bool colorIsARenderBuffer)
 {
 	GLuint handle = 0;
 	glGenFramebuffers(1, &handle);
 	glBindFramebuffer(GL_FRAMEBUFFER, handle);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorbuffer, 0);
+	if (colorIsARenderBuffer)
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, colorbuffer);
+	else
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorbuffer, 0);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthstencil);
 	CheckFrameBufferCompleteness();
 	return handle;
 }
 
-GLuint FGLRenderBuffers::CreateFrameBuffer(GLuint colorbuffer, GLuint depth, GLuint stencil)
+GLuint FGLRenderBuffers::CreateFrameBuffer(GLuint colorbuffer, GLuint depth, GLuint stencil, bool colorIsARenderBuffer)
 {
 	GLuint handle = 0;
 	glGenFramebuffers(1, &handle);
 	glBindFramebuffer(GL_FRAMEBUFFER, handle);
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorbuffer, 0);
+	if (colorIsARenderBuffer)
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, colorbuffer);
+	else
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorbuffer, 0);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth);
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, stencil);
 	CheckFrameBufferCompleteness();

--- a/src/gl/renderer/gl_renderbuffers.h
+++ b/src/gl/renderer/gl_renderbuffers.h
@@ -45,8 +45,8 @@ private:
 	GLuint CreateRenderBuffer(GLuint format, int width, int height);
 	GLuint CreateRenderBuffer(GLuint format, int samples, int width, int height);
 	GLuint CreateFrameBuffer(GLuint colorbuffer);
-	GLuint CreateFrameBuffer(GLuint colorbuffer, GLuint depthstencil);
-	GLuint CreateFrameBuffer(GLuint colorbuffer, GLuint depth, GLuint stencil);
+	GLuint CreateFrameBuffer(GLuint colorbuffer, GLuint depthstencil, bool colorIsARenderBuffer);
+	GLuint CreateFrameBuffer(GLuint colorbuffer, GLuint depth, GLuint stencil, bool colorIsARenderBuffer);
 	void CheckFrameBufferCompleteness();
 	void DeleteTexture(GLuint &handle);
 	void DeleteRenderBuffer(GLuint &handle);


### PR DESCRIPTION
Seems there was an error in FGLRenderBuffers::CreateFrameBuffer that Nvidia's driver didn't care much about, but Intel's OS X driver did.