### PR TITLE
ZScript version of SetCameraToTexture

### DIFF
--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -65,6 +65,7 @@
 #include "p_maputl.h"
 #include "sbar.h"
 #include "math/cmath.h"
+#include "vm.h"
 
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
@@ -981,6 +982,18 @@ void FCanvasTextureInfo::Add (AActor *viewpoint, FTextureID picnum, int fov)
 	probe->Next = List;
 	texture->bFirstUpdate = true;
 	List = probe;
+}
+
+// [ZZ] expose this to ZScript
+DEFINE_ACTION_FUNCTION(_TexMan, SetCameraToTexture)
+{
+	PARAM_PROLOGUE;
+	PARAM_OBJECT(viewpoint, AActor);
+	PARAM_STRING(texturename); // [ZZ] there is no point in having this as FTextureID because it's easier to refer to a cameratexture by name and it isn't executed too often to cache it.
+	PARAM_INT(fov);
+	FTextureID textureid = TexMan.CheckForTexture(texturename, FTexture::TEX_Wall, FTextureManager::TEXMAN_Overridable);
+	FCanvasTextureInfo::Add(viewpoint, textureid, fov);
+	return 0;
 }
 
 //==========================================================================

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -93,6 +93,8 @@ struct TexMan
 	native static Vector2 GetScaledSize(TextureID tex);
 	native static Vector2 GetScaledOffset(TextureID tex);
 	native static int CheckRealHeight(TextureID tex);
+
+	native static void SetCameraToTexture(Actor viewpoint, String texture, int fov);
 }
 
 enum DrawTextureTags


### PR DESCRIPTION
Some code from my old thing #272. Tested, works :)

It's actually useful to have this in ZScript since it can be used to do fullscreen postprocessing effects by putting a shader on a HUD cameratexture.