### PR TITLE
Update LASTRUNVERSION to handle the snd_hrtf change

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -378,9 +378,13 @@ void FGameConfigFile::DoGlobalSetup ()
 				if (var != NULL) var->ResetToDefault();
 				var = FindCVar("uiscale", NULL);
 				if (var != NULL) var->ResetToDefault();
-
 			}
-
+			if (last < 215)
+			{
+				// Previously a true/false boolean. Now an on/off/auto tri-state with auto as the default.
+				FBaseCVar *var = FindCVar("snd_hrtf", NULL);
+				if (var != NULL) var->ResetToDefault();
+			}
 		}
 	}
 }

--- a/src/sound/i_sound.cpp
+++ b/src/sound/i_sound.cpp
@@ -66,7 +66,7 @@ EXTERN_CVAR (Float, snd_sfxvolume)
 CVAR (Int, snd_samplerate, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Int, snd_buffersize, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (String, snd_output, "default", CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-CVAR (Int, snd_hrtf, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR (Int, snd_hrtf, -1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
 #if !defined(NO_OPENAL)
 #define DEF_BACKEND "openal"

--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -756,7 +756,7 @@ OpenALSoundRenderer::OpenALSoundRenderer()
 	if(ALC.SOFT_HRTF)
 	{
 		attribs.Push(ALC_HRTF_SOFT);
-		if(*snd_hrtf < 0)
+		if(*snd_hrtf == 0)
 			attribs.Push(ALC_FALSE);
 		else if(*snd_hrtf > 0)
 			attribs.Push(ALC_TRUE);

--- a/src/version.h
+++ b/src/version.h
@@ -68,7 +68,7 @@ const char *GetVersionString();
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define LASTRUNVERSION "214"
+#define LASTRUNVERSION "215"
 
 // Protocol version used in demos.
 // Bump it if you change existing DEM_ commands or add new ones.

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -309,10 +309,10 @@ OptionValue "OffOn"
 	1, "$OPTVAL_OFF"
 }
 
-OptionValue OffAutoOn
+OptionValue AutoOffOn
 {
-	-1, "$OPTVAL_OFF"
-	0, "$OPTVAL_AUTO"
+	-1, "$OPTVAL_AUTO"
+	0, "$OPTVAL_OFF"
 	1, "$OPTVAL_ON"
 }
 
@@ -1636,7 +1636,7 @@ OptionMenu AdvSoundOptions
 {
 	Title "$ADVSNDMNU_TITLE"
 	Option "$ADVSNDMNU_SAMPLERATE",			"snd_samplerate", "SampleRates"
-	Option "$ADVSNDMNU_HRTF",				"snd_hrtf", "OffAutoOn"
+	Option "$ADVSNDMNU_HRTF",				"snd_hrtf", "AutoOffOn"
 	StaticText " "
 	StaticText "$ADVSNDMNU_OPLSYNTHESIS",	1
 	Slider "$ADVSNDMNU_OPLNUMCHIPS", 		"opl_numchips", 1, 8, 1, 0


### PR DESCRIPTION
Also snd_hrtf now uses -1 for "auto" and 0 for "off", which makes more sense.