### PR TITLE
Fix for incorrect offscreen rendering of player's blend

### DIFF
--- a/src/gl/scene/gl_scene.cpp
+++ b/src/gl/scene/gl_scene.cpp
@@ -866,6 +866,14 @@ sector_t * FGLRenderer::RenderViewpoint (AActor * camera, GL_IRECT * bounds, flo
 			// This should be done after postprocessing, not before.
 			mBuffers->BindCurrentFB();
 			glViewport(mScreenViewport.left, mScreenViewport.top, mScreenViewport.width, mScreenViewport.height);
+
+			if (!toscreen)
+			{
+				gl_RenderState.mViewMatrix.loadIdentity();
+				gl_RenderState.mProjectionMatrix.ortho(mScreenViewport.left, mScreenViewport.width, mScreenViewport.height, mScreenViewport.top, -1.0f, 1.0f);
+				gl_RenderState.ApplyMatrices();
+			}
+
 			DrawBlend(lviewsector);
 		}
 		mDrawingScene2D = false;


### PR DESCRIPTION
Player's blend was rendered incorrectly in some cases, for example on saved game picture:
![offscreen_blend](https://cloud.githubusercontent.com/assets/777125/22625116/1f0dc878-eb96-11e6-891c-a8c27bafde8f.jpg)In-game player's view is fine.

I cannot reproduce this on Windows with OpenGL 4.5 Core but on macOS 4.1 Core it's always the case, i.e. position of blend's rectangle on screen depends on camera angle.

The pull request has been made because I'm in doubt about the proper way to fix it.
Apparently the problem is with view and projection matrices. Although it's not clear to me will it be correct to apply identities only? Or should it require to adjust changes to
```c++
if (!toscreen)
{
	framebuffer->Begin2D(false);
}
``` 