### PR TITLE
Fixed shuffle with use of srand & time.

### DIFF
--- a/src/s_playlist.cpp
+++ b/src/s_playlist.cpp
@@ -34,6 +34,7 @@
 
 #include <stdlib.h>
 #include <errno.h>
+#include <ctime>
 
 #include "cmdlib.h"
 #include "s_playlist.h"
@@ -162,6 +163,7 @@ void FPlayList::Shuffle ()
 
 	for (i = 0; i < numsongs; ++i)
 	{
+		srand(time(NULL));
 		swapvalues (Songs[i], Songs[(rand() % (numsongs - i)) + i]);
 	}
 	Position = 0;


### PR DESCRIPTION
I noticed when using playlists with GZDoom it didn't actually shuffle randomly. Rather it just started at say track 7 rather than a random track. With srand & time in there it's random now. Yay!