### PR TITLE
Unfriendly coop

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1765,6 +1765,8 @@ void G_DoReborn (int playernum, bool freshbot)
 	}
 	else
 	{
+		bool isUnfriendly = players[playernum].mo && !(players[playernum].mo->flags & MF_FRIENDLY);
+
 		// respawn at the start
 		// first disassociate the corpse
 		if (players[playernum].mo)
@@ -1774,7 +1776,7 @@ void G_DoReborn (int playernum, bool freshbot)
 		}
 
 		// spawn at random spot if in deathmatch
-		if (deathmatch)
+		if (deathmatch || isUnfriendly)
 		{
 			G_DeathMatchSpawnPlayer (playernum);
 			return;

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -250,9 +250,6 @@ void P_NoiseAlert (AActor *target, AActor *emitter, bool splash, double maxdist)
 	if (emitter == NULL)
 		return;
 
-	/*if (target != NULL && target->player && !(target->flags & MF_FRIENDLY))
-		return;*/
-
 	if (target != NULL && target->player && (target->player->cheats & CF_NOTARGET))
 		return;
 

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -250,6 +250,9 @@ void P_NoiseAlert (AActor *target, AActor *emitter, bool splash, double maxdist)
 	if (emitter == NULL)
 		return;
 
+	/*if (target != NULL && target->player && !(target->flags & MF_FRIENDLY))
+		return;*/
+
 	if (target != NULL && target->player && (target->player->cheats & CF_NOTARGET))
 		return;
 
@@ -1883,6 +1886,9 @@ bool P_LookForPlayers (AActor *actor, INTBOOL allaround, FLookExParams *params)
 		if (!(player->mo->flags & MF_SHOOTABLE))
 			continue;			// not shootable (observer or dead)
 
+		if (!((actor->flags ^ player->mo->flags) & MF_FRIENDLY))
+			continue;			// same +MF_FRIENDLY, ignore
+
 		if (player->cheats & CF_NOTARGET)
 			continue;			// no target
 
@@ -1982,7 +1988,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Look)
 			targ = NULL;
 		}
 
-		if (targ && targ->player && (targ->player->cheats & CF_NOTARGET))
+		if (targ && targ->player && ((targ->player->cheats & CF_NOTARGET) || !(targ->flags & MF_FRIENDLY)))
 		{
 			return 0;
 		}

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -7285,6 +7285,9 @@ bool AActor::IsFriend (AActor *other)
 			other->FriendPlayer == 0 ||
 			players[FriendPlayer-1].mo->IsTeammate(players[other->FriendPlayer-1].mo);
 	}
+	// [SP] If friendly flags match, then they are on the same team.
+	/*if (!((flags ^ other->flags) & MF_FRIENDLY))
+		return true;*/
 	return false;
 }
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -7204,7 +7204,7 @@ bool AActor::IsTeammate (AActor *other)
 	}
 	else if (!deathmatch && player && other->player)
 	{
-		return true;
+		return (!((flags ^ other->flags) & MF_FRIENDLY));
 	}
 	else if (teamplay)
 	{

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -4103,6 +4103,22 @@ void P_SetupLevel (const char *lumpname, int position)
 		}
 	}
 
+	// [SP] move unfriendly players around
+	// horribly hacky - yes, this needs rewritten.
+	for (i = 0; i < MAXPLAYERS; ++i)
+	{
+		if (playeringame[i] && players[i].mo != NULL)
+		{
+			if (!(players[i].mo->flags & MF_FRIENDLY))
+			{
+				AActor * oldSpawn = players[i].mo;
+				G_DeathMatchSpawnPlayer (i);
+				oldSpawn->Destroy();
+			}
+		}
+	}
+
+
 	// Don't count monsters in end-of-level sectors if option is on
 	if (dmflags2 & DF2_NOCOUNTENDMONST)
 	{


### PR DESCRIPTION
- Not sure how you feel about this prior to 2.4. The discussion that spawned this is here:
https://forum.zdoom.org/viewtopic.php?f=3&t=55496

Basically what happens is this: If a player chooses a class that is -FRIENDLY, it implies they are a monster, and certain deathmatch mechanics are enabled for them (such as no teamdamage protection, proper obituaries, etc). Would like your feedback on this.