### PR TITLE
Const function and ScopeBarrier-related fixes

### DIFF
--- a/src/scripting/backend/codegen.cpp
+++ b/src/scripting/backend/codegen.cpp
@@ -6084,7 +6084,7 @@ FxExpression *FxIdentifier::ResolveMember(FCompileContext &ctx, PStruct *classct
 			}
 			PClass* cls_ctx = dyn_cast<PClass>(classctx);
 			PClass* cls_target = dyn_cast<PClass>(objtype);
-			if ((vsym->Flags & VARF_Protected) && (!cls_ctx || !cls_target || cls_ctx->IsDescendantOf(cls_target)))
+			if ((vsym->Flags & VARF_Protected) && (!cls_ctx || !cls_target || !cls_ctx->IsDescendantOf(cls_target)))
 			{
 				ScriptPosition.Message(MSG_ERROR, "Protected member %s not accessible", vsym->SymbolName.GetChars());
 				return nullptr;

--- a/src/scripting/backend/codegen.cpp
+++ b/src/scripting/backend/codegen.cpp
@@ -6841,12 +6841,6 @@ bool FxStructMember::RequestAddress(FCompileContext &ctx, bool *writable)
 		// [ZZ] original check.
 		bool bWritable = (AddressWritable && !ctx.CheckWritable(membervar->Flags) &&
 			(!classx->ValueType->IsKindOf(RUNTIME_CLASS(PPointer)) || !static_cast<PPointer*>(classx->ValueType)->IsConst));
-		// [ZZ] self in a const function is not writable.
-		if (bWritable) // don't do complex checks on early fail
-		{
-			if ((classx->ExprType == EFX_Self) && (ctx.Function && (ctx.Function->Variants[0].Flags & VARF_ReadOnly)))
-				bWritable = false;
-		}
 		// [ZZ] implement write barrier between different scopes
 		if (bWritable)
 		{

--- a/src/scripting/backend/codegen.cpp
+++ b/src/scripting/backend/codegen.cpp
@@ -8725,7 +8725,7 @@ ExpEmit FxVMFunctionCall::Emit(VMFunctionBuilder *build)
 	}
 
 	VMFunction *vmfunc = Function->Variants[0].Implementation;
-	bool staticcall = (vmfunc->Final || vmfunc->VirtualIndex == ~0u || NoVirtual);
+	bool staticcall = ((vmfunc->VarFlags & VARF_Final) || vmfunc->VirtualIndex == ~0u || NoVirtual);
 
 	count = 0;
 	// Emit code to pass implied parameters

--- a/src/scripting/backend/codegen.cpp
+++ b/src/scripting/backend/codegen.cpp
@@ -6082,6 +6082,13 @@ FxExpression *FxIdentifier::ResolveMember(FCompileContext &ctx, PStruct *classct
 				ScriptPosition.Message(MSG_ERROR, "Private member %s not accessible", vsym->SymbolName.GetChars());
 				return nullptr;
 			}
+			PClass* cls_ctx = dyn_cast<PClass>(classctx);
+			PClass* cls_target = dyn_cast<PClass>(objtype);
+			if ((vsym->Flags & VARF_Protected) && (!cls_ctx || !cls_target || cls_ctx->IsDescendantOf(cls_target)))
+			{
+				ScriptPosition.Message(MSG_ERROR, "Protected member %s not accessible", vsym->SymbolName.GetChars());
+				return nullptr;
+			}
 
 			auto x = isclass ? new FxClassMember(object, vsym, ScriptPosition) : new FxStructMember(object, vsym, ScriptPosition);
 			object = nullptr;

--- a/src/scripting/backend/scopebarrier.cpp
+++ b/src/scripting/backend/scopebarrier.cpp
@@ -44,6 +44,19 @@ int FScopeBarrier::FlagsFromSide(int side)
 	}
 }
 
+int FScopeBarrier::ObjectFlagsFromSide(int side)
+{
+	switch (side)
+	{
+	case Side_Play:
+		return OF_Play;
+	case Side_UI:
+		return OF_UI;
+	default:
+		return 0;
+	}
+}
+
 // used for errors
 const char* FScopeBarrier::StringFromSide(int side)
 {
@@ -69,6 +82,14 @@ int FScopeBarrier::ChangeSideInFlags(int flags, int side)
 {
 	flags &= ~(VARF_UI | VARF_Play | VARF_VirtualScope | VARF_ClearScope);
 	flags |= FlagsFromSide(side);
+	return flags;
+}
+
+// this modifies OF_ flags and sets the side properly.
+int FScopeBarrier::ChangeSideInObjectFlags(int flags, int side)
+{
+	flags &= ~(OF_UI | OF_Play);
+	flags |= ObjectFlagsFromSide(side);
 	return flags;
 }
 

--- a/src/scripting/backend/scopebarrier.h
+++ b/src/scripting/backend/scopebarrier.h
@@ -35,12 +35,15 @@ struct FScopeBarrier
 
 	//
 	static int FlagsFromSide(int side);
+	static int ObjectFlagsFromSide(int side);
 	
 	// used for errors
 	static const char* StringFromSide(int side);
 
 	// this modifies VARF_ flags and sets the side properly.
 	static int ChangeSideInFlags(int flags, int side);
+	// this modifies OF_ flags and sets the side properly.
+	static int ChangeSideInObjectFlags(int flags, int side);
 	FScopeBarrier();
 	FScopeBarrier(int flags1, int flags2, const char* name);
 

--- a/src/scripting/thingdef.cpp
+++ b/src/scripting/thingdef.cpp
@@ -195,8 +195,8 @@ PFunction *FindClassMemberFunction(PStruct *selfcls, PStruct *funccls, FName nam
 
 	if (symbol != nullptr)
 	{
-		PClass* cls_ctx = dyn_cast<PClass>(selfcls);
-		PClass* cls_target = dyn_cast<PClass>(funccls);
+		PClass* cls_ctx = dyn_cast<PClass>(funccls);
+		PClass* cls_target = funcsym?dyn_cast<PClass>(funcsym->OwningClass):nullptr;
 		if (funcsym == nullptr)
 		{
 			sc.Message(MSG_ERROR, "%s is not a member function of %s", name.GetChars(), selfcls->TypeName.GetChars());
@@ -206,7 +206,7 @@ PFunction *FindClassMemberFunction(PStruct *selfcls, PStruct *funccls, FName nam
 			// private access is only allowed if the symbol table belongs to the class in which the current function is being defined.
 			sc.Message(MSG_ERROR, "%s is declared private and not accessible", symbol->SymbolName.GetChars());
 		}
-		else if ((funcsym->Variants[0].Flags & VARF_Protected) && (!cls_ctx || !cls_target || cls_ctx->IsDescendantOf((PClass*)cls_target)))
+		else if ((funcsym->Variants[0].Flags & VARF_Protected) && (!cls_ctx || !cls_target || !cls_ctx->IsDescendantOf((PClass*)cls_target)))
 		{
 			sc.Message(MSG_ERROR, "%s is declared protected and not accessible", symbol->SymbolName.GetChars());
 			return nullptr;

--- a/src/scripting/thingdef.cpp
+++ b/src/scripting/thingdef.cpp
@@ -195,6 +195,8 @@ PFunction *FindClassMemberFunction(PStruct *selfcls, PStruct *funccls, FName nam
 
 	if (symbol != nullptr)
 	{
+		PClass* cls_ctx = dyn_cast<PClass>(selfcls);
+		PClass* cls_target = dyn_cast<PClass>(funccls);
 		if (funcsym == nullptr)
 		{
 			sc.Message(MSG_ERROR, "%s is not a member function of %s", name.GetChars(), selfcls->TypeName.GetChars());
@@ -203,6 +205,11 @@ PFunction *FindClassMemberFunction(PStruct *selfcls, PStruct *funccls, FName nam
 		{
 			// private access is only allowed if the symbol table belongs to the class in which the current function is being defined.
 			sc.Message(MSG_ERROR, "%s is declared private and not accessible", symbol->SymbolName.GetChars());
+		}
+		else if ((funcsym->Variants[0].Flags & VARF_Protected) && (!cls_ctx || !cls_target || cls_ctx->IsDescendantOf((PClass*)cls_target)))
+		{
+			sc.Message(MSG_ERROR, "%s is declared protected and not accessible", symbol->SymbolName.GetChars());
+			return nullptr;
 		}
 		else if (funcsym->Variants[0].Flags & VARF_Deprecated)
 		{

--- a/src/scripting/vm/vm.h
+++ b/src/scripting/vm/vm.h
@@ -705,10 +705,8 @@ do_double:		if (inexact)
 class VMFunction
 {
 public:
-	bool Native;
-	bool Final = false;				// cannot be overridden
-	bool Unsafe = false;			// Contains references to class fields that are unsafe for psp and item state calls.
-	bool FuncConst = false;			// [ZZ] readonly function
+	bool Unsafe = false;
+	int VarFlags = 0; // [ZZ] this replaces 5+ bool fields
 	int BarrierSide = 0;			// [ZZ] FScopeBarrier::Side
 	BYTE ImplicitArgs = 0;	// either 0 for static, 1 for method or 3 for action
 	unsigned VirtualIndex = ~0u;
@@ -718,7 +716,7 @@ public:
 
 	class PPrototype *Proto;
 
-	VMFunction(FName name = NAME_None) : Native(false), ImplicitArgs(0), Name(name), Proto(NULL)
+	VMFunction(FName name = NAME_None) : ImplicitArgs(0), Name(name), Proto(NULL)
 	{
 		AllFunctions.Push(this);
 	}
@@ -942,9 +940,10 @@ class VMNativeFunction : public VMFunction
 public:
 	typedef int (*NativeCallType)(VMValue *param, TArray<VMValue> &defaultparam, int numparam, VMReturn *ret, int numret);
 
-	VMNativeFunction() : NativeCall(NULL) { Native = true; }
-	VMNativeFunction(NativeCallType call) : NativeCall(call) { Native = true; }
-	VMNativeFunction(NativeCallType call, FName name) : VMFunction(name), NativeCall(call) { Native = true; }
+	// 8 is VARF_Native.
+	VMNativeFunction() : NativeCall(NULL) { VarFlags = 8; }
+	VMNativeFunction(NativeCallType call) : NativeCall(call) { VarFlags = 8; }
+	VMNativeFunction(NativeCallType call, FName name) : VMFunction(name), NativeCall(call) { VarFlags = 8; }
 
 	// Return value is the number of results.
 	NativeCallType NativeCall;

--- a/src/scripting/vm/vm.h
+++ b/src/scripting/vm/vm.h
@@ -707,7 +707,6 @@ class VMFunction
 public:
 	bool Unsafe = false;
 	int VarFlags = 0; // [ZZ] this replaces 5+ bool fields
-	int BarrierSide = 0;			// [ZZ] FScopeBarrier::Side
 	BYTE ImplicitArgs = 0;	// either 0 for static, 1 for method or 3 for action
 	unsigned VirtualIndex = ~0u;
 	FName Name;
@@ -940,7 +939,7 @@ class VMNativeFunction : public VMFunction
 public:
 	typedef int (*NativeCallType)(VMValue *param, TArray<VMValue> &defaultparam, int numparam, VMReturn *ret, int numret);
 
-	// 8 is VARF_Native.
+	// 8 is VARF_Native. I can't write VARF_Native because of circular references between this and dobject/dobjtype.
 	VMNativeFunction() : NativeCall(NULL) { VarFlags = 8; }
 	VMNativeFunction(NativeCallType call) : NativeCall(call) { VarFlags = 8; }
 	VMNativeFunction(NativeCallType call, FName name) : VMFunction(name), NativeCall(call) { VarFlags = 8; }

--- a/src/scripting/vm/vmexec.h
+++ b/src/scripting/vm/vmexec.h
@@ -22,7 +22,7 @@ static int Exec(VMFrameStack *stack, const VMOP *pc, VMReturn *ret, int numret)
 	const FVoidObj *konsta;
 	const VM_ATAG *konstatag;
 
-	if (f->Func != NULL && !f->Func->Native)
+	if (f->Func != NULL && !(f->Func->VarFlags & VARF_Native))
 	{
 		sfunc = static_cast<VMScriptFunction *>(f->Func);
 		konstd = sfunc->KonstD;
@@ -679,7 +679,7 @@ begin:
 #endif
 
 			FillReturns(reg, f, returns, pc+1, C);
-			if (call->Native)
+			if (call->VarFlags & VARF_Native)
 			{
 				try
 				{
@@ -736,7 +736,7 @@ begin:
 		{
 			VMFunction *call = (VMFunction *)ptr;
 
-			if (call->Native)
+			if (call->VarFlags & VARF_Native)
 			{
 				try
 				{
@@ -1966,7 +1966,7 @@ static void SetReturn(const VMRegisters &reg, VMFrame *frame, VMReturn *ret, VM_
 	const void *src;
 	VMScriptFunction *func = static_cast<VMScriptFunction *>(frame->Func);
 
-	assert(func != NULL && !func->Native);
+	assert(func != NULL && !(func->VarFlags & VARF_Native));
 	assert((regtype & ~REGT_KONST) == ret->RegType);
 
 	switch (regtype & REGT_TYPE)

--- a/src/scripting/vm/vmframe.cpp
+++ b/src/scripting/vm/vmframe.cpp
@@ -48,7 +48,6 @@ TArray<VMFunction *> VMFunction::AllFunctions;
 
 VMScriptFunction::VMScriptFunction(FName name)
 {
-	Native = false;
 	Name = name;
 	LineInfo = nullptr;
 	Code = NULL;
@@ -438,7 +437,7 @@ int VMFrameStack::Call(VMFunction *func, VMValue *params, int numparams, VMRetur
 	bool allocated = false;
 	try
 	{	
-		if (func->Native)
+		if (func->VarFlags & VARF_Native)
 		{
 			return static_cast<VMNativeFunction *>(func)->NativeCall(params, func->DefaultArgs, numparams, results, numresults);
 		}

--- a/src/scripting/zscript/zcc-parse.lemon
+++ b/src/scripting/zscript/zcc-parse.lemon
@@ -330,6 +330,7 @@ struct_def(X) ::= STRUCT(T) IDENTIFIER(A) struct_flags(S) LBRACE opt_struct_body
 struct_flags(X) ::= .										{ X.Flags = 0; }
 struct_flags(X) ::= struct_flags(A) UI.						{ X.Flags = A.Flags | ZCC_UIFlag; }
 struct_flags(X) ::= struct_flags(A) PLAY.					{ X.Flags = A.Flags | ZCC_Play; }
+struct_flags(X) ::= struct_flags(A) CLEARSCOPE.				{ X.Flags = A.Flags | ZCC_ClearScope; }
 struct_flags(X) ::= struct_flags(A) NATIVE.					{ X.Flags = A.Flags | ZCC_Native; }
 
 opt_struct_body(X) ::= .								{ X = NULL; }

--- a/src/scripting/zscript/zcc_compile.cpp
+++ b/src/scripting/zscript/zcc_compile.cpp
@@ -2415,7 +2415,6 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 		if (sym->Variants[0].Implementation != nullptr)
 		{
 			// [ZZ] unspecified virtual function inherits old scope. virtual function scope can't be changed.
-			sym->Variants[0].Implementation->BarrierSide = FScopeBarrier::SideFromFlags(varflags);
 			sym->Variants[0].Implementation->VarFlags = sym->Variants[0].Flags;
 		}
 
@@ -2461,8 +2460,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 							Error(f, "Attempt to change private/protected qualifiers for virtual function %s", FName(f->Name).GetChars());
 						}
 						// inherit scope of original function if override not specified
-						sym->Variants[0].Implementation->BarrierSide = oldfunc->BarrierSide;
-						sym->Variants[0].Flags = FScopeBarrier::ChangeSideInFlags(sym->Variants[0].Flags, oldfunc->BarrierSide);
+						sym->Variants[0].Flags = FScopeBarrier::ChangeSideInFlags(sym->Variants[0].Flags, FScopeBarrier::SideFromFlags(oldfunc->VarFlags));
 						// inherit const from original function
 						if (oldfunc->VarFlags & VARF_ReadOnly)
 							sym->Variants[0].Flags |= VARF_ReadOnly;

--- a/src/scripting/zscript/zcc_compile.cpp
+++ b/src/scripting/zscript/zcc_compile.cpp
@@ -2128,8 +2128,8 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 			varflags |= VARF_UI;
 		if (c->Type()->ObjectFlags & OF_Play)
 			varflags |= VARF_Play;
-		if (f->Flags & ZCC_FuncConst)
-			varflags = FScopeBarrier::ChangeSideInFlags(varflags, FScopeBarrier::Side_PlainData); // const implies clearscope. this is checked a bit later to also not have ZCC_Play/ZCC_UIFlag.
+		//if (f->Flags & ZCC_FuncConst)
+		//	varflags = FScopeBarrier::ChangeSideInFlags(varflags, FScopeBarrier::Side_PlainData); // const implies clearscope. this is checked a bit later to also not have ZCC_Play/ZCC_UIFlag.
 		if (f->Flags & ZCC_UIFlag)
 			varflags = FScopeBarrier::ChangeSideInFlags(varflags, FScopeBarrier::Side_UI);
 		if (f->Flags & ZCC_Play)
@@ -2214,13 +2214,6 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 		if ((varflags&(VARF_VirtualScope | VARF_Method)) == VARF_VirtualScope) // non-method virtualscope function
 		{
 			Error(f, "'VirtualScope' on a static method is not supported");
-		}
-
-		// you can't have a const function belonging to either ui or play.
-		// const is intended for plain data to signify that you can call a method on readonly variable.
-		if ((f->Flags & ZCC_FuncConst) && (f->Flags & (ZCC_UIFlag | ZCC_Play | ZCC_VirtualScope)))
-		{
-			Error(f, "Invalid combination of qualifiers %s on function %s", FlagsToString(f->Flags&(ZCC_FuncConst | ZCC_UIFlag | ZCC_Play | ZCC_VirtualScope)).GetChars(), FName(f->Name).GetChars());
 		}
 
 		static int excludescope[] = { ZCC_UIFlag, ZCC_Play, ZCC_ClearScope, ZCC_VirtualScope };
@@ -2458,9 +2451,9 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 							Error(f, "Attempt to change scope for virtual function %s", FName(f->Name).GetChars());
 						}
 						// you can't change const qualifier for a virtual method
-						if (oldfunc->FuncConst != sym->Variants[0].Implementation->FuncConst)
+						if (sym->Variants[0].Implementation->FuncConst && !oldfunc->FuncConst)
 						{
-							Error(f, "Attempt to change const qualifier for virtual function %s", FName(f->Name).GetChars());
+							Error(f, "Attempt to add const qualifier to virtual function %s", FName(f->Name).GetChars());
 						}
 						// inherit scope of original function if override not specified
 						sym->Variants[0].Implementation->BarrierSide = oldfunc->BarrierSide;

--- a/src/scripting/zscript/zcc_compile.cpp
+++ b/src/scripting/zscript/zcc_compile.cpp
@@ -501,10 +501,13 @@ void ZCCCompiler::CreateStructTypes()
 			Error(s->strct, "Struct %s has incompatible flags", s->NodeName().GetChars());
 		}
 
+		if (outer) s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::SideFromObjectFlags(outer->ObjectFlags));
 		if (s->strct->Flags & ZCC_UIFlag)
-			s->Type()->ObjectFlags |= OF_UI;
+			s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::Side_UI);
 		if (s->strct->Flags & ZCC_Play)
-			s->Type()->ObjectFlags |= OF_Play;
+			s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::Side_Play);
+		if (s->strct->Flags & ZCC_ClearScope)
+			s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::Side_PlainData); // don't inherit the scope from the outer class
 		s->strct->Symbol = new PSymbolType(s->NodeName(), s->Type());
 		syms->AddSymbol(s->strct->Symbol);
 

--- a/src/scripting/zscript/zcc_compile.cpp
+++ b/src/scripting/zscript/zcc_compile.cpp
@@ -501,7 +501,8 @@ void ZCCCompiler::CreateStructTypes()
 			Error(s->strct, "Struct %s has incompatible flags", s->NodeName().GetChars());
 		}
 
-		if (outer) s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::SideFromObjectFlags(outer->ObjectFlags));
+		if (outer != OutNamespace) s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::SideFromObjectFlags(outer->ObjectFlags));
+		else if (s->strct->Flags & ZCC_ClearScope) Warn(s->strct, "Useless 'ClearScope' on struct %s not inside a class", s->NodeName().GetChars());
 		if (s->strct->Flags & ZCC_UIFlag)
 			s->Type()->ObjectFlags = FScopeBarrier::ChangeSideInObjectFlags(s->Type()->ObjectFlags, FScopeBarrier::Side_UI);
 		if (s->strct->Flags & ZCC_Play)

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -283,12 +283,12 @@ class StaticEventHandler : Object native play
 {
     // static event handlers CAN register other static event handlers.
     // unlike EventHandler.Create that will not create them.
-    clearscope protected static native StaticEventHandler Create(class<StaticEventHandler> type);
-    clearscope protected static native StaticEventHandler CreateOnce(class<StaticEventHandler> type);
-    clearscope protected static native StaticEventHandler Find(Class<StaticEventHandler> type); // just for convenience. who knows.
+    clearscope static native StaticEventHandler Create(class<StaticEventHandler> type);
+    clearscope static native StaticEventHandler CreateOnce(class<StaticEventHandler> type);
+    clearscope static native StaticEventHandler Find(Class<StaticEventHandler> type); // just for convenience. who knows.
     
-    clearscope protected static native bool Register(StaticEventHandler handler);
-    clearscope protected static native bool Unregister(StaticEventHandler handler);
+    clearscope static native bool Register(StaticEventHandler handler);
+    clearscope static native bool Unregister(StaticEventHandler handler);
     
     // these are called when the handler gets registered or unregistered
     // you can set Order/IsUiProcessor here.

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -283,12 +283,12 @@ class StaticEventHandler : Object native play
 {
     // static event handlers CAN register other static event handlers.
     // unlike EventHandler.Create that will not create them.
-    protected static native StaticEventHandler Create(class<StaticEventHandler> type);
-    protected static native StaticEventHandler CreateOnce(class<StaticEventHandler> type);
-    protected static native StaticEventHandler Find(Class<StaticEventHandler> type); // just for convenience. who knows.
+    clearscope protected static native StaticEventHandler Create(class<StaticEventHandler> type);
+    clearscope protected static native StaticEventHandler CreateOnce(class<StaticEventHandler> type);
+    clearscope protected static native StaticEventHandler Find(Class<StaticEventHandler> type); // just for convenience. who knows.
     
-    protected static native bool Register(StaticEventHandler handler);
-    protected static native bool Unregister(StaticEventHandler handler);
+    clearscope protected static native bool Register(StaticEventHandler handler);
+    clearscope protected static native bool Unregister(StaticEventHandler handler);
     
     // these are called when the handler gets registered or unregistered
     // you can set Order/IsUiProcessor here.
@@ -337,12 +337,12 @@ class StaticEventHandler : Object native play
 
 class EventHandler : StaticEventHandler native
 {
-    static native StaticEventHandler Create(class<StaticEventHandler> type);
-    static native StaticEventHandler CreateOnce(class<StaticEventHandler> type);
-    static native StaticEventHandler Find(class<StaticEventHandler> type);
+    clearscope static native StaticEventHandler Create(class<StaticEventHandler> type);
+    clearscope static native StaticEventHandler CreateOnce(class<StaticEventHandler> type);
+    clearscope static native StaticEventHandler Find(class<StaticEventHandler> type);
 
-    static native bool Register(StaticEventHandler handler);
-    static native bool Unregister(StaticEventHandler handler);
+    clearscope static native bool Register(StaticEventHandler handler);
+    clearscope static native bool Unregister(StaticEventHandler handler);
     
     clearscope static native void SendNetworkEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
 }


### PR DESCRIPTION
- probably fixed virtual inheritance of const property (not exactly sure how... but seems to work properly now — you can't enable const for a non-const virtual, and if it's already const you can specify or not specify it without any effect)
- removed the old checks that const==clearscope (I initially wanted to keep EITHER clearscope or const, that's why it was there)
Const can now have play or ui qualifier with all the restrictions of these +readonly self.