### PR TITLE
Added DONTCULLBACKFACES MODELDEF flag to forcefully disable backface …

### DIFF
--- a/src/gl/models/gl_models.cpp
+++ b/src/gl/models/gl_models.cpp
@@ -787,6 +787,10 @@ void gl_InitModels()
 							map[c]=1;
 						}
 					}
+					else if (sc.Compare("dontcullbackfaces"))
+					{
+						smf.flags |= MDL_DONTCULLBACKFACES;
+					}
 					else
 					{
 						sc.ScriptMessage("Unrecognized string \"%s\"", sc.String);
@@ -949,8 +953,9 @@ void gl_RenderModel(GLSprite * spr)
 	gl_RenderState.EnableTexture(true);
 	// [BB] In case the model should be rendered translucent, do back face culling.
 	// This solves a few of the problems caused by the lack of depth sorting.
+	// [Nash] Don't do back face culling if explicitly specified in MODELDEF
 	// TO-DO: Implement proper depth sorting.
-	if (!( spr->actor->RenderStyle == LegacyRenderStyles[STYLE_Normal] ))
+	if (!(spr->actor->RenderStyle == LegacyRenderStyles[STYLE_Normal]) && !(smf->flags & MDL_DONTCULLBACKFACES))
 	{
 		glEnable(GL_CULL_FACE);
 		glFrontFace(GL_CW);

--- a/src/gl/models/gl_models.h
+++ b/src/gl/models/gl_models.h
@@ -370,6 +370,7 @@ enum
 	MDL_USEACTORPITCH				= 32,
 	MDL_USEACTORROLL				= 64,
 	MDL_BADROTATION					= 128,
+	MDL_DONTCULLBACKFACES			= 256,
 };
 
 struct FSpriteModelFrame


### PR DESCRIPTION
…culling on models

Needed for models with render styles, meant to be used as special effects.

With uncontrollable backface culling, the model's polygons have to be doubled and flipped so that it will render on both sides, which is a waste of resources.

See example image

http://i.imgur.com/IBwXgRL.png