### PR TITLE
Bouncing pointer fix

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -3535,9 +3535,9 @@ bool P_BounceActor(AActor *mo, AActor *BlockingMobj, bool ontop)
 		if (mo->bouncecount>0 && --mo->bouncecount == 0)
 		{
 			if (mo->flags & MF_MISSILE)
-				P_ExplodeMissile(mo, nullptr, nullptr);
+				P_ExplodeMissile(mo, nullptr, BlockingMobj);
 			else
-				mo->CallDie(nullptr, nullptr);
+				mo->CallDie(BlockingMobj, nullptr);
 			return true;
 		}
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1814,15 +1814,18 @@ void P_ExplodeMissile (AActor *mo, line_t *line, AActor *target)
 	mo->effects = 0;		// [RH]
 	mo->flags &= ~MF_SHOOTABLE;
 	
-	FState *nextstate=NULL;
+	FState *nextstate = nullptr;
 	
-	if (target != NULL && ((target->flags & (MF_SHOOTABLE|MF_CORPSE)) || (target->flags6 & MF6_KILLED)) )
+	if (target != nullptr)
 	{
 		if (mo->flags7 & MF7_HITTARGET)	mo->target = target;
 		if (mo->flags7 & MF7_HITMASTER)	mo->master = target;
 		if (mo->flags7 & MF7_HITTRACER)	mo->tracer = target;
-		if (target->flags & MF_NOBLOOD) nextstate = mo->FindState(NAME_Crash);
-		if (nextstate == NULL) nextstate = mo->FindState(NAME_Death, NAME_Extreme);
+		if ((target->flags & (MF_SHOOTABLE | MF_CORPSE)) || (target->flags6 & MF6_KILLED))
+		{
+			if (target->flags & MF_NOBLOOD) nextstate = mo->FindState(NAME_Crash);
+			if (nextstate == NULL) nextstate = mo->FindState(NAME_Death, NAME_Extreme);
+		}
 	}
 	if (nextstate == NULL) nextstate = mo->FindState(NAME_Death);
 	


### PR DESCRIPTION
- Fixed HITTARGET, HITMASTER, HITTRACER, crash and xdeath states being broken on bouncing actors that die/explode.