### PR TITLE
- Fixed GCC/Clang compile errors.

### DIFF
--- a/src/dsectoreffect.cpp
+++ b/src/dsectoreffect.cpp
@@ -25,6 +25,7 @@
 #include "dsectoreffect.h"
 #include "gi.h"
 #include "p_local.h"
+#include "g_levellocals.h"
 #include "p_3dmidtex.h"
 #include "r_data/r_interpolate.h"
 #include "statnums.h"

--- a/src/gl/scene/gl_fakeflat.cpp
+++ b/src/gl/scene/gl_fakeflat.cpp
@@ -27,6 +27,7 @@
 
 #include "p_lnspec.h"
 #include "p_local.h"
+#include "g_levellocals.h"
 #include "a_sharedglobal.h"
 #include "r_sky.h"
 #include "gl/renderer/gl_renderer.h"

--- a/src/p_secnodes.cpp
+++ b/src/p_secnodes.cpp
@@ -21,6 +21,7 @@
 //
 //-----------------------------------------------------------------------------
 
+#include "g_levellocals.h"
 #include "r_state.h"
 #include "p_maputl.h"
 #include "p_blockmap.h"

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -57,6 +57,7 @@
 #include "r_utility.h"
 #include "d_player.h"
 #include "p_local.h"
+#include "g_levellocals.h"
 #include "p_maputl.h"
 #include "math/cmath.h"
 


### PR DESCRIPTION
Broken by commit a9ef73528d073ce6140169633f711fd4680d0802 .

In any case, there should be a guideline about the order of the includes...