### PR TITLE
Fix compilation with GCC 7.1.0

### DIFF
--- a/src/sound/oalsound.cpp
+++ b/src/sound/oalsound.cpp
@@ -39,6 +39,7 @@
 #include <dlfcn.h>
 #endif
 
+#include <functional>
 #include <memory>
 #include <chrono>
 


### PR DESCRIPTION
I've found this to be needed to build on Linux+OpenAl with GCC 7.1.0.

mem_fn is defined in "functional". Without this change, I get "mem_fn is not a member of std".

Reference:

https://stackoverflow.com/a/24580500