### PR TITLE
- Fixed: voxels were not properly remapped after "restart" ccmd

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2692,6 +2692,7 @@ void D_DoomMain (void)
 			// These calls from inside V_Init2 are still necessary
 			C_NewModeAdjust();
 			M_InitVideoModesMenu();
+			Renderer->RemapVoxels();
 			D_StartTitle ();				// start up intro loop
 			setmodeneeded = false;			// This may be set to true here, but isn't needed for a restart
 		}


### PR DESCRIPTION
This mostly affects the software renderer. For example, if "restarting" into TGRDM3 without this fix, the voxels would have a tutti-fruitti effect. This fixes that.