### PR TITLE
Enabled user shader for a cameratexture

### DIFF
--- a/src/gl/textures/gl_material.cpp
+++ b/src/gl/textures/gl_material.cpp
@@ -447,6 +447,11 @@ FMaterial::FMaterial(FTexture * tx, bool expanded)
 	}
 	else if (tx->bHasCanvas)
 	{
+		if (tx->gl_info.shaderindex >= FIRST_USER_SHADER)
+		{
+			mShaderIndex = tx->gl_info.shaderindex;
+		}
+		// no brightmap for cameratexture
 	}
 	else
 	{


### PR DESCRIPTION
Continuation of this thread: http://forum.drdteam.org/viewtopic.php?f=22&t=6733
Actually got to test it, the engine doesn't seem to have any problems with this edit. Probably the blocked custom shader was leftover code from some other ideas or the older renderer.

Example use case aka what it was tested on: http://i.imgur.com/8BBH9tz.png