### PR TITLE
Flat Sprite Fix

### DIFF
--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -122,7 +122,7 @@ void GLSprite::CalculateVertices(FVector3 *v)
 
 		mat.Translate(x, z, y);
 		mat.Rotate(0, 1, 0, 270. - actor->Angles.Yaw.Degrees);
-		mat.Rotate(0, 0, 1, pitch.Degrees);
+		mat.Rotate(1, 0, 0, pitch.Degrees);
 
 		if (actor->renderflags & RF_ROLLCENTER)
 		{


### PR DESCRIPTION
This is the last one. It's finally ready.

- Fixed: Pitch was rotating around the wrong axis. This also addresses the issue of the rolling not occurring in the very center of the sprite.