### PR TITLE
- fixed: Remove ccmd should check if an object is actually an invento…

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2110,7 +2110,7 @@ static int RemoveClass(const PClass *cls)
 				continue;
 			}
 			// [SP] Don't remove owned inventory objects.
-			if (static_cast<AInventory *>(actor)->Owner != NULL)
+			if (actor->IsKindOf(RUNTIME_CLASS(AInventory)) && static_cast<AInventory *>(actor)->Owner != NULL)
 			{
 				continue;
 			}


### PR DESCRIPTION
…ry object before attempting to check its owner. (Ooops!)

https://mantis.zdoom.org/view.php?id=80