### PR TITLE
OpenVR Virtual Reality mode, take 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,8 +300,6 @@ endif()
 
 set( LZMA_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lzma/C" )
 
-option( GZDOOM_USE_OPENVR "Support OpenVR API for virtual reality head mounted displays" OFF )
-
 if( NOT CMAKE_CROSSCOMPILING )
 	if( NOT CROSS_EXPORTS )
 		set( CROSS_EXPORTS "" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,8 @@ endif()
 
 set( LZMA_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lzma/C" )
 
+option( GZDOOM_USE_OPENVR "Support OpenVR API for virtual reality head mounted displays" OFF )
+
 if( NOT CMAKE_CROSSCOMPILING )
 	if( NOT CROSS_EXPORTS )
 		set( CROSS_EXPORTS "" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -482,6 +482,9 @@ if (GZDOOM_USE_OPENVR)
 		# Incorporate the whole openvr API into zdoom, using a few rules lifted from the OpenVR CMakeLists.txt files
 		# This branch avoids the need to ship openvr_api.dll
 		add_definitions( -DVR_API_PUBLIC )
+		if(WIN32 AND X64)
+			add_definitions( -DWIN64 )
+		endif()
 		include_directories(${OPENVR_SDK_PATH}/src ${OPENVR_SDK_PATH}/src/vrcommon)
 		file(GLOB OPENVR_SOURCES "${OPENVR_SDK_PATH}/src/*.cpp" "${OPENVR_SDK_PATH}/src/vrcommon/*.cpp")
 	else() # link to shared OpenVR library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,6 +461,58 @@ if( NOT DYN_FLUIDSYNTH )
 	endif()
 endif()
 
+if (GZDOOM_USE_OPENVR)
+	find_path(OPENVR_SDK_PATH
+		NAMES
+			headers/openvr.h
+		HINTS
+			ENV OPENVR_DIR ENV PROGRAMFILES ENV HOME ENV USERPROFILE
+		PATH_SUFFIXES
+			openvr git/openvr
+	)
+	find_path(OPENVR_INCLUDE_DIRECTORY
+		NAMES
+			openvr.h
+		HINTS
+			${OPENVR_SDK_PATH}/headers
+	)
+	include_directories("${OPENVR_INCLUDE_DIRECTORY}")
+	option( GZDOOM_OPENVR_STATIC "Statically link OpenVR API" ON )
+	if(GZDOOM_OPENVR_STATIC)
+		# Incorporate the whole openvr API into zdoom, using a few rules lifted from the OpenVR CMakeLists.txt files
+		# This branch avoids the need to ship openvr_api.dll
+		add_definitions( -DVR_API_PUBLIC )
+		include_directories(${OPENVR_SDK_PATH}/src ${OPENVR_SDK_PATH}/src/vrcommon)
+		file(GLOB OPENVR_SOURCES "${OPENVR_SDK_PATH}/src/*.cpp" "${OPENVR_SDK_PATH}/src/vrcommon/*.cpp")
+	else() # link to shared OpenVR library
+		# Link to correct library for this platform
+		if(WIN32)
+			set(OPENVR_PLAT "win")
+		elseif( APPLE )
+			set(OPENVR_PLAT "osx")
+		else()
+			set(OPENVR_PLAT "linux")
+		endif()
+		if(X64)
+			set(OPENVR_PLAT ${OPENVR_PLAT}64)
+		else()
+			set(OPENVR_PLAT ${OPENVR_PLAT}32)
+		endif()
+		find_library(OPENVR_LIBRARY
+			NAMES openvr_api
+			HINTS "${OPENVR_SDK_PATH}/lib/${OPENVR_PLAT}/"
+		)
+		list(APPEND ZDOOM_LIBS ${OPENVR_LIBRARY})
+		# Find shared library file needed for package distribution
+		find_program(OPENVR_SHARED_LIBRARY
+			NAMES libopenvr_api.so libopenvr_api.dylib openvr_api.dll
+			PATHS "${OPENVR_SDK_PATH}/bin/${OPENVR_PLAT}/"
+			NO_DEFAULT_PATH
+		)
+	endif()
+	add_definitions("-DUSE_OPENVR")
+endif()
+
 # Start defining source files for ZDoom
 set( PLAT_WIN32_SOURCES
 	sound/mididevices/music_win_mididevice.cpp
@@ -994,6 +1046,7 @@ set (PCH_SOURCES
 	gl/stereo3d/gl_stereo_leftright.cpp
 	gl/stereo3d/scoped_view_shifter.cpp
 	gl/stereo3d/gl_anaglyph.cpp
+	gl/stereo3d/gl_openvr.cpp
 	gl/stereo3d/gl_quadstereo.cpp
 	gl/stereo3d/gl_sidebyside3d.cpp
 	gl/stereo3d/gl_interleaved3d.cpp
@@ -1147,6 +1200,7 @@ add_executable( zdoom WIN32 MACOSX_BUNDLE
 	${X86_SOURCES}
 	${FASTMATH_SOURCES}
 	${PCH_SOURCES}
+	${OPENVR_SOURCES}
 	x86.cpp
 	strnatcmp.c
 	zstring.cpp
@@ -1284,6 +1338,11 @@ endif()
 install(TARGETS zdoom
 		DESTINATION ${INSTALL_PATH}
 		COMPONENT "Game executable")
+if(OPENVR_SHARED_LIBRARY)
+	install(PROGRAMS ${OPENVR_SHARED_LIBRARY} 
+		DESTINATION ${INSTALL_PATH}
+		COMPONENT "Shared libraries")
+endif()
 
 source_group("Audio Files" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/sound/.+")
 source_group("Audio Files\\OPL Synth" REGULAR_EXPRESSION "^${CMAKE_CURRENT_SOURCE_DIR}/sound/oplsynth/.+")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -461,7 +461,9 @@ if( NOT DYN_FLUIDSYNTH )
 	endif()
 endif()
 
-if (GZDOOM_USE_OPENVR)
+option( ENABLE_OPENVR "Enable OpenVR virtual reality mode" OFF )
+if (ENABLE_OPENVR)
+	add_definitions("-DUSE_OPENVR")
 	find_path(OPENVR_SDK_PATH
 		NAMES
 			headers/openvr.h
@@ -477,17 +479,24 @@ if (GZDOOM_USE_OPENVR)
 			${OPENVR_SDK_PATH}/headers
 	)
 	include_directories("${OPENVR_INCLUDE_DIRECTORY}")
-	option( GZDOOM_OPENVR_STATIC "Statically link OpenVR API" ON )
-	if(GZDOOM_OPENVR_STATIC)
-		# Incorporate the whole openvr API into zdoom, using a few rules lifted from the OpenVR CMakeLists.txt files
-		# This branch avoids the need to ship openvr_api.dll
-		add_definitions( -DVR_API_PUBLIC )
-		if(WIN32 AND X64)
-			add_definitions( -DWIN64 )
+	option( DYN_OPENVR "Dynamically load OpenVR" ON )
+	if (DYN_OPENVR)
+		add_definitions( -DDYN_OPENVR )
+	else(DYN_OPENVR)
+		option( STATIC_OPENVR "Statically link OpenVR API" ON )
+		if(STATIC_OPENVR)
+			# Incorporate the whole openvr API into zdoom, using a few rules lifted from the OpenVR CMakeLists.txt files
+			# This branch avoids the need to ship openvr_api.dll
+			add_definitions( -DVR_API_PUBLIC )
+			add_definitions( -DOPENVR_API_NODLL )
+			if(WIN32 AND X64)
+				add_definitions( -DWIN64 )
+			endif()
+			include_directories(${OPENVR_SDK_PATH}/src ${OPENVR_SDK_PATH}/src/vrcommon)
+			file(GLOB OPENVR_SOURCES "${OPENVR_SDK_PATH}/src/*.cpp" "${OPENVR_SDK_PATH}/src/vrcommon/*.cpp")
 		endif()
-		include_directories(${OPENVR_SDK_PATH}/src ${OPENVR_SDK_PATH}/src/vrcommon)
-		file(GLOB OPENVR_SOURCES "${OPENVR_SDK_PATH}/src/*.cpp" "${OPENVR_SDK_PATH}/src/vrcommon/*.cpp")
-	else() # link to shared OpenVR library
+	endif()
+	if(DYN_OPENVR OR NOT STATIC_OPENVR)
 		# Link to correct library for this platform
 		if(WIN32)
 			set(OPENVR_PLAT "win")
@@ -505,15 +514,17 @@ if (GZDOOM_USE_OPENVR)
 			NAMES openvr_api
 			HINTS "${OPENVR_SDK_PATH}/lib/${OPENVR_PLAT}/"
 		)
-		list(APPEND ZDOOM_LIBS ${OPENVR_LIBRARY})
-		# Find shared library file needed for package distribution
+		# Find shared library file needed for package distribution (see install rule later in this file)
 		find_program(OPENVR_SHARED_LIBRARY
 			NAMES libopenvr_api.so libopenvr_api.dylib openvr_api.dll
 			PATHS "${OPENVR_SDK_PATH}/bin/${OPENVR_PLAT}/"
 			NO_DEFAULT_PATH
 		)
+		if(NOT DYN_OPENVR)
+			# Link directly to shared library
+			list(APPEND ZDOOM_LIBS ${OPENVR_LIBRARY})
+		endif()
 	endif()
-	add_definitions("-DUSE_OPENVR")
 endif()
 
 # Start defining source files for ZDoom

--- a/src/gl/data/gl_matrix.h
+++ b/src/gl/data/gl_matrix.h
@@ -62,7 +62,7 @@ class VSMatrix {
 		void perspective(FLOATTYPE fov, FLOATTYPE ratio, FLOATTYPE nearp, FLOATTYPE farp);
 		void ortho(FLOATTYPE left, FLOATTYPE right, FLOATTYPE bottom, FLOATTYPE top, FLOATTYPE nearp=-1.0f, FLOATTYPE farp=1.0f);
 		void frustum(FLOATTYPE left, FLOATTYPE right, FLOATTYPE bottom, FLOATTYPE top, FLOATTYPE nearp, FLOATTYPE farp);
-		void copy(FLOATTYPE * pDest)
+		void copy(FLOATTYPE * pDest) const
 		{
 			memcpy(pDest, mMatrix, 16 * sizeof(FLOATTYPE));
 		}

--- a/src/gl/renderer/gl_postprocess.cpp
+++ b/src/gl/renderer/gl_postprocess.cpp
@@ -711,6 +711,7 @@ void FGLRenderer::Flush()
 			mBuffers->BindEyeFB(eye_ix);
 			glViewport(mScreenViewport.left, mScreenViewport.top, mScreenViewport.width, mScreenViewport.height);
 			glScissor(mScreenViewport.left, mScreenViewport.top, mScreenViewport.width, mScreenViewport.height);
+			stereo3dMode.getEyePose(eye_ix)->Adjust2DMatrices();
 			m2DDrawer->Draw();
 			FGLDebug::PopGroup();
 		}

--- a/src/gl/stereo3d/LSMatrix.h
+++ b/src/gl/stereo3d/LSMatrix.h
@@ -30,9 +30,7 @@
 #include "gl/data/gl_matrix.h"
 #include "openvr.h"
 
-namespace vr {
-	HmdMatrix34_t;
-}
+struct HmdMatrix34_t;
 
 class LSVec3
 {
@@ -92,7 +90,7 @@ public:
 		loadIdentity();
 	}
 		
-	LSMatrix44(const vr::HmdMatrix34_t& m) {
+	LSMatrix44(const HmdMatrix34_t& m) {
 		loadIdentity();
 		for (int i = 0; i < 3; ++i) {
 			for (int j = 0; j < 4; ++j) {

--- a/src/gl/stereo3d/LSMatrix.h
+++ b/src/gl/stereo3d/LSMatrix.h
@@ -57,6 +57,13 @@ public:
 		return *this;
 	}
 
+	LSVec3& operator+=(const LSVec3& rhs) {
+		LSVec3& lhs = *this;
+		for (int i = 0; i < 4; ++i)
+			lhs[i] += rhs[i];
+		return *this;
+	}
+
 	const FLOATTYPE& operator[](int i) const {return mVec[i];}
 	FLOATTYPE& operator[](int i) { return mVec[i]; }
 

--- a/src/gl/stereo3d/LSMatrix.h
+++ b/src/gl/stereo3d/LSMatrix.h
@@ -1,0 +1,152 @@
+//
+//---------------------------------------------------------------------------
+//
+// Copyright(C) 2016-2017 Christopher Bruns
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+//
+//--------------------------------------------------------------------------
+//
+/*
+** LSMatrix.h
+** less-simple matrix class
+*/
+
+#ifndef VR_LS_MATRIX_H_
+#define VR_LS_MATRIX_H_
+
+#include "gl/data/gl_matrix.h"
+#include "openvr.h"
+
+namespace vr {
+	HmdMatrix34_t;
+}
+
+class LSVec3
+{
+public:
+	LSVec3(FLOATTYPE x, FLOATTYPE y, FLOATTYPE z, FLOATTYPE w=1.0f) 
+		: x(mVec[0]), y(mVec[1]), z(mVec[2]), w(mVec[3])
+	{
+		mVec[0] = x;
+		mVec[1] = y;
+		mVec[2] = z;
+		mVec[3] = w;
+	}
+
+	LSVec3(const LSVec3& rhs) 
+		: x(mVec[0]), y(mVec[1]), z(mVec[2]), w(mVec[3])
+	{
+		*this = rhs;
+	}
+
+	LSVec3& operator=(const LSVec3& rhs) {
+		LSVec3& lhs = *this;
+		for (int i = 0; i < 4; ++i)
+			lhs[i] = rhs[i];
+		return *this;
+	}
+
+	const FLOATTYPE& operator[](int i) const {return mVec[i];}
+	FLOATTYPE& operator[](int i) { return mVec[i]; }
+
+	LSVec3 operator-(const LSVec3& rhs) const {
+		const LSVec3& lhs = *this;
+		LSVec3 result = *this;
+		for (int i = 0; i < 4; ++i)
+			result[i] -= rhs[i];
+		return result;
+	}
+
+	FLOATTYPE mVec[4];
+	FLOATTYPE& x;
+	FLOATTYPE& y;
+	FLOATTYPE& z;
+	FLOATTYPE& w;
+};
+
+LSVec3 operator*(FLOATTYPE s, const LSVec3& rhs) {
+	LSVec3 result = rhs;
+	for (int i = 0; i < 4; ++i)
+		result[i] *= s;
+	return result;
+}
+
+class LSMatrix44 : public VSMatrix
+{
+public:
+	LSMatrix44() 
+	{
+		loadIdentity();
+	}
+		
+	LSMatrix44(const vr::HmdMatrix34_t& m) {
+		loadIdentity();
+		for (int i = 0; i < 3; ++i) {
+			for (int j = 0; j < 4; ++j) {
+				(*this)[i][j] = m.m[i][j];
+			}
+		}
+	}
+
+	LSMatrix44(const VSMatrix& m) {
+		m.copy(mMatrix);
+	}
+
+	// overload bracket operator to return one row of the matrix, so you can invoke, say, m[2][3]
+	FLOATTYPE* operator[](int i) {return &mMatrix[i*4];}
+	const FLOATTYPE* operator[](int i) const { return &mMatrix[i * 4]; }
+
+	LSMatrix44 operator*(const VSMatrix& rhs) const {
+		LSMatrix44 result(*this);
+		result.multMatrix(rhs);
+		return result;
+	}
+
+	LSVec3 operator*(const LSVec3& rhs) const {
+		const LSMatrix44& lhs = *this;
+		LSVec3 result(0, 0, 0, 0);
+		for (int i = 0; i < 4; ++i) {
+			for (int j = 0; j < 4; ++j) {
+				result[i] += lhs[i][j] * rhs[j];
+			}
+		}
+		return result;
+	}
+
+	LSMatrix44 getWithoutTranslation() const {
+		LSMatrix44 m = *this;
+		// Remove translation component
+		m[3][3] = 1.0f;
+		m[3][2] = m[3][1] = m[3][0] = 0.0f;
+		m[2][3] = m[1][3] = m[0][3] = 0.0f;
+		return m;
+	}
+
+	LSMatrix44 transpose() const {
+		LSMatrix44 result;
+		for (int i = 0; i < 4; ++i) {
+			for (int j = 0; j < 4; ++j) {
+				result[i][j] = (*this)[j][i];
+			}
+		}
+		return result;
+	}
+
+};
+
+#endif // VR_LS_MATRIX_H_
+
+

--- a/src/gl/stereo3d/gl_openvr.cpp
+++ b/src/gl/stereo3d/gl_openvr.cpp
@@ -1,0 +1,611 @@
+//
+//---------------------------------------------------------------------------
+//
+// Copyright(C) 2016-2017 Christopher Bruns
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+//
+//--------------------------------------------------------------------------
+//
+/*
+** gl_openvr.cpp
+** Stereoscopic virtual reality mode for the HTC Vive headset
+**
+*/
+
+#ifdef USE_OPENVR
+
+#include "gl_openvr.h"
+#include "openvr.h"
+#include <string>
+#include "gl/system/gl_system.h"
+#include "doomtype.h" // Printf
+#include "d_player.h"
+#include "g_game.h" // G_Add...
+#include "p_local.h" // P_TryMove
+#include "r_utility.h" // viewpitch
+#include "gl/renderer/gl_renderer.h"
+#include "gl/renderer/gl_renderbuffers.h"
+#include "g_levellocals.h" // pixelstretch
+#include "math/cmath.h"
+#include "c_cvars.h"
+#include "LSMatrix.h"
+
+// For conversion between real-world and doom units
+#define VERTICAL_DOOM_UNITS_PER_METER 27.0f
+
+EXTERN_CVAR(Int, screenblocks);
+
+using namespace vr;
+
+// feature toggles, for testing and debugging
+static const bool doTrackHmdYaw = true;
+static const bool doTrackHmdPitch = true;
+static const bool doTrackHmdRoll = true;
+static const bool doLateScheduledRotationTracking = true;
+static const bool doStereoscopicViewpointOffset = true;
+static const bool doRenderToDesktop = true; // mirroring to the desktop is very helpful for debugging
+static const bool doRenderToHmd = true;
+static const bool doTrackHmdVerticalPosition = false; // todo:
+static const bool doTrackHmdHorizontalPostion = false; // todo:
+static const bool doTrackVrControllerPosition = false; // todo:
+
+namespace s3d 
+{
+
+/* static */
+const Stereo3DMode& OpenVRMode::getInstance()
+{
+		static OpenVRMode instance;
+		if (! instance.hmdWasFound)
+			return  MonoView::getInstance();
+		return instance;
+}
+
+static HmdVector3d_t eulerAnglesFromQuat(HmdQuaternion_t quat) {
+	double q0 = quat.w;
+	// permute axes to make "Y" up/yaw
+	double q2 = quat.x;
+	double q3 = quat.y;
+	double q1 = quat.z;
+
+	// http://stackoverflow.com/questions/18433801/converting-a-3x3-matrix-to-euler-tait-bryan-angles-pitch-yaw-roll
+	double roll = atan2(2 * (q0*q1 + q2*q3), 1 - 2 * (q1*q1 + q2*q2));
+	double pitch = asin(2 * (q0*q2 - q3*q1));
+	double yaw = atan2(2 * (q0*q3 + q1*q2), 1 - 2 * (q2*q2 + q3*q3));
+
+	return HmdVector3d_t{ yaw, pitch, roll };
+}
+
+static HmdQuaternion_t quatFromMatrix(HmdMatrix34_t matrix) {
+	HmdQuaternion_t q;
+	typedef float f34[3][4];
+	f34& a = matrix.m;
+	// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/
+	float trace = a[0][0] + a[1][1] + a[2][2]; // I removed + 1.0f; see discussion with Ethan
+	if (trace > 0) {// I changed M_EPSILON to 0
+		float s = 0.5f / sqrtf(trace + 1.0f);
+		q.w = 0.25f / s;
+		q.x = (a[2][1] - a[1][2]) * s;
+		q.y = (a[0][2] - a[2][0]) * s;
+		q.z = (a[1][0] - a[0][1]) * s;
+	}
+	else {
+		if (a[0][0] > a[1][1] && a[0][0] > a[2][2]) {
+			float s = 2.0f * sqrtf(1.0f + a[0][0] - a[1][1] - a[2][2]);
+			q.w = (a[2][1] - a[1][2]) / s;
+			q.x = 0.25f * s;
+			q.y = (a[0][1] + a[1][0]) / s;
+			q.z = (a[0][2] + a[2][0]) / s;
+		}
+		else if (a[1][1] > a[2][2]) {
+			float s = 2.0f * sqrtf(1.0f + a[1][1] - a[0][0] - a[2][2]);
+			q.w = (a[0][2] - a[2][0]) / s;
+			q.x = (a[0][1] + a[1][0]) / s;
+			q.y = 0.25f * s;
+			q.z = (a[1][2] + a[2][1]) / s;
+		}
+		else {
+			float s = 2.0f * sqrtf(1.0f + a[2][2] - a[0][0] - a[1][1]);
+			q.w = (a[1][0] - a[0][1]) / s;
+			q.x = (a[0][2] + a[2][0]) / s;
+			q.y = (a[1][2] + a[2][1]) / s;
+			q.z = 0.25f * s;
+		}
+	}
+
+	return q;
+}
+
+static HmdVector3d_t eulerAnglesFromMatrix(HmdMatrix34_t mat) {
+	return eulerAnglesFromQuat(quatFromMatrix(mat));
+}
+
+OpenVREyePose::OpenVREyePose(int eye)
+	: ShiftedEyePose( 0.0f )
+	, eye(eye)
+	, eyeTexture(nullptr)
+	, currentPose(nullptr)
+{
+}
+
+
+/* virtual */
+OpenVREyePose::~OpenVREyePose() 
+{
+	dispose();
+}
+
+static void vSMatrixFromHmdMatrix34(VSMatrix& m1, const vr::HmdMatrix34_t& m2)
+{
+	float tmp[16];
+	for (int i = 0; i < 3; ++i) {
+		for (int j = 0; j < 4; ++j) {
+			tmp[4 * i + j] = m2.m[i][j];
+		}
+	}
+	int i = 3;
+	for (int j = 0; j < 4; ++j) {
+		tmp[4 * i + j] = 0;
+	}
+	tmp[15] = 1;
+	m1.loadMatrix(&tmp[0]);
+}
+
+
+/* virtual */
+void OpenVREyePose::GetViewShift(FLOATTYPE yaw, FLOATTYPE outViewShift[3]) const
+{
+	outViewShift[0] = outViewShift[1] = outViewShift[2] = 0;
+
+	if (currentPose == nullptr)
+		return;
+	const vr::TrackedDevicePose_t& hmd = *currentPose;
+	if (! hmd.bDeviceIsConnected)
+		return;
+	if (! hmd.bPoseIsValid)
+		return;
+
+	if (! doStereoscopicViewpointOffset)
+		return;
+
+	const vr::HmdMatrix34_t& hmdPose = hmd.mDeviceToAbsoluteTracking;
+
+	// Pitch and Roll are identical between OpenVR and Doom worlds.
+	// But yaw can differ, depending on starting state, and controller movement.
+	float doomYawDegrees = yaw;
+	float openVrYawDegrees = RAD2DEG(-eulerAnglesFromMatrix(hmdPose).v[0]);
+	float deltaYawDegrees = doomYawDegrees - openVrYawDegrees;
+	while (deltaYawDegrees > 180)
+		deltaYawDegrees -= 360;
+	while (deltaYawDegrees < -180)
+		deltaYawDegrees += 360;
+
+	// extract rotation component from hmd transform
+	LSMatrix44 openvr_X_hmd(hmdPose);
+	LSMatrix44 hmdRot = openvr_X_hmd.getWithoutTranslation(); // .transpose();
+
+	/// In these eye methods, just get local inter-eye stereoscopic shift, not full position shift ///
+
+	// compute local eye shift
+	LSMatrix44 eyeShift2;
+	eyeShift2.loadIdentity();
+	eyeShift2 = eyeShift2 * eyeToHeadTransform; // eye to head
+	eyeShift2 = eyeShift2 * hmdRot; // head to openvr
+
+	LSVec3 eye_EyePos = LSVec3(0, 0, 0); // eye position in eye frame
+	LSVec3 hmd_EyePos = LSMatrix44(eyeToHeadTransform) * eye_EyePos;
+	LSVec3 hmd_HmdPos = LSVec3(0, 0, 0); // hmd position in hmd frame
+	LSVec3 openvr_EyePos = openvr_X_hmd * hmd_EyePos;
+	LSVec3 openvr_HmdPos = openvr_X_hmd * hmd_HmdPos;
+	LSVec3 hmd_OtherEyePos = LSMatrix44(otherEyeToHeadTransform) * eye_EyePos;
+	LSVec3 openvr_OtherEyePos = openvr_X_hmd * hmd_OtherEyePos;
+	LSVec3 openvr_EyeOffset = openvr_EyePos - openvr_HmdPos;
+
+	VSMatrix doomInOpenVR = VSMatrix();
+	doomInOpenVR.loadIdentity();
+	// permute axes
+	float permute[] = { // Convert from OpenVR to Doom axis convention, including mirror inversion
+		-1,  0,  0,  0, // X-right in OpenVR -> X-left in Doom
+			0,  0,  1,  0, // Z-backward in OpenVR -> Y-backward in Doom
+			0,  1,  0,  0, // Y-up in OpenVR -> Z-up in Doom
+			0,  0,  0,  1};
+	doomInOpenVR.multMatrix(permute);
+	doomInOpenVR.scale(VERTICAL_DOOM_UNITS_PER_METER, VERTICAL_DOOM_UNITS_PER_METER, VERTICAL_DOOM_UNITS_PER_METER); // Doom units are not meters
+	doomInOpenVR.scale(level.info->pixelstretch, level.info->pixelstretch, 1.0); // Doom universe is scaled by 1990s pixel aspect ratio
+	doomInOpenVR.rotate(deltaYawDegrees, 0, 0, 1);
+
+	LSVec3 doom_EyeOffset = LSMatrix44(doomInOpenVR) * openvr_EyeOffset;
+	outViewShift[0] = doom_EyeOffset[0];
+	outViewShift[1] = doom_EyeOffset[1];
+	outViewShift[2] = doom_EyeOffset[2];
+}
+
+/* virtual */
+VSMatrix OpenVREyePose::GetProjection(FLOATTYPE fov, FLOATTYPE aspectRatio, FLOATTYPE fovRatio) const
+{
+	// Ignore those arguments and get the projection from the SDK
+	// VSMatrix vs1 = ShiftedEyePose::GetProjection(fov, aspectRatio, fovRatio);
+	return projectionMatrix;
+}
+
+void OpenVREyePose::initialize(vr::IVRSystem& vrsystem)
+{
+	float zNear = 5.0;
+	float zFar = 65536.0;
+	vr::HmdMatrix44_t projection = vrsystem.GetProjectionMatrix(
+			vr::EVREye(eye), zNear, zFar);
+	vr::HmdMatrix44_t proj_transpose;
+	for (int i = 0; i < 4; ++i) {
+		for (int j = 0; j < 4; ++j) {
+			proj_transpose.m[i][j] = projection.m[j][i];
+		}
+	}
+	projectionMatrix.loadIdentity();
+	projectionMatrix.multMatrix(&proj_transpose.m[0][0]);
+
+	vr::HmdMatrix34_t eyeToHead = vrsystem.GetEyeToHeadTransform(vr::EVREye(eye));
+	vSMatrixFromHmdMatrix34(eyeToHeadTransform, eyeToHead);
+	vr::HmdMatrix34_t otherEyeToHead = vrsystem.GetEyeToHeadTransform(eye == Eye_Left ? Eye_Right : Eye_Left);
+	vSMatrixFromHmdMatrix34(otherEyeToHeadTransform, otherEyeToHead);
+
+	if (eyeTexture == nullptr)
+		eyeTexture = new vr::Texture_t();
+	eyeTexture->handle = nullptr; // TODO: populate this at resolve time
+	eyeTexture->eType = vr::TextureType_OpenGL;
+	eyeTexture->eColorSpace = vr::ColorSpace_Linear;
+}
+
+void OpenVREyePose::dispose()
+{
+	if (eyeTexture) {
+		delete eyeTexture;
+		eyeTexture = nullptr;
+	}
+}
+
+bool OpenVREyePose::submitFrame() const
+{
+	if (eyeTexture == nullptr)
+		return false;
+	if (vr::VRCompositor() == nullptr)
+		return false;
+	// Copy HDR framebuffer into 24-bit RGB texture
+	GLRenderer->mBuffers->BindEyeFB(eye, true);
+	if (eyeTexture->handle == nullptr) {
+		GLuint handle;
+		glGenTextures(1, &handle);
+		eyeTexture->handle = (void *)handle;
+		glBindTexture(GL_TEXTURE_2D, handle);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, GLRenderer->mSceneViewport.width,
+			GLRenderer->mSceneViewport.height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+	}
+	glBindTexture(GL_TEXTURE_2D, (GLuint)eyeTexture->handle);
+	glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, 0, 0,
+		GLRenderer->mSceneViewport.width,
+		GLRenderer->mSceneViewport.height, 0);
+	vr::VRCompositor()->Submit(vr::EVREye(eye), eyeTexture);
+	return true;
+}
+
+void OpenVREyePose::Adjust2DMatrices() const
+{
+	const bool doAdjust2D = true; // Don't use default 2D projection
+	const bool doRecomputeDefault2D = false; // For debugging, recapitulate default 2D projection
+
+	if (!doAdjust2D) // for debugging
+		return;
+
+	VSMatrix new_projection;
+	new_projection.loadIdentity();
+	if (doRecomputeDefault2D) { // for debugging
+								// quad coordinates from pixel coordinates [xy range -1,1]
+		new_projection.translate(-1, 1, 0);
+		new_projection.scale(2.0 / SCREENWIDTH, -2.0 / SCREENHEIGHT, -1.0);
+	}
+	else {
+		// doom_units from meters
+		new_projection.scale(
+			-VERTICAL_DOOM_UNITS_PER_METER,
+			VERTICAL_DOOM_UNITS_PER_METER,
+			-VERTICAL_DOOM_UNITS_PER_METER);
+		new_projection.scale(level.info->pixelstretch, level.info->pixelstretch, 1.0); // Doom universe is scaled by 1990s pixel aspect ratio
+
+		// eye coordinates from hmd coordinates
+		LSMatrix44 e2h(eyeToHeadTransform);
+		new_projection.multMatrix(e2h.transpose());
+
+		// Un-apply HMD yaw angle, to keep the menu in front of the player
+		float openVrYawDegrees = RAD2DEG(-eulerAnglesFromMatrix(currentPose->mDeviceToAbsoluteTracking).v[0]);
+		new_projection.rotate(openVrYawDegrees, 0, 1, 0);
+
+		// apply inverse of hmd rotation, to keep the menu fixed in the world
+		LSMatrix44 hmdPose(currentPose->mDeviceToAbsoluteTracking);
+		hmdPose = hmdPose.getWithoutTranslation();
+		new_projection.multMatrix(hmdPose.transpose());
+
+		// Tilt the HUD downward, so its not so high up
+		new_projection.rotate(15, 1, 0, 0);
+
+		// hmd coordinates (meters) from ndc coordinates
+		const float menu_distance_meters = 1.0f;
+		const float menu_width_meters = 0.4f * menu_distance_meters;
+		const float aspect = SCREENWIDTH / float(SCREENHEIGHT);
+		new_projection.translate(0.0, 0.0, menu_distance_meters);
+		new_projection.scale(
+			-menu_width_meters,
+			menu_width_meters / aspect,
+			-menu_width_meters);
+
+		// ndc coordinates from pixel coordinates
+		new_projection.translate(-1.0, 1.0, 0);
+		new_projection.scale(2.0 / SCREENWIDTH, -2.0 / SCREENHEIGHT, -1.0);
+
+		// projection matrix - clip coordinates from eye coordinates
+		VSMatrix proj(projectionMatrix);
+		proj.multMatrix(new_projection);
+		new_projection = proj;
+	}
+
+	gl_RenderState.mProjectionMatrix = new_projection;
+	gl_RenderState.ApplyMatrices();
+}
+
+OpenVRMode::OpenVRMode() 
+	: vrSystem(nullptr)
+	, leftEyeView(vr::Eye_Left)
+	, rightEyeView(vr::Eye_Right)
+	, hmdWasFound(false)
+	, sceneWidth(0), sceneHeight(0)
+{
+	eye_ptrs.Push(&leftEyeView); // default behavior to Mono non-stereo rendering
+
+	EVRInitError eError;
+	if (VR_IsHmdPresent())
+	{
+		vrSystem = VR_Init(&eError, VRApplication_Scene);
+		if (eError != vr::VRInitError_None) {
+			std::string errMsg = VR_GetVRInitErrorAsEnglishDescription(eError);
+			vrSystem = nullptr;
+			return;
+			// TODO: report error
+		}
+		vrSystem->GetRecommendedRenderTargetSize(&sceneWidth, &sceneHeight);
+
+		// OK
+		leftEyeView.initialize(*vrSystem);
+		rightEyeView.initialize(*vrSystem);
+
+		if (!vr::VRCompositor())
+			return;
+
+		eye_ptrs.Push(&rightEyeView); // NOW we render to two eyes
+		hmdWasFound = true;
+	}
+}
+
+/* virtual */
+// AdjustViewports() is called from within FLGRenderer::SetOutputViewport(...)
+void OpenVRMode::AdjustViewports() const
+{
+	// Draw the 3D scene into the entire framebuffer
+	GLRenderer->mSceneViewport.width = sceneWidth;
+	GLRenderer->mSceneViewport.height = sceneHeight;
+	GLRenderer->mSceneViewport.left = 0;
+	GLRenderer->mSceneViewport.top = 0;
+
+	GLRenderer->mScreenViewport.width = sceneWidth;
+	GLRenderer->mScreenViewport.height = sceneHeight;
+}
+
+void OpenVRMode::AdjustPlayerSprites() const
+{
+	Stereo3DMode::AdjustPlayerSprites();
+
+	// TODO: put weapon onto a 3D quad
+	const bool doProjectWeaponSprite = true; // Don't use default 2D projection
+	const bool doRecomputeDefault2D = false; // For debugging, recapitulate default 2D projection
+
+	if (!doProjectWeaponSprite) // for debugging
+		return;
+
+	VSMatrix new_projection;
+	new_projection.loadIdentity();
+	if (doRecomputeDefault2D) { // for debugging
+								// quad coordinates from pixel coordinates [xy range -1,1]
+		new_projection.translate(-1, 1, 0);
+		new_projection.scale(2.0 / SCREENWIDTH, -2.0 / SCREENHEIGHT, -1.0);
+	}
+	else {
+		// doom_units from meters
+		new_projection.scale(
+			-VERTICAL_DOOM_UNITS_PER_METER,
+			 VERTICAL_DOOM_UNITS_PER_METER,
+			-VERTICAL_DOOM_UNITS_PER_METER);
+		new_projection.scale(level.info->pixelstretch, level.info->pixelstretch, 1.0); // Doom universe is scaled by 1990s pixel aspect ratio
+
+		const OpenVREyePose * activeEye = &rightEyeView;
+		if (! activeEye->isActive())
+			activeEye = &leftEyeView;
+
+		// eye coordinates from hmd coordinates
+		LSMatrix44 e2h(activeEye->eyeToHeadTransform);
+		new_projection.multMatrix(e2h.transpose());
+
+		// Follow HMD orientation, EXCEPT for roll angle (keep weapon upright)
+		float openVrRollDegrees = RAD2DEG(-eulerAnglesFromMatrix(activeEye->currentPose->mDeviceToAbsoluteTracking).v[2]);
+		new_projection.rotate(-openVrRollDegrees, 0, 0, 1);
+
+		// hmd coordinates (meters) from ndc coordinates
+		const float weapon_distance_meters = 0.55f;
+		const float weapon_width_meters = 0.3f;
+		const float aspect = SCREENWIDTH / float(SCREENHEIGHT);
+		new_projection.translate(0.0, 0.0, weapon_distance_meters);
+		new_projection.scale(
+			-weapon_width_meters,
+			 weapon_width_meters / aspect,
+			-weapon_width_meters);
+
+		// ndc coordinates from pixel coordinates
+		new_projection.translate(-1.0, 1.0, 0);
+		new_projection.scale(2.0 / SCREENWIDTH, -2.0 / SCREENHEIGHT, -1.0);
+
+		// projection matrix - clip coordinates from eye coordinates
+		VSMatrix proj(activeEye->projectionMatrix);
+		proj.multMatrix(new_projection);
+		new_projection = proj;
+	}
+
+	gl_RenderState.mProjectionMatrix = new_projection;
+	gl_RenderState.ApplyMatrices();
+}
+
+/* virtual */
+void OpenVRMode::Present() const {
+	// TODO: For performance, don't render to the desktop screen here
+	if (doRenderToDesktop) {
+		GLRenderer->mBuffers->BindOutputFB();
+		GLRenderer->ClearBorders();
+
+		// Compute screen regions to use for left and right eye views
+		int leftWidth = GLRenderer->mOutputLetterbox.width / 2;
+		int rightWidth = GLRenderer->mOutputLetterbox.width - leftWidth;
+		GL_IRECT leftHalfScreen = GLRenderer->mOutputLetterbox;
+		leftHalfScreen.width = leftWidth;
+		GL_IRECT rightHalfScreen = GLRenderer->mOutputLetterbox;
+		rightHalfScreen.width = rightWidth;
+		rightHalfScreen.left += leftWidth;
+
+		GLRenderer->mBuffers->BindEyeTexture(0, 0);
+		GLRenderer->DrawPresentTexture(leftHalfScreen, true);
+		GLRenderer->mBuffers->BindEyeTexture(1, 0);
+		GLRenderer->DrawPresentTexture(rightHalfScreen, true);
+	}
+
+	if (doRenderToHmd) 
+	{
+		leftEyeView.submitFrame();
+		rightEyeView.submitFrame();
+	}
+}
+
+static int mAngleFromRadians(double radians) 
+{
+	double m = std::round(65535.0 * radians / (2.0 * M_PI));
+	return int(m);
+}
+
+void OpenVRMode::updateHmdPose(
+	double hmdYawRadians, 
+	double hmdPitchRadians, 
+	double hmdRollRadians) const 
+{
+	double hmdyaw = hmdYawRadians;
+	double hmdpitch = hmdPitchRadians;
+	double hmdroll = hmdRollRadians;
+
+	double dYaw = 0;
+	if (doTrackHmdYaw) {
+		// Set HMD angle game state parameters for NEXT frame
+		static double previousYaw = 0;
+		static bool havePreviousYaw = false;
+		if (!havePreviousYaw) {
+			previousYaw = hmdyaw;
+			havePreviousYaw = true;
+		}
+		dYaw = hmdyaw - previousYaw;
+		G_AddViewAngle(mAngleFromRadians(-dYaw));
+		previousYaw = hmdyaw;
+	}
+
+	/* */
+	// Pitch
+	if (doTrackHmdPitch) {
+		double hmdPitchInDoom = -atan(tan(hmdpitch) / level.info->pixelstretch);
+		double viewPitchInDoom = GLRenderer->mAngles.Pitch.Radians();
+		double dPitch = hmdPitchInDoom - viewPitchInDoom;
+		G_AddViewPitch(mAngleFromRadians(-dPitch));
+	}
+
+	// Roll can be local, because it doesn't affect gameplay.
+	if (doTrackHmdRoll)
+		GLRenderer->mAngles.Roll = RAD2DEG(-hmdroll);
+
+	// Late-schedule update to renderer angles directly, too
+	if (doLateScheduledRotationTracking) {
+		if (doTrackHmdPitch)
+			GLRenderer->mAngles.Pitch = RAD2DEG(-hmdpitch);
+		if (doTrackHmdYaw) {
+			// TODO: this is not working, especially in menu GS_TITLESCREEN mode
+			GLRenderer->mAngles.Yaw += RAD2DEG(dYaw); // "plus" is the correct direction
+			// Printf("In updateHmdPose: %.1f\n", r_viewpoint.Angles.Yaw.Degrees);
+		}
+	}
+}
+
+/* virtual */
+void OpenVRMode::SetUp() const
+{
+	super::SetUp();
+
+	cachedScreenBlocks = screenblocks;
+	screenblocks = 12; // always be full-screen during 3D scene render
+
+	if (vr::VRCompositor() == nullptr)
+		return;
+
+	static vr::TrackedDevicePose_t poses[vr::k_unMaxTrackedDeviceCount];
+	vr::VRCompositor()->WaitGetPoses(
+		poses, vr::k_unMaxTrackedDeviceCount, // current pose
+		nullptr, 0 // future pose?
+	);
+
+	TrackedDevicePose_t& hmdPose0 = poses[vr::k_unTrackedDeviceIndex_Hmd];
+
+	if (hmdPose0.bPoseIsValid) {
+		const vr::HmdMatrix34_t& hmdPose = hmdPose0.mDeviceToAbsoluteTracking;
+		HmdVector3d_t eulerAngles = eulerAnglesFromMatrix(hmdPose);
+		// Printf("%.1f %.1f %.1f\n", eulerAngles.v[0], eulerAngles.v[1], eulerAngles.v[2]);
+		updateHmdPose(eulerAngles.v[0], eulerAngles.v[1], eulerAngles.v[2]);
+		leftEyeView.setCurrentHmdPose(&hmdPose0);
+		rightEyeView.setCurrentHmdPose(&hmdPose0);
+		// TODO: position tracking
+	}
+}
+
+/* virtual */
+void OpenVRMode::TearDown() const
+{
+	screenblocks = cachedScreenBlocks;
+	super::TearDown();
+}
+
+/* virtual */
+OpenVRMode::~OpenVRMode() 
+{
+	if (vrSystem != nullptr) {
+		VR_Shutdown();
+		vrSystem = nullptr;
+		leftEyeView.dispose();
+		rightEyeView.dispose();
+	}
+}
+
+} /* namespace s3d */
+
+#endif
+

--- a/src/gl/stereo3d/gl_openvr.cpp
+++ b/src/gl/stereo3d/gl_openvr.cpp
@@ -287,14 +287,14 @@ bool OpenVREyePose::submitFrame() const
 	if (eyeTexture->handle == nullptr) {
 		GLuint handle;
 		glGenTextures(1, &handle);
-		eyeTexture->handle = (void *)handle;
+		eyeTexture->handle = (void *)(std::ptrdiff_t)handle;
 		glBindTexture(GL_TEXTURE_2D, handle);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, GLRenderer->mSceneViewport.width,
 			GLRenderer->mSceneViewport.height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
 	}
-	glBindTexture(GL_TEXTURE_2D, (GLuint)eyeTexture->handle);
+	glBindTexture(GL_TEXTURE_2D, (GLuint)(std::ptrdiff_t)eyeTexture->handle);
 	glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, 0, 0,
 		GLRenderer->mSceneViewport.width,
 		GLRenderer->mSceneViewport.height, 0);

--- a/src/gl/stereo3d/gl_openvr.cpp
+++ b/src/gl/stereo3d/gl_openvr.cpp
@@ -691,7 +691,6 @@ void OpenVRMode::updateHmdPose(
 			double hmdViewAngle = RAD2DEG(hmdYaw);
 			double doomViewAngle = r_viewpoint.Angles.Yaw.Degrees;
 			double currentOffset = doomViewAngle - hmdViewAngle;
-			Printf("%.1f\n", currentOffset);
 			if ((gamestate == GS_LEVEL)
 				&& (menuactive == MENU_Off))
 			{

--- a/src/gl/stereo3d/gl_openvr.h
+++ b/src/gl/stereo3d/gl_openvr.h
@@ -90,6 +90,7 @@ protected:
 	uint32_t vrToken;
 
 	mutable int cachedScreenBlocks;
+	mutable double hmdYaw; // cached latest value in radians
 
 private:
 	typedef Stereo3DMode super;

--- a/src/gl/stereo3d/gl_openvr.h
+++ b/src/gl/stereo3d/gl_openvr.h
@@ -1,0 +1,102 @@
+//
+//---------------------------------------------------------------------------
+//
+// Copyright(C) 2016-2017 Christopher Bruns
+// All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see http://www.gnu.org/licenses/
+//
+//--------------------------------------------------------------------------
+//
+/*
+** gl_openvr.h
+** Stereoscopic virtual reality mode for the HTC Vive headset
+*/
+
+#ifndef GL_OPENVR_H_
+#define GL_OPENVR_H_
+
+#include "gl_stereo3d.h"
+#include "gl_stereo_leftright.h"
+
+// forward declaration from openvr.h
+namespace vr {
+	class IVRSystem;
+	struct HmdMatrix44_t;
+	struct Texture_t;
+	struct TrackedDevicePose_t;
+}
+
+/* stereoscopic 3D API */
+namespace s3d {
+
+class OpenVREyePose : public ShiftedEyePose
+{
+public:
+	friend class OpenVRMode;
+
+	OpenVREyePose(int eye);
+	virtual ~OpenVREyePose() override;
+	virtual VSMatrix GetProjection(FLOATTYPE fov, FLOATTYPE aspectRatio, FLOATTYPE fovRatio) const override;
+	void GetViewShift(FLOATTYPE yaw, FLOATTYPE outViewShift[3]) const override;
+	virtual void Adjust2DMatrices() const override;
+
+	void initialize(vr::IVRSystem& vrsystem);
+	void dispose();
+	void setCurrentHmdPose(const vr::TrackedDevicePose_t * pose) const {currentPose = pose;}
+	bool submitFrame() const;
+
+protected:
+	VSMatrix projectionMatrix;
+	VSMatrix eyeToHeadTransform;
+	VSMatrix otherEyeToHeadTransform;
+	vr::Texture_t* eyeTexture;
+	int eye;
+
+	mutable const vr::TrackedDevicePose_t * currentPose;
+};
+
+class OpenVRMode : public Stereo3DMode
+{
+public:
+	static const Stereo3DMode& getInstance(); // Might return Mono mode, if no HMD available
+
+	virtual ~OpenVRMode() override;
+	virtual void SetUp() const override; // called immediately before rendering a scene frame
+	virtual void TearDown() const override; // called immediately after rendering a scene frame
+	virtual void Present() const override;
+	virtual void AdjustViewports() const override;
+	virtual void AdjustPlayerSprites() const override;
+
+protected:
+	OpenVRMode();
+	// void updateDoomViewDirection() const;
+	void updateHmdPose(double hmdYawRadians, double hmdPitchRadians, double hmdRollRadians) const;
+
+	OpenVREyePose leftEyeView;
+	OpenVREyePose rightEyeView;
+
+	vr::IVRSystem* vrSystem;
+	mutable int cachedScreenBlocks;
+
+private:
+	typedef Stereo3DMode super;
+	bool hmdWasFound;
+	uint32_t sceneWidth, sceneHeight;
+};
+
+} /* namespace st3d */
+
+
+#endif /* GL_OPENVR_H_ */

--- a/src/gl/stereo3d/gl_openvr.h
+++ b/src/gl/stereo3d/gl_openvr.h
@@ -30,13 +30,11 @@
 #include "gl_stereo3d.h"
 #include "gl_stereo_leftright.h"
 
-// forward declaration from openvr.h
-namespace vr {
-	class IVRSystem;
-	struct HmdMatrix44_t;
-	struct Texture_t;
-	struct TrackedDevicePose_t;
-}
+// forward declarations
+struct TrackedDevicePose_t;
+struct Texture_t;
+struct VR_IVRSystem_FnTable;
+struct VR_IVRCompositor_FnTable;
 
 /* stereoscopic 3D API */
 namespace s3d {
@@ -52,19 +50,19 @@ public:
 	void GetViewShift(FLOATTYPE yaw, FLOATTYPE outViewShift[3]) const override;
 	virtual void Adjust2DMatrices() const override;
 
-	void initialize(vr::IVRSystem& vrsystem);
+	void initialize(VR_IVRSystem_FnTable * vrsystem);
 	void dispose();
-	void setCurrentHmdPose(const vr::TrackedDevicePose_t * pose) const {currentPose = pose;}
-	bool submitFrame() const;
+	void setCurrentHmdPose(const TrackedDevicePose_t * pose) const {currentPose = pose;}
+	bool submitFrame(VR_IVRCompositor_FnTable * vrCompositor) const;
 
 protected:
 	VSMatrix projectionMatrix;
 	VSMatrix eyeToHeadTransform;
 	VSMatrix otherEyeToHeadTransform;
-	vr::Texture_t* eyeTexture;
+	Texture_t* eyeTexture;
 	int eye;
 
-	mutable const vr::TrackedDevicePose_t * currentPose;
+	mutable const TrackedDevicePose_t * currentPose;
 };
 
 class OpenVRMode : public Stereo3DMode
@@ -87,7 +85,10 @@ protected:
 	OpenVREyePose leftEyeView;
 	OpenVREyePose rightEyeView;
 
-	vr::IVRSystem* vrSystem;
+	VR_IVRSystem_FnTable * vrSystem;
+	VR_IVRCompositor_FnTable * vrCompositor;
+	uint32_t vrToken;
+
 	mutable int cachedScreenBlocks;
 
 private:

--- a/src/gl/stereo3d/gl_stereo3d.h
+++ b/src/gl/stereo3d/gl_stereo3d.h
@@ -51,13 +51,18 @@ public:
 class EyePose 
 {
 public:
-	EyePose() {}
+	EyePose() : m_isActive(false) {}
 	virtual ~EyePose() {}
 	virtual VSMatrix GetProjection(float fov, float aspectRatio, float fovRatio) const;
 	virtual Viewport GetViewport(const Viewport& fullViewport) const;
 	virtual void GetViewShift(float yaw, float outViewShift[3]) const;
-	virtual void SetUp() const {};
-	virtual void TearDown() const {};
+	virtual void SetUp() const {m_isActive = true;}
+	virtual void TearDown() const {m_isActive = false;}
+	virtual void Adjust2DMatrices() const {}
+	bool isActive() const {return m_isActive;}
+
+private:
+	mutable bool m_isActive;
 };
 
 

--- a/src/gl/stereo3d/gl_stereo_cvars.cpp
+++ b/src/gl/stereo3d/gl_stereo_cvars.cpp
@@ -25,10 +25,12 @@
 **
 */
 
-#include "gl/stereo3d/gl_stereo3d.h"
-#include "gl/stereo3d/gl_stereo_leftright.h"
-#include "gl/stereo3d/gl_anaglyph.h"
-#include "gl/stereo3d/gl_quadstereo.h"
+#include "gl_stereo3d.h"
+#include "gl_stereo_leftright.h"
+#include "gl_anaglyph.h"
+#include "gl_openvr.h"
+#include "gl_quadstereo.h"
+#include "gl_sidebyside3d.h"
 #include "gl/stereo3d/gl_sidebyside3d.h"
 #include "gl/stereo3d/gl_interleaved3d.h"
 #include "gl/system/gl_cvars.h"
@@ -101,8 +103,12 @@ const Stereo3DMode& Stereo3DMode::getCurrentMode()
 	// TODO: 8: Oculus Rift
 	case 9:
 		setCurrentMode(AmberBlue::getInstance(vr_ipd));
-		break;	
-	// TODO: 10: HTC Vive/OpenVR
+		break;
+#ifdef USE_OPENVR
+	case 10:
+		setCurrentMode(OpenVRMode::getInstance());
+		break;
+#endif
 	case 11:
 		setCurrentMode(TopBottom3D::getInstance(vr_ipd));
 		break;

--- a/src/gl/stereo3d/scoped_view_shifter.cpp
+++ b/src/gl/stereo3d/scoped_view_shifter.cpp
@@ -31,7 +31,7 @@
 
 namespace s3d {
 
-ScopedViewShifter::ScopedViewShifter(float dxyz[3]) // in meters
+ScopedViewShifter::ScopedViewShifter(float dxyz[3]) // in doom units
 {
 	// save original values
 	cachedView = r_viewpoint.Pos;

--- a/src/gl/stereo3d/scoped_view_shifter.h
+++ b/src/gl/stereo3d/scoped_view_shifter.h
@@ -40,7 +40,7 @@ namespace s3d {
 	class ScopedViewShifter
 	{
 	public:
-		ScopedViewShifter(float dxyz[3]); // in meters
+		ScopedViewShifter(float dxyz[3]); // in doom units
 		~ScopedViewShifter();
 
 	private:

--- a/src/vectors.h
+++ b/src/vectors.h
@@ -902,7 +902,7 @@ struct TAngle
 
 	TAngle &operator= (double other)
 	{
-		Degrees = other;
+		Degrees = (vec_t)other;
 		return *this;
 	}
 
@@ -1084,7 +1084,7 @@ struct TAngle
 
 	vec_t Radians() const
 	{
-		return Degrees * (pi::pi() / 180.0);
+		return Degrees * (vec_t)(pi::pi() / 180.0);
 	}
 
 	unsigned BAMs() const

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2792,6 +2792,7 @@ OPTVAL_ROWINTERLEAVED		= "Row Interleaved";
 OPTVAL_COLUMNINTERLEAVED	= "Column Interleaved";
 OPTVAL_CHECKERBOARD			= "Checkerboard";
 OPTVAL_QUADBUFFERED 		= "Quad-buffered";
+OPTVAL_OPENVR 				= "OpenVR-Vive";
 OPTVAL_UNCHARTED2			= "Uncharted 2";
 OPTVAL_HEJLDAWSON			= "Hejl Dawson";
 OPTVAL_REINHARD				= "Reinhard";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2106,6 +2106,7 @@ OptionValue VRMode
 	5, "$OPTVAL_LEFTEYE"
 	6, "$OPTVAL_RIGHTEYE"
 	7, "$OPTVAL_QUADBUFFERED"
+	10, "$OPTVAL_OPENVR"
 }
 
 OptionMenu "GLTextureGLOptions" protected


### PR DESCRIPTION
Create OpenVR mode, including rough placement of HUD, menu, and weapon sprite on 3D quads.

This supersedes my previous pull request #338 , which was reviewed by raa-eruanna , and which in turn superseded #336 , which was reviewed by alexey-lysiuk
Sorry I messed up the history on that branch so I made another new pull request here.
Compared to the previous pull request, this one adds projection of 2D display items, and the weapon sprite, onto 3D quads in the game world, rendering the game somewhat playable.

Create initial rotation-tracking-only implementation of OpenVR mode for VR headsets.
Adds an optional CMake build rule for developers who have the OpenVR SDK installed.
There remain several tricky problems to be solved to make this a fun and playable mode.

As before, the zdoom forums discussion is at https://forum.zdoom.org/viewtopic.php?f=59&t=56623
