### PR TITLE
- Added numerous compatibility fixes for Doom2: Maps 02 to 11. These …

### DIFF
--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -484,6 +484,63 @@ F6EE16F770AD309D608EA0B1F1E249FC // Ultimate Doom, e4m3
 	setsectorspecial 263 0
 	setsectorspecial 264 0
 }
+AB24AE6E2CB13CBDD04600A4D37F9189 // doom2.wad map02
+1EC0AF1E3985650F0C9000319C599D0C // doom2bfg.wad map02
+{
+	// missing textures
+	setwalltexture 327 front bot STONE4
+	setwalltexture 328 front bot STONE4
+	setwalltexture 338 front bot STONE4
+	setwalltexture 339 front bot STONE4
+}
+5E8679670469F92E15CF4219B5B98FEF // doom2.wad map03
+{
+	// unmarked secret
+	setsectorspecial 62 1024
+}
+CEC791136A83EEC4B91D39718BDF9D82 // doom2.wad map04
+{
+	// missing textures
+	setwalltexture 456 back top SUPPORT3
+	setwalltexture 108 front top STONE
+	setwalltexture 109 front top STONE
+	setwalltexture 110 front top STONE
+	setwalltexture 111 front top STONE
+	setwalltexture 127 front top STONE
+	setwalltexture 128 front top STONE
+	// remove erronious blue keycard pickup ambush sector tags (nearby viewing windows, and the lights)
+	setsectortag 19 0
+	setsectortag 20 0
+	setsectortag 23 0
+	setsectortag 28 0
+	setsectortag 33 0
+	setsectortag 34 0
+	setsectortag 83 0
+	setsectortag 85 0
+}
+9E061AD7FBCD7FAD968C976CB4AA3B9D // doom2.wad map05
+{
+	// fix bug with opening westmost door in door hallway - incorrect sector tagging - see doomwiki.org for more info
+	setsectortag 4 0
+	setsectortag 153 0
+}
+66C46385EB1A23D60839D1532522076B // doom2.wad map08
+{
+	setwalltexture 101 back top BRICK7
+}
+6C620F43705BEC0ABBABBF46AC3E62D2 // doom2.wad map10
+{
+	// unmarked secrets
+	setsectorspecial 25 1090
+	setsectorspecial 137 1024
+	setsectorspecial 176 1024
+}
+73D9E03CEE7BF1A97EFD2EAD86688EF8 // doom2.wad map11
+{
+	// unmarked secrets
+	setsectorspecial 94 1024
+	setsectorspecial 138 1024	
+}
 1A540BA717BF9EC85F8522594C352F2A // Doom II, map15
 {
 	setsectorspecial 147 0

--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -508,7 +508,7 @@ CEC791136A83EEC4B91D39718BDF9D82 // doom2.wad map04
 	setwalltexture 111 front top STONE
 	setwalltexture 127 front top STONE
 	setwalltexture 128 front top STONE
-	// remove erronious blue keycard pickup ambush sector tags (nearby viewing windows, and the lights)
+	// remove erroneous blue keycard pickup ambush sector tags (nearby viewing windows, and the lights)
 	setsectortag 19 0
 	setsectortag 20 0
 	setsectortag 23 0


### PR DESCRIPTION
…fixes mark previously unmarked secrets, and texture fixes in several locations that had HOMs.