### PR TITLE
- Fixed uninitialized data for libsndfile.

### DIFF
--- a/src/sound/sndfile_decoder.cpp
+++ b/src/sound/sndfile_decoder.cpp
@@ -60,6 +60,7 @@ bool SndFileDecoder::open(FileReader *reader)
 		SF_VIRTUAL_IO sfio = { file_get_filelen, file_seek, file_read, file_write, file_tell };
 
 		Reader = reader;
+		SndInfo.format = 0;
 		SndFile = sf_open_virtual(&sfio, SFM_READ, &SndInfo, this);
 		if (SndFile)
 		{


### PR DESCRIPTION
According to the [API docs](http://www.mega-nerd.com/libsndfile/api.html#open), when opening a file for read, SF_INFO::format must be set to 0.
Discovered with Valgrind while running Deus Vult 2 map01.