### PR TITLE
Enabled simple intermission for hubs

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -653,7 +653,7 @@ void G_ChangeLevel(const char *levelname, int position, int flags, int nextSkill
 
 	if (thiscluster && (thiscluster->flags & CLUSTER_HUB))
 	{
-		if ((level.flags & LEVEL_NOINTERMISSION) || (nextcluster == thiscluster))
+		if ((level.flags & LEVEL_NOINTERMISSION) || ((nextcluster == thiscluster) && !(thiscluster->flags & CLUSTER_ALLOWINTERMISSION)))
 			NoWipe = 35;
 		D_DrawIcon = "TELEICON";
 	}
@@ -874,7 +874,7 @@ void G_DoCompleted (void)
 
 	if (!deathmatch &&
 		((level.flags & LEVEL_NOINTERMISSION) ||
-		((nextcluster == thiscluster) && (thiscluster->flags & CLUSTER_HUB))))
+		((nextcluster == thiscluster) && (thiscluster->flags & CLUSTER_HUB) && !(thiscluster->flags & CLUSTER_ALLOWINTERMISSION))))
 	{
 		G_WorldDone ();
 		return;

--- a/src/g_level.h
+++ b/src/g_level.h
@@ -473,6 +473,7 @@ struct cluster_info_t
 #define CLUSTER_LOOKUPENTERTEXT	0x00000020	// Enter text is the name of a language string
 #define CLUSTER_LOOKUPNAME		0x00000040	// Name is the name of a language string
 #define CLUSTER_LOOKUPCLUSTERNAME 0x00000080	// Cluster name is the name of a language string
+#define CLUSTER_ALLOWINTERMISSION 0x00000100  // Allow intermissions between levels in a hub.
 
 extern FLevelLocals level;
 

--- a/src/g_mapinfo.cpp
+++ b/src/g_mapinfo.cpp
@@ -699,6 +699,10 @@ void FMapInfoParser::ParseCluster()
 		{
 			clusterinfo->flags |= CLUSTER_HUB;
 		}
+		else if (sc.Compare("allowintermission"))
+		{
+			clusterinfo->flags |= CLUSTER_ALLOWINTERMISSION;
+		}
 		else if (sc.Compare("cdtrack"))
 		{
 			ParseAssign();


### PR DESCRIPTION
This adds a keyword in cluster{} definition of MAPINFO — AllowIntermission, which negates the check for level switching inside the current hub.