### PR TITLE
OPLsynth: Default to center panning.

### DIFF
--- a/src/sound/oplsynth/musicblock.cpp
+++ b/src/sound/oplsynth/musicblock.cpp
@@ -36,6 +36,7 @@
 musicBlock::musicBlock ()
 {
 	memset (this, 0, sizeof(*this));
+	for(auto &oplchannel : oplchannels) oplchannel.Panning = 64;	// default to center panning.
 	for(auto &voice : voices) voice.index = ~0u;	// mark all free.
 }
 


### PR DESCRIPTION
Some music tracks, for example the title track of Freedoom 0.11.2, lack panning information. Since `musicBlock()` memsets all its members to 0, which for the `Panning` field of `OPLChannel` means "full left",  this has the effect of playing such tracks on the left speaker only, which is annoying and unexpected (other source ports don't do this either).

This commit defaults the `Panning` field to 64, e.g. center panning, so that tracks without panning information play on both speakers.

Update: this of course matters only when the `opl_fullpan` cvar is set to true.
