### PR TITLE
SetCamera Fix

### DIFF
--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -6923,18 +6923,18 @@ DEFINE_ACTION_FUNCTION(AActor, SetCamera)
 
 	if (self->player == nullptr || self->player->mo != self) return 0;
 
-	if (camera == nullptr)
+	if (cam == nullptr)
 	{
-		camera = self;
+		cam = self;
 		revert = false;
 	}
 	AActor *oldcamera = self->player->camera;
-	self->player->camera = camera;
+	self->player->camera = cam;
 	if (revert) self->player->cheats |= CF_REVERTPLEASE;
 
-	if (oldcamera != camera)
+	if (oldcamera != cam)
 	{
-		R_ClearPastViewer(camera);
+		R_ClearPastViewer(cam);
 	}
 	return 0;
 }

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -498,7 +498,7 @@ class Actor : Thinker native
 	native bool UsePuzzleItem(int PuzzleItemType);
 	native float AccuracyFactor();
 	native bool MorphMonster (Class<Actor> spawntype, int duration, int style, Class<Actor> enter_flash, Class<Actor> exit_flash);
-	native void SetCamera(Actor cam, bool revert = false);
+	action native void SetCamera(Actor cam, bool revert = false);
 
 	// DECORATE compatible functions
 	native int	CountInv(class<Inventory> itemtype, int ptr_select = AAPTR_DEFAULT);


### PR DESCRIPTION
- Fixed: SetCamera didn't have the 'action' identifier, nor did it use the actual 'cam' actor provided, rendering it nonfunctional.