### PR TITLE
- fixed Skulltag rune bugs.

### DIFF
--- a/src/g_inventory/a_weapons.cpp
+++ b/src/g_inventory/a_weapons.cpp
@@ -230,7 +230,7 @@ bool AWeapon::CheckAmmo (int fireMode, bool autoSwitch, bool requireAmmo, int am
 	int enough, enoughmask;
 	int lAmmoUse1;
 
-	if ((dmflags & DF_INFINITE_AMMO) || (Owner->player->cheats & CF_INFINITEAMMO))
+	if ((dmflags & DF_INFINITE_AMMO) || (Owner->FindInventory (PClass::FindActor(NAME_PowerInfiniteAmmo), true) != nullptr))
 	{
 		return true;
 	}
@@ -311,7 +311,7 @@ DEFINE_ACTION_FUNCTION(AWeapon, CheckAmmo)
 
 bool AWeapon::DepleteAmmo (bool altFire, bool checkEnough, int ammouse)
 {
-	if (!((dmflags & DF_INFINITE_AMMO) || (Owner->player->cheats & CF_INFINITEAMMO)))
+	if (!((dmflags & DF_INFINITE_AMMO) || (Owner->FindInventory (PClass::FindActor(NAME_PowerInfiniteAmmo), true) != nullptr)))
 	{
 		if (checkEnough && !CheckAmmo (altFire ? AltFire : PrimaryFire, false, false, ammouse))
 		{

--- a/src/namedef.h
+++ b/src/namedef.h
@@ -203,6 +203,8 @@ xx(CallTryPickup)
 xx(QuestItem25)
 xx(QuestItem28)
 xx(QuestItem29)
+xx(PowerDoubleFiringSpeed)
+xx(PowerInfiniteAmmo)
 
 xx(AcolyteBlue)
 xx(SpectralLightningV1)

--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -2841,7 +2841,7 @@ FUNC(LS_SetPlayerProperty)
 	// Add or remove a power
 	if (arg2 >= PROP_INVULNERABILITY && arg2 <= PROP_SPEED)
 	{
-		static ENamedName powers[11] =
+		static ENamedName powers[13] =
 		{
 			NAME_PowerInvulnerable,
 			NAME_PowerStrength,
@@ -2853,7 +2853,9 @@ FUNC(LS_SetPlayerProperty)
 			NAME_PowerFlight,
 			NAME_None,
 			NAME_None,
-			NAME_PowerSpeed
+			NAME_PowerSpeed,
+			NAME_PowerInfiniteAmmo,
+			NAME_PowerDoubleFiringSpeed
 		};
 		int power = arg2 - PROP_INVULNERABILITY;
 

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -1381,7 +1381,7 @@ void DPSprite::Tick()
 			Tics--;
 
 			// [BC] Apply double firing speed.
-			if ((Flags & PSPF_POWDOUBLE) && Tics && (Owner->cheats & CF_DOUBLEFIRINGSPEED))
+			if ((Flags & PSPF_POWDOUBLE) && Tics && (Owner->mo->FindInventory (PClass::FindActor(NAME_PowerDoubleFiringSpeed), true)))
 				Tics--;
 
 			if (!Tics)


### PR DESCRIPTION
1) When used in a hub, returning to a previous level in the hub deactivated the runes if they were a permanent powerup.
2) When picking up two different runes with the same effect, one rune wearing off removed the effect completely.
3) This entire system was done through an extremely hacky CheatFlags implementation. This was a gross hack, and it was no wonder it didn't always work properly.