### PR TITLE
Gzdoom banded SW Light

### DIFF
--- a/src/gl/renderer/gl_renderstate.cpp
+++ b/src/gl/renderer/gl_renderstate.cpp
@@ -43,6 +43,7 @@ void gl_SetTextureMode(int type);
 FRenderState gl_RenderState;
 
 CVAR(Bool, gl_direct_state_change, true, 0)
+CVAR(Bool, gl_bandedswlight, true, CVAR_ARCHIVE)
 
 
 static VSMatrix identityMatrix(1);
@@ -146,6 +147,7 @@ bool FRenderState::ApplyShader()
 
 	activeShader->muDesaturation.Set(mDesaturation / 255.f);
 	activeShader->muFogEnabled.Set(fogset);
+	activeShader->muPalLightLevels.Set(gl_bandedswlight);
 	activeShader->muTextureMode.Set(mTextureMode);
 	activeShader->muCameraPos.Set(mCameraPos.vec);
 	activeShader->muLightParms.Set(mLightParms);

--- a/src/gl/renderer/gl_renderstate.cpp
+++ b/src/gl/renderer/gl_renderstate.cpp
@@ -43,7 +43,7 @@ void gl_SetTextureMode(int type);
 FRenderState gl_RenderState;
 
 CVAR(Bool, gl_direct_state_change, true, 0)
-CVAR(Bool, gl_bandedswlight, true, CVAR_ARCHIVE)
+CVAR(Bool, gl_bandedswlight, false, CVAR_ARCHIVE)
 
 
 static VSMatrix identityMatrix(1);

--- a/src/gl/shaders/gl_shader.cpp
+++ b/src/gl/shaders/gl_shader.cpp
@@ -214,6 +214,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 
 	muDesaturation.Init(hShader, "uDesaturationFactor");
 	muFogEnabled.Init(hShader, "uFogEnabled");
+	muPalLightLevels.Init(hShader, "uPalLightLevels");
 	muTextureMode.Init(hShader, "uTextureMode");
 	muCameraPos.Init(hShader, "uCameraPos");
 	muLightParms.Init(hShader, "uLightAttr");

--- a/src/gl/shaders/gl_shader.h
+++ b/src/gl/shaders/gl_shader.h
@@ -259,6 +259,7 @@ class FShader
 
 	FBufferedUniform1f muDesaturation;
 	FBufferedUniform1i muFogEnabled;
+	FBufferedUniform1i muPalLightLevels;
 	FBufferedUniform1i muTextureMode;
 	FBufferedUniform4f muCameraPos;
 	FBufferedUniform4f muLightParms;

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2647,6 +2647,7 @@ GLPREFMNU_SSAO_PORTALS			= "Portals with AO";
 GLPREFMNU_FXAA					= "FXAA Quality";
 GLPREFMNU_PALTONEMAPORDER		= "Tonemap Palette Order";
 GLPREFMNU_PALTONEMAPPOWER		= "Tonemap Palette Exponent";
+GLPREFMNU_SWLMBANDED			= "Banded SW Lightmode";
 
 // Option Values
 OPTVAL_SMART 				= "Smart";

--- a/wadsrc/static/menudef.zz
+++ b/wadsrc/static/menudef.zz
@@ -232,6 +232,7 @@ OptionMenu "GLPrefOptions"
 {
 	Title "$GLPREFMNU_TITLE"
 	Option "$GLPREFMNU_SECLIGHTMODE",			gl_lightmode,					"LightingModes"
+	Option "$GLPREFMNU_SWLMBANDED",				gl_bandedswlight,				"OnOff"
 	Option "$GLPREFMNU_FOGMODE",				gl_fogmode,						"FogMode"
 	Option "$GLPREFMNU_FOGFORCEFULLBRIGHT",		gl_brightfog,					"YesNo"
 	Slider "$GLPREFMNU_WPNLIGHTSTR",			gl_weaponlight,					0,32, 2

--- a/wadsrc/static/menudef.zz
+++ b/wadsrc/static/menudef.zz
@@ -257,6 +257,6 @@ OptionMenu "GLPrefOptions"
 	Slider "$GLPREFMNU_SSAO_PORTALS",			gl_ssao_portals,				0.0, 4.0, 1.0, 0
 	Option "$GLPREFMNU_FXAA",		 			gl_fxaa,						"FXAAQuality"
 	StaticText " "
-	Slider "$GLPREFMNU_PALTONEMAPPOWER",		gl_paltonemap_powtable,			0.2, 3.0, 0.1, 0
+	Slider "$GLPREFMNU_PALTONEMAPPOWER",		gl_paltonemap_powtable,			0.2, 3.0, 0.1, 1
 	Option "$GLPREFMNU_PALTONEMAPORDER",		gl_paltonemap_reverselookup,	"LookupOrder"
 }

--- a/wadsrc/static/shaders/glsl/main.fp
+++ b/wadsrc/static/shaders/glsl/main.fp
@@ -123,7 +123,7 @@ float R_DoomLightingEquation(float light)
 	float shade = 64.0 - (L + 12.0) * 32.0/128.0;
 	float lightscale;
 	if (uPalLightLevels != 0)
-		lightscale = clamp(int(shade - min(24.0, vis)) / 32.0, 0.0, 31.0/32.0);
+		lightscale = clamp(float(int(shade - min(24.0, vis))) / 32.0, 0.0, 31.0/32.0);
 	else
 		lightscale = clamp((shade - min(24.0, vis)) / 32.0, 0.0, 31.0/32.0);
 

--- a/wadsrc/static/shaders/glsl/main.fp
+++ b/wadsrc/static/shaders/glsl/main.fp
@@ -121,7 +121,11 @@ float R_DoomLightingEquation(float light)
 	/* The zdoom light equation */
 	float vis = globVis / z;
 	float shade = 64.0 - (L + 12.0) * 32.0/128.0;
-	float lightscale = clamp((shade - min(24.0, vis)) / 32.0, 0.0, 31.0/32.0);
+	float lightscale;
+	if (uPalLightLevels != 0)
+		lightscale = clamp(int(shade - min(24.0, vis)) / 32.0, 0.0, 31.0/32.0);
+	else
+		lightscale = clamp((shade - min(24.0, vis)) / 32.0, 0.0, 31.0/32.0);
 
 	// Result is the normalized colormap index (0 bright .. 1 dark)
 	return lightscale;

--- a/wadsrc/static/shaders/glsl/shaderdefs.i
+++ b/wadsrc/static/shaders/glsl/shaderdefs.i
@@ -41,6 +41,7 @@ uniform vec4 uLightAttr;
 #define uLightFactor uLightAttr.g
 #define uLightDist uLightAttr.r
 uniform int uFogEnabled;
+uniform int uPalLightLevels;
 
 // dynamic lights
 uniform int uLightIndex;


### PR DESCRIPTION
When emulating the software lighting mode, this gives the option to add the lighting bands that were present in the original Doom engine due to the restriction of 32 COLORMAP light levels. Without a tonemap this more or less looks like EDGE, with a palette tonemap this looks a lot more like original ZDoom.