### PR TITLE
- fixed: Remove ccmd now no longer removes owned inventory objects (t…

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2109,6 +2109,11 @@ static int RemoveClass(const PClass *cls)
 				player = true;
 				continue;
 			}
+			// [SP] Don't remove owned inventory objects.
+			if (static_cast<AInventory *>(actor)->Owner != NULL)
+			{
+				continue;
+			}
 			removecount++; 
 			actor->ClearCounters();
 			actor->Destroy();


### PR DESCRIPTION
…hat's what the "take" ccmd is for)