### PR TITLE
EffectTics Fix

### DIFF
--- a/wadsrc/static/zscript/inventory/powerups.txt
+++ b/wadsrc/static/zscript/inventory/powerups.txt
@@ -93,7 +93,7 @@ class Powerup : Inventory
 		{
 			Destroy ();
 		}
-		if (EffectTics > 0 && --EffectTics == 0)
+		if (EffectTics == 0 || (EffectTics > 0 && --EffectTics == 0))
 		{
 			Destroy ();
 		}


### PR DESCRIPTION
- Fixed: Powerups failed to expire when the EffectTics was set directly to 0 since the variable is always subtracted first before the check.