### PR TITLE
SDLGLFB: Implement mouse coordinate scaling for the menus.

### DIFF
--- a/src/posix/sdl/sdlglvideo.cpp
+++ b/src/posix/sdl/sdlglvideo.cpp
@@ -555,3 +555,38 @@ int SDLGLFB::GetClientHeight()
 	SDL_GL_GetDrawableSize(Screen, nullptr, &height);
 	return height;
 }
+
+void SDLGLFB::ScaleCoordsFromWindow(int16_t &x, int16_t &y)
+{
+	int w, h;
+	SDL_GetWindowSize (Screen, &w, &h);
+
+	// Detect if we're doing scaling in the Window and adjust the mouse
+	// coordinates accordingly. This could be more efficent, but I
+	// don't think performance is an issue in the menus.
+	if(IsFullscreen())
+	{
+		int realw = w, realh = h;
+		ScaleWithAspect (realw, realh, SCREENWIDTH, SCREENHEIGHT);
+		if (realw != SCREENWIDTH || realh != SCREENHEIGHT)
+		{
+			double xratio = (double)SCREENWIDTH/realw;
+			double yratio = (double)SCREENHEIGHT/realh;
+			if (realw < w)
+			{
+				x = (x - (w - realw)/2)*xratio;
+				y *= yratio;
+			}
+			else
+			{
+				y = (y - (h - realh)/2)*yratio;
+				x *= xratio;
+			}
+		}
+	}
+	else
+	{
+		x = (int16_t)(x*Width/w);
+		y = (int16_t)(y*Height/h);
+	}
+}

--- a/src/posix/sdl/sdlglvideo.h
+++ b/src/posix/sdl/sdlglvideo.h
@@ -72,6 +72,8 @@ public:
 	int GetClientWidth();
 	int GetClientHeight();
 
+	virtual void ScaleCoordsFromWindow(int16_t &x, int16_t &y);
+
 	SDL_Window *GetSDLWindow() override { return Screen; }
 
 protected:

--- a/src/posix/sdl/sdlvideo.cpp
+++ b/src/posix/sdl/sdlvideo.cpp
@@ -112,31 +112,6 @@ static cycle_t SDLFlipCycles;
 
 // CODE --------------------------------------------------------------------
 
-void ScaleWithAspect (int &w, int &h, int Width, int Height)
-{
-	int resRatio = CheckRatio (Width, Height);
-	int screenRatio;
-	CheckRatio (w, h, &screenRatio);
-	if (resRatio == screenRatio)
-		return;
-
-	double yratio;
-	switch(resRatio)
-	{
-		case 0: yratio = 4./3.; break;
-		case 1: yratio = 16./9.; break;
-		case 2: yratio = 16./10.; break;
-		case 3: yratio = 17./10.; break;
-		case 4: yratio = 5./4.; break;
-		default: return;
-	}
-	double y = w/yratio;
-	if (y > h)
-		w = h*yratio;
-	else
-		h = y;
-}
-
 // FrameBuffer implementation -----------------------------------------------
 
 SDLFB::SDLFB (int width, int height, bool bgra, bool fullscreen, SDL_Window *oldwin)

--- a/src/sound/music_midi_base.cpp
+++ b/src/sound/music_midi_base.cpp
@@ -51,9 +51,9 @@ static uint32_t	nummididevices;
 static bool		nummididevicesset;
 
 #ifdef HAVE_FLUIDSYNTH
-#define NUM_DEF_DEVICES 6
-#else
 #define NUM_DEF_DEVICES 5
+#else
+#define NUM_DEF_DEVICES 4
 #endif
 
 static void AddDefaultMidiDevices(FOptionValues *opt)
@@ -75,8 +75,6 @@ static void AddDefaultMidiDevices(FOptionValues *opt)
 	pair[p+2].Value = -2.0;
 	pair[p+3].Text = "WildMidi";
 	pair[p+3].Value = -6.0;
-	pair[p+4].Text = "Sound System";
-	pair[p+4].Value = -1.0;
 
 }
 

--- a/src/v_video.cpp
+++ b/src/v_video.cpp
@@ -1747,6 +1747,32 @@ bool AspectTallerThanWide(float aspect)
 	return aspect < 1.333f;
 }
 
+void ScaleWithAspect (int &w, int &h, int Width, int Height)
+{
+	int resRatio = CheckRatio (Width, Height);
+	int screenRatio;
+	CheckRatio (w, h, &screenRatio);
+	if (resRatio == screenRatio)
+		return;
+
+	double yratio;
+	switch(resRatio)
+	{
+		case 0: yratio = 4./3.; break;
+		case 1: yratio = 16./9.; break;
+		case 2: yratio = 16./10.; break;
+		case 3: yratio = 17./10.; break;
+		case 4: yratio = 5./4.; break;
+		case 6: yratio = 21./9.; break;
+		default: return;
+	}
+	double y = w/yratio;
+	if (y > h)
+		w = h*yratio;
+	else
+		h = y;
+}
+
 void IVideo::DumpAdapters ()
 {
 	Printf("Multi-monitor support unavailable.\n");

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -565,6 +565,8 @@ int AspectBaseHeight(float aspect);
 double AspectPspriteOffset(float aspect);
 int AspectMultiplier(float aspect);
 bool AspectTallerThanWide(float aspect);
+void ScaleWithAspect(int &w, int &h, int Width, int Height);
+
 int GetUIScale(int altval);
 
 EXTERN_CVAR(Int, uiscale);


### PR DESCRIPTION
Commit d1857f9 implements (well, copies from SDLFB) ScaleCoordsFromWindow() for SDLGLFB. This is needed in fullscreen mode if the rendering resolution does not match the desktop resolution. For example, my desktop resolution is 1280x800, but I play GZDoom at 640x400. Without ScaleCoordsFromWindow(), the menus think that the mouse is in the bottom right when it is actually in the middle of the screen. (And things get even weirder when you're forcing an aspect ratio that doesn't match your screen's aspect ratio.)

Since the implementation of ScaleCoordsFromWindow() for SDLGLFB is identical to the one for SDLFB, it might make sense to implement it at a higher level instead, e.g. in SDLBaseFB. However, since there are more methods that already have an identical implementation in SDLFB and SDLGLFB (for example IsFullscreen()), I decided against this for now.

Because ScaleWithAspect() is now needed by both SDLGL and SDLGLFB, and because it is a pure function, I have moved it to v_video.h/cpp. I've also added a missing case (6, to be consisten with CheckRatio()).

Commit 9e44af2 fixes cycling the "midi devices" menu option to the right, which was broken in commit ba37f09.