### PR TITLE
FLATSPRITE + SPRITEANGLE interaction fix

### DIFF
--- a/src/gl/scene/gl_sprite.cpp
+++ b/src/gl/scene/gl_sprite.cpp
@@ -789,7 +789,7 @@ void GLSprite::Process(AActor* thing, sector_t * sector, int thruportal)
 		{
 			DAngle sprangle;
 			int rot;
-			if (!(thing->renderflags & RF_FLATSPRITE))
+			if (!(thing->renderflags & RF_FLATSPRITE) || thing->flags7 & MF7_SPRITEANGLE)
 			{
 				sprangle = thing->GetSpriteAngle(ang, r_viewpoint.TicFrac);
 				rot = -1;


### PR DESCRIPTION
- fixed: Flat sprites did not rotate their sprite angles when given t…he FLATSPRITE flag.