### PR TITLE
Fixed broken Interleaved 3D output when GL Sampler objects are used

### DIFF
--- a/src/gl/stereo3d/gl_interleaved3d.cpp
+++ b/src/gl/stereo3d/gl_interleaved3d.cpp
@@ -37,6 +37,7 @@
 #include "gl/renderer/gl_renderer.h"
 #include "gl/renderer/gl_renderbuffers.h"
 #include "gl/renderer/gl_renderer.h"
+#include "gl/renderer/gl_postprocessstate.h"
 #include "gl/system/gl_framebuffer.h"
 #include "gl/shaders/gl_present3dRowshader.h"
 
@@ -122,6 +123,8 @@ static void prepareInterleavedPresent(FPresentStereoShaderBase& shader)
 
 void CheckerInterleaved3D::Present() const
 {
+	FGLPostProcessState savedState;
+	savedState.SaveTextureBindings(2);
 	prepareInterleavedPresent(*GLRenderer->mPresent3dCheckerShader);
 
 	// Compute absolute offset from top of screen to top of current display window
@@ -165,6 +168,8 @@ void s3d::CheckerInterleaved3D::AdjustViewports() const
 
 void ColumnInterleaved3D::Present() const
 {
+	FGLPostProcessState savedState;
+	savedState.SaveTextureBindings(2);
 	prepareInterleavedPresent(*GLRenderer->mPresent3dColumnShader);
 
 	// Compute absolute offset from top of screen to top of current display window
@@ -185,6 +190,8 @@ void ColumnInterleaved3D::Present() const
 
 void RowInterleaved3D::Present() const
 {
+	FGLPostProcessState savedState;
+	savedState.SaveTextureBindings(2);
 	prepareInterleavedPresent(*GLRenderer->mPresent3dRowShader);
 
 	// Compute absolute offset from top of screen to top of current display window


### PR DESCRIPTION
Within current master Interleaved 3D output does not work (the Right view is black).
The patch fixes this problem.

Incorrect image:
![gzdoom_row_interleaved_ko](https://cloud.githubusercontent.com/assets/851453/26713073/4cb011f8-4773-11e7-9f6d-32b4018d31c7.png)
Correct image:
![gzdoom_row_interleaved_ok](https://cloud.githubusercontent.com/assets/851453/26713078/5360e9a0-4773-11e7-9769-8f5e684e99b3.png)
