### PR TITLE
Vel3DFromAngle Fix

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -8137,7 +8137,7 @@ DEFINE_ACTION_FUNCTION(AActor, Vel3DFromAngle)
 	PARAM_FLOAT(speed);
 	PARAM_ANGLE(angle);
 	PARAM_ANGLE(pitch);
-	self->Vel3DFromAngle(pitch, angle, speed);
+	self->Vel3DFromAngle(angle, pitch, speed);
 	return 0;
 }
 


### PR DESCRIPTION
- Fixed: Vel3DFromAngle's internal function call had the pitch and angle parameters backwards:

void Vel3DFromAngle(DAngle angle, DAngle pitch, double speed)