### PR TITLE
Deprecated Function Fix

### DIFF
--- a/src/scripting/backend/codegen.cpp
+++ b/src/scripting/backend/codegen.cpp
@@ -8516,7 +8516,6 @@ bool FxVMFunctionCall::CheckAccessibility(const VersionInfo &ver)
 	if ((Function->Variants[0].Flags & VARF_Deprecated) && Function->mVersion >= ver)
 	{
 		ScriptPosition.Message(MSG_WARNING, "Accessing deprecated function %s - deprecated since %d.%d.%d", Function->SymbolName.GetChars(), Function->mVersion.major, Function->mVersion.minor, Function->mVersion.revision);
-		return false;
 	}
 	return true;
 }


### PR DESCRIPTION
- Fixed: Deprecated functions could not act because FxVMFunctionCall::CheckAccessibility returned false on warning.