### PR TITLE
Fix A_CheckProximity setting pointer to dead things when it shouldn't.

### DIFF
--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -756,6 +756,16 @@ int P_Thing_CheckProximity(AActor *self, PClass *classname, double distance, int
 			if ((flags & CPXF_CHECKSIGHT) && !(P_CheckSight(mo, ref, SF_IGNOREVISIBILITY | SF_IGNOREWATERBOUNDARY)))
 				continue;
 
+			if (mo->flags6 & MF6_KILLED)
+			{
+				if (!(flags & (CPXF_COUNTDEAD | CPXF_DEADONLY)))
+					continue;
+			}
+			else
+			{
+				if (flags & CPXF_DEADONLY)
+					continue;
+			}
 			if (ptrWillChange)
 			{
 				current = ref->Distance2D(mo);
@@ -772,16 +782,6 @@ int P_Thing_CheckProximity(AActor *self, PClass *classname, double distance, int
 				}
 				else if (!dist)
 					dist = mo; // Just get the first one and call it quits if there's nothing selected.
-			}
-			if (mo->flags6 & MF6_KILLED)
-			{
-				if (!(flags & (CPXF_COUNTDEAD | CPXF_DEADONLY)))
-					continue;
-			}
-			else
-			{
-				if (flags & CPXF_DEADONLY)
-					continue;
 			}
 			counter++;
 


### PR DESCRIPTION
When using A_CheckProximity with CPXF_SETTARGET, the target pointer could
be set to a dead monster even without the CPXF_COUNTDEAD and CPXF_DEADONLY
flags. This is becuase the check for death would occur after setting the
pointer.

Fix simply moves death check to occur before setting pointers.