### PR TITLE
Direct PicNum override in PSprite like in Actor itself.

### DIFF
--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -90,7 +90,7 @@ void FGLRenderer::DrawPSprite (player_t * player,DPSprite *psp, float sx, float 
 	}
 	else
 	{
-		gl_GetSpriteFrame(psp->GetSprite(), psp->GetFrame(), 0, 0, &mirror);
+		lump = gl_GetSpriteFrame(psp->GetSprite(), psp->GetFrame(), 0, 0, &mirror);
 	}
 
 	if (!lump.isValid()) return;

--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -154,8 +154,11 @@ void FGLRenderer::DrawPSprite (player_t * player,DPSprite *psp, float sx, float 
 		fV1 = tex->GetSpriteVT();
 		fU2 = tex->GetSpriteUR();
 		fV2 = tex->GetSpriteVB();
-		
 	}
+
+	// [ZZ] vertical mirroring of canvas texture. for reasons.
+	if (tex->tex->bHasCanvas)
+		std::swap(fV1, fV2);
 
 	if (tex->GetTransparent() || OverrideShader != -1)
 	{

--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -81,7 +81,18 @@ void FGLRenderer::DrawPSprite (player_t * player,DPSprite *psp, float sx, float 
 
 	// decide which patch to use
 	bool mirror;
-	FTextureID lump = gl_GetSpriteFrame(psp->GetSprite(), psp->GetFrame(), 0, 0, &mirror);
+	FTextureID picnumOverride = psp->GetPicNum();
+	FTextureID lump;
+	if (picnumOverride.isValid())
+	{
+		lump = picnumOverride;
+		mirror = false;
+	}
+	else
+	{
+		gl_GetSpriteFrame(psp->GetSprite(), psp->GetFrame(), 0, 0, &mirror);
+	}
+
 	if (!lump.isValid()) return;
 
 	FMaterial * tex = FMaterial::ValidateTexture(lump, true, false);

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -111,6 +111,7 @@ DEFINE_FIELD(DPSprite, Caller)
 DEFINE_FIELD(DPSprite, Next)
 DEFINE_FIELD(DPSprite, Owner)
 DEFINE_FIELD(DPSprite, Sprite)
+DEFINE_FIELD(DPSprite, PicNum)
 DEFINE_FIELD(DPSprite, Frame)
 DEFINE_FIELD(DPSprite, ID)
 DEFINE_FIELD(DPSprite, processPending)
@@ -168,6 +169,8 @@ DPSprite::DPSprite(player_t *owner, AActor *caller, int id)
 
 	if (Caller->IsKindOf(NAME_Weapon) || Caller->IsKindOf(RUNTIME_CLASS(APlayerPawn)))
 		Flags = (PSPF_ADDWEAPON|PSPF_ADDBOB|PSPF_POWDOUBLE|PSPF_CVARFAST);
+
+	PicNum.SetInvalid();
 }
 
 //------------------------------------------------------------------------

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -68,6 +68,7 @@ public:
 
 	int			GetID()		const { return ID; }
 	int			GetSprite()	const { return Sprite; }
+	FTextureID  GetPicNum() const { return PicNum; }
 	int			GetFrame()	const { return Frame; }
 	int			GetTics()   const {	return Tics; }
 	FState*		GetState()	const { return State; }
@@ -98,6 +99,7 @@ public:	// must be public to be able to generate the field export tables. Grrr..
 	int Frame;
 	int ID;
 	bool processPending; // true: waiting for periodic processing on this tick
+	FTextureID PicNum;
 
 	friend class player_t;
 	friend void CopyPlayer(player_t *dst, player_t *src, const char *name);

--- a/src/r_things.cpp
+++ b/src/r_things.cpp
@@ -1301,21 +1301,30 @@ void R_DrawPSprite(DPSprite *pspr, AActor *owner, float bobx, float boby, double
 		avis.Reserve(avis.Size() - vispspindex + 1);
 
 	// decide which patch to use
-	if ((unsigned)pspr->GetSprite() >= (unsigned)sprites.Size())
+	picnum = pspr->GetPicNum();
+	if (!picnum.isValid())
 	{
-		DPrintf(DMSG_ERROR, "R_DrawPSprite: invalid sprite number %i\n", pspr->GetSprite());
-		return;
-	}
-	sprdef = &sprites[pspr->GetSprite()];
-	if (pspr->GetFrame() >= sprdef->numframes)
-	{
-		DPrintf(DMSG_ERROR, "R_DrawPSprite: invalid sprite frame %i : %i\n", pspr->GetSprite(), pspr->GetFrame());
-		return;
-	}
-	sprframe = &SpriteFrames[sprdef->spriteframes + pspr->GetFrame()];
+		if ((unsigned)pspr->GetSprite() >= (unsigned)sprites.Size())
+		{
+			DPrintf(DMSG_ERROR, "R_DrawPSprite: invalid sprite number %i\n", pspr->GetSprite());
+			return;
+		}
+		sprdef = &sprites[pspr->GetSprite()];
+		if (pspr->GetFrame() >= sprdef->numframes)
+		{
+			DPrintf(DMSG_ERROR, "R_DrawPSprite: invalid sprite frame %i : %i\n", pspr->GetSprite(), pspr->GetFrame());
+			return;
+		}
+		sprframe = &SpriteFrames[sprdef->spriteframes + pspr->GetFrame()];
 
-	picnum = sprframe->Texture[0];
-	flip = sprframe->Flip & 1;
+		picnum = sprframe->Texture[0];
+		flip = sprframe->Flip & 1;
+	}
+	else
+	{
+		flip = false;
+	}
+
 	tex = TexMan(picnum);
 
 	if (tex->UseType == FTexture::TEX_Null)

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -994,6 +994,18 @@ void FCanvasTextureInfo::Add (AActor *viewpoint, FTextureID picnum, int fov)
 	List = probe;
 }
 
+// [ZZ] expose this to ZScript
+DEFINE_ACTION_FUNCTION(_TexMan, SetCameraToTexture)
+{
+	PARAM_PROLOGUE;
+	PARAM_OBJECT(viewpoint, AActor);
+	PARAM_STRING(texturename); // [ZZ] there is no point in having this as FTextureID because it's easier to refer to a cameratexture by name and it isn't executed too often to cache it.
+	PARAM_INT(fov);
+	FTextureID textureid = TexMan.CheckForTexture(texturename, FTexture::TEX_Wall, FTextureManager::TEXMAN_Overridable);
+	FCanvasTextureInfo::Add(viewpoint, textureid, fov);
+	return 0;
+}
+
 //==========================================================================
 //
 // FCanvasTextureInfo :: UpdateAll

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -96,6 +96,8 @@ struct TexMan
 	native static void ReplaceTextures(String from, String to, int flags);
 	native static int, int GetSize(TextureID tex);
 	native static Vector2 GetScaledSize(TextureID tex);
+    
+    native static void SetCameraToTexture(Actor viewpoint, String texture, int fov);
 }
 
 enum DrawTextureTags

--- a/wadsrc/static/zscript/shared/player.txt
+++ b/wadsrc/static/zscript/shared/player.txt
@@ -207,6 +207,7 @@ class PSprite : Object native play
 	native readonly State CurState; 
 	native Actor Caller;
 	native readonly PSprite Next;
+    native TextureID PicNum;
 	native readonly PlayerInfo Owner;
 	native SpriteID Sprite;
 	native int Frame;


### PR DESCRIPTION
subj. Tested in both softwares (D3D and DDraw) and OpenGL.

The most direct usage is cameratexture as part of a weapon (e.g. video camera or fancy scope, especially if FOV and shader are applied (remember I made a PR that enabled shaders for cameratextures?)). As such I also touched that part and added SetCameraToTexture to ZScript.

Might be some other uses I haven't thought of, but definitely no more abuse possible than with regular sprites. *thinks of mouse cursor in overlay in DECORATE by whoever did it*