### PR TITLE
Palette Tonemap Tweaks

### DIFF
--- a/src/gl/renderer/gl_postprocess.cpp
+++ b/src/gl/renderer/gl_postprocess.cpp
@@ -81,8 +81,8 @@ CVAR(Float, gl_exposure_min, 0.35f, CVAR_ARCHIVE)
 CVAR(Float, gl_exposure_base, 0.35f, CVAR_ARCHIVE)
 CVAR(Float, gl_exposure_speed, 0.05f, CVAR_ARCHIVE)
 
-CVAR(Float, gl_paltonemap_powtable, 1.2f, CVAR_ARCHIVE)
-CVAR(Bool, gl_paltonemap_reverselookup, false, CVAR_ARCHIVE)
+CVAR(Float, gl_paltonemap_powtable, 2.0f, CVAR_ARCHIVE)
+CVAR(Bool, gl_paltonemap_reverselookup, true, CVAR_ARCHIVE)
 
 CUSTOM_CVAR(Int, gl_tonemap, 0, CVAR_ARCHIVE)
 {

--- a/src/gl/renderer/gl_postprocess.cpp
+++ b/src/gl/renderer/gl_postprocess.cpp
@@ -81,6 +81,9 @@ CVAR(Float, gl_exposure_min, 0.35f, CVAR_ARCHIVE)
 CVAR(Float, gl_exposure_base, 0.35f, CVAR_ARCHIVE)
 CVAR(Float, gl_exposure_speed, 0.05f, CVAR_ARCHIVE)
 
+CVAR(Float, gl_paltonemap_powtable, 1.2f, CVAR_ARCHIVE)
+CVAR(Bool, gl_paltonemap_reverselookup, false, CVAR_ARCHIVE)
+
 CUSTOM_CVAR(Int, gl_tonemap, 0, CVAR_ARCHIVE)
 {
 	if (self < 0 || self > 5)
@@ -828,7 +831,7 @@ int FGLRenderer::PTM_BestColor (const uint32 *pal_in, int r, int g, int b, int f
 	if (firstTime)
 	{
 		firstTime = false;
-		for (int x = 0; x < 256; x++) powtable[x] = pow((double)x/255,1.2);
+		for (int x = 0; x < 256; x++) powtable[x] = pow((double)x/255, (double)gl_paltonemap_powtable);
 	}
 
 	for (int color = first; color < num; color++)
@@ -837,9 +840,9 @@ int FGLRenderer::PTM_BestColor (const uint32 *pal_in, int r, int g, int b, int f
 		double y = powtable[abs(g-pal[color].g)];
 		double z = powtable[abs(b-pal[color].b)];
 		fdist = x + y + z;
-		if (color == first || fdist < fbestdist)
+		if (color == first || ((gl_paltonemap_reverselookup)?(fdist <= fbestdist):(fdist < fbestdist)))
 		{
-			if (fdist == 0)
+			if (fdist == 0 && !gl_paltonemap_reverselookup)
 				return color;
 
 			fbestdist = fdist;

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2645,6 +2645,8 @@ GLPREFMNU_LENS					= "Lens distortion effect";
 GLPREFMNU_SSAO					= "Ambient occlusion quality";
 GLPREFMNU_SSAO_PORTALS			= "Portals with AO";
 GLPREFMNU_FXAA					= "FXAA Quality";
+GLPREFMNU_PALTONEMAPORDER		= "Tonemap Palette Order";
+GLPREFMNU_PALTONEMAPPOWER		= "Tonemap Palette Exponent";
 
 // Option Values
 OPTVAL_SMART 				= "Smart";
@@ -2728,3 +2730,5 @@ OPTVAL_LOW					= "Low";
 OPTVAL_MEDIUM				= "Medium";
 OPTVAL_HIGH					= "High";
 OPTVAL_EXTREME				= "Extreme";
+OPTVAL_OBVERSEFIRST			= "Obverse";
+OPTVAL_REVERSEFIRST			= "Reverse";

--- a/wadsrc/static/menudef.zz
+++ b/wadsrc/static/menudef.zz
@@ -1,3 +1,9 @@
+OptionValue "LookupOrder"
+{
+	0, "$OPTVAL_OBVERSEFIRST"
+	1, "$OPTVAL_REVERSEFIRST"
+}
+
 OptionValue "SpriteclipModes"
 {
 	0, "$OPTVAL_NEVER"
@@ -249,4 +255,7 @@ OptionMenu "GLPrefOptions"
 	Option "$GLPREFMNU_SSAO",		 			gl_ssao,						"SSAOModes"
 	Slider "$GLPREFMNU_SSAO_PORTALS",			gl_ssao_portals,				0.0, 4.0, 1.0, 0
 	Option "$GLPREFMNU_FXAA",		 			gl_fxaa,						"FXAAQuality"
+	StaticText " "
+	Slider "$GLPREFMNU_PALTONEMAPPOWER",		gl_paltonemap_powtable,			0.2, 3.0, 0.1, 0
+	Option "$GLPREFMNU_PALTONEMAPORDER",		gl_paltonemap_reverselookup,	"LookupOrder"
 }


### PR DESCRIPTION
CVAR(Float, gl_paltonemap_powtable, 2.0f, CVAR_ARCHIVE)
CVAR(Bool, gl_paltonemap_reverselookup, true, CVAR_ARCHIVE)

These variables change the way the palette tonemap table is generated. Their default values have also been changed to be more "id-like" - since id Software used a "last-first" algorithm in generating the default COLORMAP lumps.