### PR TITLE
Default to scaling message text in high res

### DIFF
--- a/src/c_console.cpp
+++ b/src/c_console.cpp
@@ -146,7 +146,7 @@ static int worklen = 0;
 
 CVAR(Float, con_notifytime, 3.f, CVAR_ARCHIVE)
 CVAR(Bool, con_centernotify, false, CVAR_ARCHIVE)
-CUSTOM_CVAR(Int, con_scaletext, 1, CVAR_ARCHIVE)		// Scale notify text at high resolutions?
+CUSTOM_CVAR(Int, con_scaletext, 0, CVAR_ARCHIVE)		// Scale notify text at high resolutions?
 {
 	if (self < 0) self = 0;
 	if (self > 3) self = 3;


### PR DESCRIPTION
Message text should be scaling in high res by default. Without it on a 24" 1920x1200 monitor, the message text is barely readable and arguably looks out of place. The below screenshots also appear to apply to a 13" 3200x1800 device.

![noscale](https://cloud.githubusercontent.com/assets/6550543/23691949/ad9e8ecc-0399-11e7-8cbf-aa632a15f1cc.png)

With it enabled, it is clearly readable and "fits" with the default HUD.

![scale](https://cloud.githubusercontent.com/assets/6550543/23691962/c3562c5c-0399-11e7-91aa-0fe3a2f6d39c.png)

It also keeps it looking closer in size to the console text.