### PR TITLE
- implemented "hazardcolor" and "hazardflash" properties. This affect…

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1462,6 +1462,8 @@ void G_InitLevelLocals ()
 	level.NextMap = info->NextMap;
 	level.NextSecretMap = info->NextSecretMap;
 	level.F1Pic = info->F1Pic;
+	level.hazardcolor = info->hazardcolor;
+	level.hazardflash = info->hazardflash;
 
 	compatflags.Callback();
 	compatflags2.Callback();

--- a/src/g_level.h
+++ b/src/g_level.h
@@ -315,6 +315,8 @@ struct level_info_t
 	FName		Intermission;
 	FName		deathsequence;
 	FName		slideshow;
+	DWORD		hazardcolor;
+	DWORD		hazardflash;
 
 	// Redirection: If any player is carrying the specified item, then
 	// you go to the RedirectMap instead of this one.

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -43,6 +43,9 @@ struct FLevelLocals
 	DWORD		fadeto;					// The color the palette fades to (usually black)
 	DWORD		outsidefog;				// The fog for sectors with sky ceilings
 
+	DWORD		hazardcolor;			// what color strife hazard blends the screen color as
+	DWORD		hazardflash;			// what color strife hazard flashes the screen color as
+
 	FString		Music;
 	int			musicorder;
 	int			cdtrack;

--- a/src/g_mapinfo.cpp
+++ b/src/g_mapinfo.cpp
@@ -273,6 +273,8 @@ void level_info_t::Reset()
 	SndSeq = "";
 	BorderTexture = "";
 	teamdamage = 0.f;
+	hazardcolor = 0xff004200;
+	hazardflash = 0xff00ff00;
 	specialactions.Clear();
 	DefaultEnvironment = 0;
 	PrecacheSounds.Clear();
@@ -1198,6 +1200,20 @@ DEFINE_MAP_OPTION(defaultenvironment, false)
 		}
 	}
 	info->DefaultEnvironment = id;
+}
+
+DEFINE_MAP_OPTION(hazardcolor, true)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetString();
+	info->hazardcolor = V_GetColor(NULL, parse.sc);
+}
+
+DEFINE_MAP_OPTION(hazardflash, true)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetString();
+	info->hazardflash = V_GetColor(NULL, parse.sc);
 }
 
 

--- a/src/v_blend.cpp
+++ b/src/v_blend.cpp
@@ -51,6 +51,7 @@
 #include "colormatcher.h"
 #include "v_palette.h"
 #include "d_player.h"
+#include "g_levellocals.h"
 
 CVAR( Float, blood_fade_scalar, 1.0f, CVAR_ARCHIVE )	// [SP] Pulled from Skulltag - changed default from 0.5 to 1.0
 CVAR( Float, pickup_fade_scalar, 1.0f, CVAR_ARCHIVE )	// [SP] Uses same logic as blood_fade_scalar except for pickups
@@ -168,13 +169,19 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 		{
 			if (CPlayer->hazardcount > 16*TICRATE || (CPlayer->hazardcount & 8))
 			{
-				V_AddBlend (0.f, 1.f, 0.f, 0.125f, blend);
+				float r = ((level.hazardflash & 0xff0000) >> 16) / 255.f;
+				float g = ((level.hazardflash & 0xff00) >> 8) / 255.f;
+				float b = ((level.hazardflash & 0xff)) / 255.f;
+				V_AddBlend (r, g, b, 0.125f, blend);
 			}
 		}
 		else
 		{
 			cnt= MIN(CPlayer->hazardcount/8, 64);
-			V_AddBlend (0.f, 0.2571f, 0.f, cnt/93.2571428571f, blend);
+			float r = ((level.hazardcolor & 0xff0000) >> 16) / 255.f;
+			float g = ((level.hazardcolor & 0xff00) >> 8) / 255.f;
+			float b = ((level.hazardcolor & 0xff)) / 255.f;
+			V_AddBlend (r, g, b, cnt/93.2571428571f, blend);
 		}
 	}
 


### PR DESCRIPTION
…s strife's sector damage type that passively builds up over time. setting "hazardcolor" changes the gradual blend that is used when palette flash is disabled. setting "hazardflash" changes the flashing blend that is used when palette flash is turned on.