### PR TITLE
Fix setting of the gl_legacy_mode cvar.

### DIFF
--- a/src/gl/system/gl_interface.cpp
+++ b/src/gl/system/gl_interface.cpp
@@ -324,7 +324,10 @@ void gl_LoadExtensions()
 		FUDGE_FUNC(glBindRenderbuffer, EXT);
 		FUDGE_FUNC(glCheckFramebufferStatus, EXT);
 	}
-	gl_legacy_mode = gl.legacyMode;
+
+	UCVarValue value;
+	value.Bool = gl.legacyMode;
+	gl_legacy_mode.ForceSet (value, CVAR_Bool);
 }
 
 //==========================================================================

--- a/src/gl/system/gl_swframebuffer.cpp
+++ b/src/gl/system/gl_swframebuffer.cpp
@@ -207,12 +207,15 @@ OpenGLSWFrameBuffer::OpenGLSWFrameBuffer(void *hMonitor, int width, int height, 
 	const char *glversion = (const char*)glGetString(GL_VERSION);
 	bool isGLES = (glversion && strlen(glversion) > 10 && memcmp(glversion, "OpenGL ES ", 10) == 0);
 
+	UCVarValue value;
 	// GL 3.0 is mostly broken on MESA drivers which really are the only relevant case here that doesn't fulfill the requirements based on version number alone.
 #ifdef _WIN32
-	gl_legacy_mode = !ogl_IsVersionGEQ(3, 0);
+	value.Bool = !ogl_IsVersionGEQ(3, 0);
 #else
-	gl_legacy_mode = !ogl_IsVersionGEQ(3, 1);
+	value.Bool = !ogl_IsVersionGEQ(3, 1);
 #endif
+	gl_legacy_mode.ForceSet (value, CVAR_Bool);
+
 	if (!isGLES && ogl_IsVersionGEQ(3, 0) == 0)
 	{
 		Printf("OpenGL acceleration requires at least OpenGL 3.0. No Acceleration will be used.\n");


### PR DESCRIPTION
Since the gl_legacy_mode cvar is a NOSET cvar, simply assigning it didn't have the intended effect, resulting in it always being set to false. Setting it through ForceSet fixes this.

Note that the same issue may apply to the osx_additional_parameters cvar from posix/osx/iwadpicker_cocoa.mm, but I left that alone because I have no means of testing/verifying that.