### PR TITLE
vid_glswfb: Prevent defunct windows.

### DIFF
--- a/src/posix/sdl/sdlglvideo.cpp
+++ b/src/posix/sdl/sdlglvideo.cpp
@@ -255,7 +255,10 @@ DFrameBuffer *SDLGLVideo::CreateFrameBuffer (int width, int height, bool bgra, b
 	{
 		fb = (SDLBaseFB*)CreateGLSWFrameBuffer(width, height, bgra, fullscreen);
 		if (!fb->IsValid())
+		{
+			delete fb;
 			fb = new SDLFB(width, height, bgra, fullscreen, nullptr);
+		}
 	}
 
 	retry = 0;


### PR DESCRIPTION
When starting gzdoom with vid_renderer=0 and vid_glswfb=1 in windowed mode on a Linux system without OpenGL 3.0 support, gzdoom rapidly creates 3 separate windows, of which 2 end up in some defunct state, while only the 3rd is being rendered to.

I'm not entirely sure why, but explicitly 'delete'ing the fb before recreating it with SDLFB fixes this; gzdoom still rapidly creates three windows, but now each window is destroyed before the next one is created, so that only one window remains.