### PR TITLE
Default to no texture filtering

### DIFF
--- a/src/gl/textures/gl_texture.cpp
+++ b/src/gl/textures/gl_texture.cpp
@@ -58,7 +58,7 @@ CCMD(gl_flush)
 	if (GLRenderer != NULL) GLRenderer->FlushTextures();
 }
 
-CUSTOM_CVAR(Int, gl_texture_filter, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
+CUSTOM_CVAR(Int, gl_texture_filter, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
 {
 	if (self < 0 || self > 6) self=4;
 	if (GLRenderer != NULL && GLRenderer->mSamplerManager != NULL) GLRenderer->mSamplerManager->SetTextureFilterMode();


### PR DESCRIPTION
GZDoom should default to using no texture filtering as it keeps that glorious, crisp original Doom/ZDoom look. 