### PR TITLE
INVERTMASK Flag

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -427,6 +427,7 @@ enum ActorRenderFlag
 	RF_ABSMASKPITCH		= 0x00800000, // [MC] The mask rotation does not offset by the actor's pitch.
 	RF_INTERPOLATEANGLES		= 0x01000000, // [MC] Allow interpolation of the actor's angle, pitch and roll.
 	RF_MAYBEINVISIBLE	= 0x02000000,
+	RF_INVERTMASK		= 0x40000000,
 };
 
 // This translucency value produces the closest match to Heretic's TINTTAB.

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1486,7 +1486,7 @@ bool AActor::IsInsideVisibleAngles() const
 		anglestart = angleend;
 		angleend = temp;
 	}
-
+	
 	if (pitchstart > pitchend)
 	{
 		DAngle temp = pitchstart;
@@ -1503,8 +1503,13 @@ bool AActor::IsInsideVisibleAngles() const
 		DVector3 diffang = ViewPos - Pos();
 		DAngle to = diffang.Angle();
 
-		if (!(renderflags & RF_ABSMASKANGLE)) 
-			to = deltaangle(Angles.Yaw, to);
+		if (!(renderflags & RF_ABSMASKANGLE))
+		{
+			if (renderflags & RF_INVERTMASK)
+				to = (Angles.Yaw - to).Normalized360();
+			else
+				to = deltaangle(Angles.Yaw, to);
+		}
 
 		if ((to >= anglestart && to <= angleend))
 		{

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -331,6 +331,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF, XFLIP, AActor, renderflags),
 	DEFINE_FLAG(RF, YFLIP, AActor, renderflags),
 	DEFINE_FLAG(RF, INTERPOLATEANGLES, AActor, renderflags),
+	DEFINE_FLAG(RF, INVERTMASK, AActor, renderflags),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),


### PR DESCRIPTION
- Changes the mask limits from [-180, 180] to [0, 360]. Currently, rendering would be invisible if specifying a range like [91, 271] and viewed beyond 180, due to normalization. This allows for backside rendering to be done much more easily.