### PR TITLE
Added E_Responder call for direct mouse input interception

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -288,7 +288,7 @@ void D_ProcessEvents (void)
 		if (M_Responder (ev))
 			continue;				// menu ate the event
 		// check events
-		if (E_Responder(ev)) // [ZZ] ZScript ate the event // update 07.03.17: mouse events are handled directly
+		if (ev->type != EV_Mouse && E_Responder(ev)) // [ZZ] ZScript ate the event // update 07.03.17: mouse events are handled directly
 			continue;
 		G_Responder (ev);
 	}
@@ -310,7 +310,7 @@ void D_PostEvent (const event_t *ev)
 		return;
 	}
 	events[eventhead] = *ev;
-	if (ev->type == EV_Mouse && !paused && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !E_Responder(ev))
+	if (ev->type == EV_Mouse && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !E_Responder(ev) && !paused)
 	{
 		if (Button_Mlook.bDown || freelook)
 		{

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -288,7 +288,7 @@ void D_ProcessEvents (void)
 		if (M_Responder (ev))
 			continue;				// menu ate the event
 		// check events
-		if (E_Responder(ev)) // [ZZ] ZScript ate the event
+		if (E_Responder(ev)) // [ZZ] ZScript ate the event // update 07.03.17: mouse events are handled directly
 			continue;
 		G_Responder (ev);
 	}
@@ -310,7 +310,7 @@ void D_PostEvent (const event_t *ev)
 		return;
 	}
 	events[eventhead] = *ev;
-	if (ev->type == EV_Mouse && !paused && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !E_CheckUiProcessors())
+	if (ev->type == EV_Mouse && !paused && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !E_Responder(ev))
 	{
 		if (Button_Mlook.bDown || freelook)
 		{

--- a/src/events.h
+++ b/src/events.h
@@ -56,7 +56,7 @@ void E_PlayerDied(int num);
 // this executes when a player leaves the game
 void E_PlayerDisconnected(int num);
 // this executes on events.
-bool E_Responder(event_t* ev); // splits events into InputProcess and UiProcess
+bool E_Responder(const event_t* ev); // splits events into InputProcess and UiProcess
 // this executes on console/net events.
 void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manual);
 
@@ -148,8 +148,8 @@ public:
 	void PlayerDisconnected(int num);
 
 	// return true if handled.
-	bool InputProcess(event_t* ev);
-	bool UiProcess(event_t* ev);
+	bool InputProcess(const event_t* ev);
+	bool UiProcess(const event_t* ev);
 	
 	// 
 	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual);
@@ -215,7 +215,7 @@ struct FUiEvent
 	bool IsCtrl;
 	bool IsAlt;
 
-	FUiEvent(event_t *ev);
+	FUiEvent(const event_t *ev);
 };
 
 struct FInputEvent
@@ -230,7 +230,7 @@ struct FInputEvent
 	int MouseX;
 	int MouseY;
 
-	FInputEvent(event_t *ev);
+	FInputEvent(const event_t *ev);
 };
 
 struct FConsoleEvent 


### PR DESCRIPTION
Properly fixes absence of EV_Mouse in the event system.
It's ok to have it called at the framerate speed because InputProcess is 'ui' anyway.

I also changed functions that accept an event_t* in the event system to const event_t* for compatibility with D_PostEvent.