### PR TITLE
Fix invocation of quad-stereo 3d mode at startup

### DIFF
--- a/src/gl/stereo3d/gl_quadstereo.h
+++ b/src/gl/stereo3d/gl_quadstereo.h
@@ -69,11 +69,13 @@ class QuadStereo : public Stereo3DMode
 public:
 	QuadStereo(double ipdMeters);
 	void Present() const override;
+	void SetUp() const override;
 	static const QuadStereo& getInstance(float ipd);
 private:
 	QuadStereoLeftPose leftEye;
 	QuadStereoRightPose rightEye;
 	bool bQuadStereoSupported;
+	void checkInitialRenderContextState();
 };
 
 


### PR DESCRIPTION
Fixes two problems with declaring vr_mode 7 at startup: screen would be totally black; or vr_mode 7 would not initialize correctly on stereo capable hardware.

This pull request is also described in the forums http://forum.drdteam.org/viewtopic.php?f=22&t=7111