### PR TITLE
Fix sound looping points

### DIFF
--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -1283,7 +1283,7 @@ std::pair<SoundHandle,bool> OpenALSoundRenderer::LoadSound(uint8_t *sfxdata, int
 	if (!startass) loop_start = Scale(loop_start, srate, 1000);
 	if (!endass) loop_end = Scale(loop_end, srate, 1000);
 	if (loop_start < 0)	loop_start = 0;
-	if (loop_end >= data.Size() / samplesize) loop_end = data.Size() / samplesize - 1;
+	if (loop_end > data.Size() / samplesize) loop_end = data.Size() / samplesize;
 
 	if ((loop_start > 0 || loop_end > 0) && loop_end > loop_start && AL.SOFT_loop_points)
 	{

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -1205,7 +1205,7 @@ std::pair<SoundHandle,bool> OpenALSoundRenderer::LoadSound(uint8_t *sfxdata, int
 	ChannelConfig chans;
 	SampleType type;
 	int srate;
-	uint32_t loop_start = 0, loop_end = 0;
+	uint32_t loop_start = 0, loop_end = std::numeric_limits<uint32_t>::max();
 	bool startass = false, endass = false;
 
 	if (!memcmp(sfxdata, "OggS", 4) || !memcmp(sfxdata, "FLAC", 4))


### PR DESCRIPTION
This fixes an off-by-one error with the loop end (OpenAL's loop end point is exclusive, rather than inclusive; it was skipping the last sample). It also fixes the default loop_end value so that an unspecified LOOP_END tag means to loop at the end of the sound.