### PR TITLE
Some menu hotkey fixes

### DIFF
--- a/wadsrc/static/zscript/menu/listmenu.txt
+++ b/wadsrc/static/zscript/menu/listmenu.txt
@@ -114,7 +114,7 @@ class ListMenu : Menu
 
 			for(int i = mDesc.mSelectedItem + 1; i < mDesc.mItems.Size(); i++)
 			{
-				if (mDesc.mItems[i].CheckHotkey(ch))
+				if (mDesc.mitems[i].Selectable() && mDesc.mItems[i].CheckHotkey(ch))
 				{
 					mDesc.mSelectedItem = i;
 					MenuSound("menu/cursor");
@@ -123,7 +123,7 @@ class ListMenu : Menu
 			}
 			for(int i = 0; i < mDesc.mSelectedItem; i++)
 			{
-				if (mDesc.mItems[i].CheckHotkey(ch))
+				if (mDesc.mitems[i].Selectable() && mDesc.mItems[i].CheckHotkey(ch))
 				{
 					mDesc.mSelectedItem = i;
 					MenuSound("menu/cursor");

--- a/wadsrc/static/zscript/menu/listmenu.txt
+++ b/wadsrc/static/zscript/menu/listmenu.txt
@@ -106,11 +106,11 @@ class ListMenu : Menu
 
 	override bool OnUIEvent(UIEvent ev)
 	{
-		if (ev.Type == UIEvent.Type_KeyDown)
+		if (ev.Type == UIEvent.Type_KeyDown && ev.KeyChar > 0)
 		{
 			// tolower
 			int ch = ev.KeyChar;
-			ch = ch >= 65 && ch <91? ch + 32 : ch;
+			ch = ch >= 65 && ch < 91 ? ch + 32 : ch;
 
 			for(int i = mDesc.mSelectedItem + 1; i < mDesc.mItems.Size(); i++)
 			{

--- a/wadsrc/static/zscript/menu/listmenuitems.txt
+++ b/wadsrc/static/zscript/menu/listmenuitems.txt
@@ -199,7 +199,7 @@ class ListMenuItemSelectable : ListMenuItem
 
 	override bool CheckHotkey(int c)
 	{ 
-		return c == mHotkey; 
+		return c > 0 && c == mHotkey;
 	}
 	
 	override bool Activate()


### PR DESCRIPTION
I noticed in the player menu that pressing shift results in some unwanted behaviour:

- It selects the next item. This happens because "shift" results in an ev.KeyChar of 0, which was being treated like an actual hotkey, and thus matching any item without a hotkey set.
- It selects unselectable items. This happens because the "which items should this hotkey select?" loops didn't check if a matching item is actually selectable.

These commits fix both issues.