### PR TITLE
PSPF_MIRROR Overlay Flag

### DIFF
--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -107,14 +107,6 @@ void GLSceneDrawer::DrawPSprite (player_t * player,DPSprite *psp, float sx, floa
 	x2 = tx * scalex + vw / 2;
 	if (x2 < 0) return; // off the left side
 	x2 += viewwindowx;
-	/*
-	if (psp->Flags & PSPF_MIRROR)
-	{
-		float dist = 320.f - sx;
-		x1 += dist * scalex;
-		x2 += dist * scalex;
-	}*/
-
 
 	// killough 12/98: fix psprite positioning problem
 	ftexturemid = 100.f - sy - r.top;

--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -98,7 +98,7 @@ void GLSceneDrawer::DrawPSprite (player_t * player,DPSprite *psp, float sx, floa
 	// calculate edges of the shape
 	scalex = (320.0f / (240.0f * r_viewwindow.WidescreenRatio)) * vw / 320;
 
-	tx = sx - (160 - r.left);
+	tx = (psp->Flags & PSPF_MIRROR) ? ((160 - r.width) - (sx + r.left)) : (sx - (160 - r.left));
 	x1 = tx * scalex + vw/2;
 	if (x1 > vw)	return; // off the right side
 	x1 += viewwindowx;
@@ -107,6 +107,13 @@ void GLSceneDrawer::DrawPSprite (player_t * player,DPSprite *psp, float sx, floa
 	x2 = tx * scalex + vw / 2;
 	if (x2 < 0) return; // off the left side
 	x2 += viewwindowx;
+	/*
+	if (psp->Flags & PSPF_MIRROR)
+	{
+		float dist = 320.f - sx;
+		x1 += dist * scalex;
+		x2 += dist * scalex;
+	}*/
 
 
 	// killough 12/98: fix psprite positioning problem
@@ -130,7 +137,8 @@ void GLSceneDrawer::DrawPSprite (player_t * player,DPSprite *psp, float sx, floa
 	y1 = viewwindowy + vh / 2 - (ftexturemid * scale);
 	y2 = y1 + (r.height * scale) + 1;
 
-	if (!(mirror) != !(psp->Flags & PSPF_FLIP))
+
+	if (!(mirror) != !(psp->Flags & (PSPF_FLIP|PSPF_MIRROR)))
 	{
 		fU2 = tex->GetSpriteUL();
 		fV1 = tex->GetSpriteVT();

--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -138,7 +138,7 @@ void GLSceneDrawer::DrawPSprite (player_t * player,DPSprite *psp, float sx, floa
 	y2 = y1 + (r.height * scale) + 1;
 
 
-	if (!(mirror) != !(psp->Flags & (PSPF_FLIP|PSPF_MIRROR)))
+	if (!(mirror) != !(psp->Flags & (PSPF_FLIP)))
 	{
 		fU2 = tex->GetSpriteUL();
 		fV1 = tex->GetSpriteVT();

--- a/src/gl/scene/gl_weapon.cpp
+++ b/src/gl/scene/gl_weapon.cpp
@@ -437,7 +437,7 @@ void GLSceneDrawer::DrawPlayerSprites(sector_t * viewsector, bool hudModelStep)
 
 			if (psp->Flags & PSPF_ADDBOB)
 			{
-				sx += bobx;
+				sx += (psp->Flags & PSPF_MIRROR) ? -bobx : bobx;
 				sy += boby;
 			}
 

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -141,6 +141,7 @@ DEFINE_FIELD_BIT(DPSprite, Flags, bAddBob, PSPF_ADDBOB)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPowDouble, PSPF_POWDOUBLE)
 DEFINE_FIELD_BIT(DPSprite, Flags, bCVarFast, PSPF_CVARFAST)
 DEFINE_FIELD_BIT(DPSprite, Flags, bFlip, PSPF_FLIP)
+DEFINE_FIELD_BIT(DPSprite, Flags, bMirror, PSPF_MIRROR)
 
 //------------------------------------------------------------------------
 //

--- a/src/p_pspr.h
+++ b/src/p_pspr.h
@@ -68,6 +68,7 @@ enum PSPFlags
 	PSPF_FLIP			= 1 << 6,
 	PSPF_FORCEALPHA		= 1 << 7,
 	PSPF_FORCESTYLE		= 1 << 8,
+	PSPF_MIRROR			= 1 << 9,
 };
 
 class DPSprite : public DObject

--- a/src/polyrenderer/scene/poly_playersprite.cpp
+++ b/src/polyrenderer/scene/poly_playersprite.cpp
@@ -232,7 +232,7 @@ void RenderPolyPlayerSprites::RenderSprite(DPSprite *pspr, AActor *owner, float 
 
 	if (pspr->Flags & PSPF_ADDBOB)
 	{
-		sx += bobx;
+		sx += (pspr->Flags & PSPF_MIRROR) ? -bobx : bobx;
 		sy += boby;
 	}
 
@@ -248,17 +248,20 @@ void RenderPolyPlayerSprites::RenderSprite(DPSprite *pspr, AActor *owner, float 
 	double pspriteyscale = pspritexscale * yaspectMul;
 	double pspritexiscale = 1 / pspritexscale;
 
-	// calculate edges of the shape
-	tx = sx - BASEXCENTER;
+	int tleft = tex->GetScaledLeftOffset();
+	int twidth = tex->GetScaledWidth();
 
-	tx -= tex->GetScaledLeftOffset();
+	// calculate edges of the shape
+	//tx = sx - BASEXCENTER;
+	tx = (pspr->Flags & PSPF_MIRROR) ? ((BASEXCENTER - twidth) - (sx - tleft)) : ((sx - BASEXCENTER) - tleft);
+
 	x1 = xs_RoundToInt(viewwindow.centerx + tx * pspritexscale);
 
 	// off the right side
 	if (x1 > viewwidth)
 		return;
 
-	tx += tex->GetScaledWidth();
+	tx += twidth;
 	x2 = xs_RoundToInt(viewwindow.centerx + tx * pspritexscale);
 
 	// off the left side

--- a/src/swrenderer/things/r_playersprite.cpp
+++ b/src/swrenderer/things/r_playersprite.cpp
@@ -240,7 +240,7 @@ namespace swrenderer
 
 		if (pspr->Flags & PSPF_ADDBOB)
 		{
-			sx += bobx;
+			sx += (pspr->Flags & PSPF_MIRROR) ? -bobx : bobx;
 			sy += boby;
 		}
 
@@ -256,17 +256,18 @@ namespace swrenderer
 		double pspriteyscale = pspritexscale * viewport->YaspectMul;
 		double pspritexiscale = 1 / pspritexscale;
 
-		// calculate edges of the shape
-		tx = sx - BASEXCENTER;
+		int tleft = tex->GetScaledLeftOffset();
+		int twidth = tex->GetScaledWidth();
 
-		tx -= tex->GetScaledLeftOffset();
+		// calculate edges of the shape
+		tx = (pspr->Flags & PSPF_MIRROR) ? ((BASEXCENTER - twidth) - (sx - tleft)) : ((sx - BASEXCENTER) - tleft);
 		x1 = xs_RoundToInt(viewport->CenterX + tx * pspritexscale);
 
 		// off the right side
 		if (x1 > viewwidth)
 			return;
 
-		tx += tex->GetScaledWidth();
+		tx += twidth;
 		x2 = xs_RoundToInt(viewport->CenterX + tx * pspritexscale);
 
 		// off the left side

--- a/wadsrc/static/zscript/constants.txt
+++ b/wadsrc/static/zscript/constants.txt
@@ -726,6 +726,7 @@ enum EPSpriteFlags
 	PSPF_FLIP		= 1 << 6,
 	PSPF_FORCEALPHA	= 1 << 7,
 	PSPF_FORCESTYLE	= 1 << 8,
+	PSPF_MIRROR		= 1 << 9,
 };
 
 // Default psprite layers


### PR DESCRIPTION
- Flips the sprite's drawing and position over entirely on the X axis. Automatically implies PSPF_FLIP.