### PR TITLE
Replace usleep with nanosleep for macOS too

### DIFF
--- a/src/posix/cocoa/i_system.mm
+++ b/src/posix/cocoa/i_system.mm
@@ -77,7 +77,12 @@ void I_WaitVBL(const int count)
 {
     // I_WaitVBL is never used to actually synchronize to the
     // vertical blank. Instead, it's used for delay purposes.
-    usleep(1000000 * count / 70);
+    struct timespec delay, rem;
+    delay.tv_sec = count / 70;
+    /* Avoid overflow. Microsec res should be good enough. */
+    delay.tv_nsec = (count%70)*1000000/70 * 1000;
+    while(nanosleep(&delay, &rem) == -1 && errno == EINTR)
+        delay = rem;
 }
 
 


### PR DESCRIPTION
I'm unable to test this, but I don't see why it shouldn't work.