### PR TITLE
- fixed: Change compiled exe version strings to match git repo number…

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -31,6 +31,8 @@
 **
 */
 
+#include "gitinfo.h"
+
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
@@ -41,12 +43,16 @@ const char *GetVersionString();
 
 /** Lots of different version numbers **/
 
+#ifdef GIT_DESCRIPTION
+#define VERSIONSTR GIT_DESCRIPTION
+#else
 #define VERSIONSTR "2.3pre"
+#endif
 
 // The version as seen in the Windows resource
 #define RC_FILEVERSION 2,3,9999,0
 #define RC_PRODUCTVERSION 2,3,9999,0
-#define RC_PRODUCTVERSION2 "2.3pre"
+#define RC_PRODUCTVERSION2 VERSIONSTR
 
 // Version identifier for network games.
 // Bump it every time you do a release unless you're certain you


### PR DESCRIPTION
…s. This is viewable in Windows by right-clicking on the executable and selecting "Properties".