### PR TITLE
PowerBuddha Cheat Interference Fix

### DIFF
--- a/src/d_player.h
+++ b/src/d_player.h
@@ -211,6 +211,7 @@ typedef enum
 	CF_BUDDHA2			= 1 << 24,		// [MC] Absolute buddha. No voodoo can kill it either.
 	CF_GODMODE2			= 1 << 25,		// [MC] Absolute godmode. No voodoo can kill it either.
 	CF_BUDDHA			= 1 << 27,		// [SP] Buddha mode - take damage, but don't die
+	CF_POWERBUDDHA		= 1 << 28,		// [MC] Powerup version of Buddha to prevent interference with actual cheat.
 	CF_NOCLIP2			= 1 << 30,		// [RH] More Quake-like noclip
 } cheat_t;
 

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -1360,7 +1360,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 			// but telefragging should still do enough damage to kill the player)
 			// Ignore players that are already dead.
 			// [MC]Buddha2 absorbs telefrag damage, and anything else thrown their way.
-			if (!(flags & DMG_FORCED) && (((player->cheats & CF_BUDDHA2) || (((player->cheats & CF_BUDDHA) || (player->mo->flags7 & MF7_BUDDHA)) && !telefragDamage)) && (player->playerstate != PST_DEAD)))
+			if (!(flags & DMG_FORCED) && (((player->cheats & CF_BUDDHA2) || (((player->cheats & CF_BUDDHA|CF_POWERBUDDHA) || (player->mo->flags7 & MF7_BUDDHA)) && !telefragDamage)) && (player->playerstate != PST_DEAD)))
 			{
 				// If this is a voodoo doll we need to handle the real player as well.
 				player->mo->health = target->health = player->health = 1;
@@ -1896,7 +1896,7 @@ void P_PoisonDamage (player_t *player, AActor *source, int damage, bool playPain
 	target->health -= damage;
 	if (target->health <= 0)
 	{ // Death
-		if ((((player->cheats & CF_BUDDHA) || (player->mo->flags7 & MF7_BUDDHA)) && damage < TELEFRAG_DAMAGE) || (player->cheats & CF_BUDDHA2))
+		if ((((player->cheats & CF_BUDDHA|CF_POWERBUDDHA) || (player->mo->flags7 & MF7_BUDDHA)) && damage < TELEFRAG_DAMAGE) || (player->cheats & CF_BUDDHA2))
 		{ // [SP] Save the player... 
 			player->health = target->health = 1;
 		}

--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -2977,7 +2977,7 @@ FUNC(LS_SetPlayerProperty)
 	switch (arg2)
 	{
 	case PROP_BUDDHA:
-		mask = CF_BUDDHA;
+		mask = CF_POWERBUDDHA;
 		break;
 	case PROP_FROZEN:
 		mask = CF_FROZEN;

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -2105,7 +2105,7 @@ void P_FallingDamage (AActor *actor)
 		}
 		if (vel >= 63)
 		{ // automatic death
-			damage = 1000000;
+			damage = TELEFRAG_DAMAGE;
 		}
 		else
 		{
@@ -2126,7 +2126,7 @@ void P_FallingDamage (AActor *actor)
 		}
 		if (vel >= 84)
 		{ // automatic death
-			damage = 1000000;
+			damage = TELEFRAG_DAMAGE;
 		}
 		else
 		{
@@ -2156,7 +2156,7 @@ void P_FallingDamage (AActor *actor)
 	{
 		S_Sound (actor, CHAN_AUTO, "*land", 1, ATTN_NORM);
 		P_NoiseAlert (actor, actor, true);
-		if (damage == 1000000 && (actor->player->cheats & (CF_GODMODE | CF_BUDDHA)))
+		if (damage >= TELEFRAG_DAMAGE && (actor->player->cheats & (CF_GODMODE | CF_BUDDHA | CF_POWERBUDDHA )))
 		{
 			damage = 999;
 		}

--- a/wadsrc/static/zscript/constants.txt
+++ b/wadsrc/static/zscript/constants.txt
@@ -1114,6 +1114,7 @@ enum EPlayerCheats
 	CF_BUDDHA2			= 1 << 24,		// [MC] Absolute buddha. No voodoo can kill it either.
 	CF_GODMODE2			= 1 << 25,		// [MC] Absolute godmode. No voodoo can kill it either.
 	CF_BUDDHA			= 1 << 27,		// [SP] Buddha mode - take damage, but don't die
+	CF_POWERBUDDHA		= 1 << 28,		// [MC] Powerup version of Buddha to prevent interference with actual cheat.
 	CF_NOCLIP2			= 1 << 30,		// [RH] More Quake-like noclip
 
 	// These flags no longer exist, but keep the names for some stray mod that might have used them. 

--- a/wadsrc/static/zscript/inventory/powerups.txt
+++ b/wadsrc/static/zscript/inventory/powerups.txt
@@ -1458,7 +1458,7 @@ class PowerBuddha : Powerup
 		if (Owner== null || Owner.player == null)
 			return;
 
-		Owner.player.cheats |= CF_BUDDHA;
+		Owner.player.cheats |= CF_POWERBUDDHA;
 	}
 
 	override void EndEffect ()
@@ -1468,7 +1468,7 @@ class PowerBuddha : Powerup
 		if (Owner== null || Owner.player == null)
 			return;
 
-		Owner.player.cheats &= ~CF_BUDDHA;
+		Owner.player.cheats &= ~CF_POWERBUDDHA;
 	}
 }
 


### PR DESCRIPTION
- Added a separate cheat flag to handle buddha powerups. Currently, Buddha powerups could interfere and disable the actual player cheat unintentionally, when the player may not want their actual cheat to be turned off.

- Set some overlooked 1000000 damage points to TELEFRAG_DAMAGE inside the falling damage code.