### PR TITLE
Added a way to tell apart console-executed events from code-executed SendNetworkEvent

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2676,7 +2676,8 @@ void Net_DoCommand (int type, BYTE **stream, int player)
 			int arg[3] = { 0, 0, 0 };
 			for (int i = 0; i < 3; i++)
 				arg[i] = ReadLong(stream);
-			E_Console(player, s, arg[0], arg[1], arg[2]);
+			bool manual = ReadByte(stream);
+			E_Console(player, s, arg[0], arg[1], arg[2], manual);
 		}
 		break;
 
@@ -2727,7 +2728,7 @@ void Net_SkipCommand (int type, BYTE **stream)
 			break;
 
 		case DEM_NETEVENT:
-			skip = strlen((char *)(*stream)) + 14;
+			skip = strlen((char *)(*stream)) + 15;
 			break;
 
 		case DEM_SUMMON2:

--- a/src/events.h
+++ b/src/events.h
@@ -58,10 +58,10 @@ void E_PlayerDisconnected(int num);
 // this executes on events.
 bool E_Responder(event_t* ev); // splits events into InputProcess and UiProcess
 // this executes on console/net events.
-void E_Console(int player, FString name, int arg1, int arg2, int arg3);
+void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manual);
 
 // send networked event. unified function.
-bool E_SendNetworkEvent(FString name, int arg1, int arg2, int arg3);
+bool E_SendNetworkEvent(FString name, int arg1, int arg2, int arg3, bool manual);
 
 // check if there is anything that should receive GUI events
 bool E_CheckUiProcessors();
@@ -152,7 +152,7 @@ public:
 	bool UiProcess(event_t* ev);
 	
 	// 
-	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3);
+	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual);
 };
 class DEventHandler : public DStaticEventHandler
 {
@@ -300,10 +300,13 @@ public:
 	//
 	FString Name;
 	int Args[3];
+	//
+	bool IsManual;
 
 	DConsoleEvent()
 	{
 		Player = -1;
+		IsManual = false;
 	}
 };
 

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -275,8 +275,11 @@ class ConsoleEvent : BaseEvent native version("2.4")
     // for net events, this will be the activator.
     // for UI events, this is always -1, and you need to check if level is loaded and use players[consoleplayer].
     native readonly int Player;
+    // this is the name and args as specified in SendNetworkEvent or event/netevent CCMDs
     native readonly String Name;
     native readonly int Args[3];
+    // this will be true if the event is fired from the console by event/netevent CCMD
+    native readonly bool IsManual;
 }
 
 class StaticEventHandler : Object native play version("2.4")


### PR DESCRIPTION
This serves similar purpose to the NET script type — so that the code can prevent cheating by checking ev.IsManual.
Also, so far regular console event is always manual.