### PR TITLE
Menu: Fix mouse handling for the autoaim slider.

### DIFF
--- a/wadsrc/static/zscript/menu/playercontrols.txt
+++ b/wadsrc/static/zscript/menu/playercontrols.txt
@@ -363,6 +363,7 @@ class ListMenuItemSlider : ListMenuItemSelectable
 	int mMinrange, mMaxrange;
 	int mStep;
 	int mSelection;
+	int mDrawX;
 
 	//=============================================================================
 	//
@@ -380,6 +381,7 @@ class ListMenuItemSlider : ListMenuItemSelectable
 		mMinrange = min;
 		mMaxrange = max;
 		mStep = step;
+		mDrawX = 0;
 	}
 
 	//=============================================================================
@@ -398,6 +400,7 @@ class ListMenuItemSlider : ListMenuItemSelectable
 		mMinrange = min;
 		mMaxrange = max;
 		mStep = step;
+		mDrawX = 0;
 	}
 
 	//=============================================================================
@@ -466,8 +469,8 @@ class ListMenuItemSlider : ListMenuItemSelectable
 			lm.ReleaseFocus();
 		}
 
-		int slide_left = SmallFont.StringWidth ("Green") + 8 + int(mXpos);
-		int slide_right = slide_left + 12*8;	// 12 char cells with 8 pixels each.
+		int slide_left = mDrawX + 8;
+		int slide_right = slide_left + 10*8;	// 12 char cells with 8 pixels each.
 
 		if (type == Menu.MOUSE_Click)
 		{
@@ -520,6 +523,8 @@ class ListMenuItemSlider : ListMenuItemSelectable
 
 		double x = SmallFont.StringWidth ("Green") + 8 + mXpos;
 		double x2 = SmallFont.StringWidth (text) + 8 + mXpos;
-		DrawSlider (MAX(x2, x), mYpos);
+		mDrawX = MAX(x2, x);
+
+		DrawSlider (mDrawX, mYpos);
 	}
 }


### PR DESCRIPTION
The drawing method and mouse event handling method of the autoaim slider were inconsistent in how they calculated the x coordinate and range of the autoaim slider, leading to strange behaviour. This commit brings the behaviour of the autoaim slider in line with the OptionMenuSliderBase class from optionmenuitems.txt.