### PR TITLE
Updated "cream" and "olive" definitions in TEXTCOLO

### DIFF
--- a/wadsrc/static/textcolors.txt
+++ b/wadsrc/static/textcolors.txt
@@ -140,7 +140,8 @@ Flat:
 
 Cream
 {
-	#CF8353  #FFD7BB
+	#6B4727  #BF7B4B    0 94
+	#BF7B4B  #FFBF9B   95 256
 Console:
 	#2B230F  #BF7B4B    0 127
 	#FFB383  #FFFFFF  128 256
@@ -150,7 +151,7 @@ Flat:
 
 Olive
 {
-	#2F371F  #7B7F50
+	#171F07  #7B7F50
 Console:
 	#373F27  #7B7F63    0 127
 	#676B4F  #D1D8A8  128 256


### PR DESCRIPTION
- Both cream and olive have been tweaked to now feature a broader range of shades, and so much starker, legible character outlines for the default fonts.
- Cream now uses 2 shading ranges to ensure it retains the look of the brown palette while having this extra outline contrast.
- This has so far been tested with the standard Doom smallfont, bigfont, and the ZDoom confont.