### PR TITLE
Cheat flag for console variables

### DIFF
--- a/src/c_cvars.cpp
+++ b/src/c_cvars.cpp
@@ -1617,8 +1617,16 @@ void C_ArchiveCVars (FConfigFile *f, uint32 filter)
 	}
 }
 
+EXTERN_CVAR(Bool, sv_cheats);
+
 void FBaseCVar::CmdSet (const char *newval)
 {
+	if ((GetFlags() & CVAR_CHEAT) && !sv_cheats)
+	{
+		Printf("sv_cheats must be true to set this console variable.\n");
+		return;
+	}
+
 	UCVarValue val;
 
 	// Casting away the const is safe in this case.

--- a/src/c_cvars.h
+++ b/src/c_cvars.h
@@ -63,6 +63,7 @@ enum
 	CVAR_NOSAVE			= 4096, // when used with CVAR_SERVERINFO, do not save var to savegame
 	CVAR_MOD			= 8192,	// cvar was defined by a mod
 	CVAR_IGNORE			= 16384,// do not send cvar across the network/inaccesible from ACS (dummy mod cvar)
+	CVAR_CHEAT			= 32768,// can be set only when sv_cheats is enabled
 };
 
 union UCVarValue

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1398,6 +1398,10 @@ void ParseCVarInfo()
 				{
 					cvarflags &= ~CVAR_ARCHIVE;
 				}
+				else if (stricmp(sc.String, "cheat") == 0)
+				{
+					cvarflags |= CVAR_CHEAT;
+				}
 				else
 				{
 					sc.ScriptError("Unknown cvar attribute '%s'", sc.String);


### PR DESCRIPTION
CVAR with this flag can be set in console or from command line when sv_cheats is enabled
There is no such restriction for changing its value from ACS, via SetCVar() and related functions
'cheat' modifier can be used in CVARINFO lump to create variable of this kind