### PR TITLE
Fix handling long wait times on POSIX's I_WaitVBL

### DIFF
--- a/src/posix/sdl/i_system.cpp
+++ b/src/posix/sdl/i_system.cpp
@@ -113,7 +113,12 @@ void I_WaitVBL (int count)
 {
     // I_WaitVBL is never used to actually synchronize to the
     // vertical blank. Instead, it's used for delay purposes.
-    usleep (1000000 * count / 70);
+    struct timespec delay, rem;
+    delay.tv_sec = count / 70;
+    /* Avoid overflow. Microsec res should be good enough. */
+    delay.tv_nsec = (count%70)*1000000/70 * 1000;
+    while(nanosleep(&delay, &rem) == -1 && errno == EINTR)
+        delay = rem;
 }
 
 //


### PR DESCRIPTION
usleep only works for sleeping up to one second. The function is also
deprecated and nanosleep should be used instead.