### PR TITLE
- Make OpenGL library link fully dynamic on Unix.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,6 @@ include( CheckIncludeFile )
 include( CheckIncludeFiles )
 include( CheckLibraryExists )
 include( FindPkgConfig )
-include( FindOpenGL )
 
 if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 	option( NO_STRIP "Do not strip Release or MinSizeRel builds" )
@@ -254,15 +253,6 @@ else()
 		add_definitions( -DHAVE_FPU_CONTROL )
 	endif()
 endif()
-
-# Check if we have OpenGL
-
-if( NOT OPENGL_FOUND )
-	message( FATAL_ERROR "OpenGL is required for building." )
-endif( NOT OPENGL_FOUND )
-
-set( ZDOOM_LIBS ${ZDOOM_LIBS} ${OPENGL_LIBRARIES} )
-include_directories( ${OPENGL_INCLUDE_DIR} )
 
 if( NOT NO_OPENAL )
 	find_package( OpenAL )

--- a/src/gl/system/gl_load.c
+++ b/src/gl/system/gl_load.c
@@ -17,11 +17,12 @@ static void* AppleGLGetProcAddress (const char *name)
 }
 #endif /* __APPLE__ */
 
-#if defined(__sgi) || defined (__sun)
+/* BEGINNING OF MANUAL CHANGES, DO NOT REMOVE! */
+#if defined(__sgi) || defined (__sun) || defined(__unix__)
 #include <dlfcn.h>
 #include <stdio.h>
 
-static void* SunGetProcAddress (const GLubyte* name)
+static void* PosixGetProcAddress (const GLubyte* name)
 {
   static void* h = NULL;
   static void* gpa;
@@ -37,7 +38,7 @@ static void* SunGetProcAddress (const GLubyte* name)
   else
     return dlsym(h, (const char*)name);
 }
-#endif /* __sgi || __sun */
+#endif /* __sgi || __sun || __unix__ */
 
 #if defined(_WIN32)
 
@@ -77,8 +78,9 @@ static PROC WinGetProcAddress(const char *name)
 	#if defined(__APPLE__)
 		#define IntGetProcAddress(name) AppleGLGetProcAddress(name)
 	#else
-		#if defined(__sgi) || defined(__sun)
-			#define IntGetProcAddress(name) SunGetProcAddress(name)
+		#if defined(__sgi) || defined(__sun) || defined(__unix__)
+			#define IntGetProcAddress(name) PosixGetProcAddress((const GLubyte*)name)
+/* END OF MANUAL CHANGES, DO NOT REMOVE! */
 		#else /* GLX */
 		    #include <GL/glx.h>
 


### PR DESCRIPTION
Also, remove all the OpenGL CMake checks, because they're not needed anymore.

cc @alexey-lysiuk @Blzut3 for feedback.