### PR TITLE
Add AssertObject macro to fix release build

### DIFF
--- a/src/scripting/vm/vm.h
+++ b/src/scripting/vm/vm.h
@@ -378,6 +378,8 @@ void NullParam(const char *varname);
 
 #ifdef _DEBUG
 bool AssertObject(void * ob);
+#else
+#define AssertObject(o) TRUE
 #endif
 
 #define PARAM_NULLCHECK(ptr, var) (ptr == nullptr? NullParam(#var), ptr : ptr)


### PR DESCRIPTION
Build accidentally grew a dependency on _DEBUG with some of the uses of AssertObject, so go ahead and add it as effectively a no-op.