### PR TITLE
Allow ReEnable portal with Line_SetPortalTarget also for Visual&Teleport

### DIFF
--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -451,20 +451,30 @@ static bool ChangePortalLine(line_t *line, int destid)
 	{
 		port->mFlags = 0;
 	}
-	else if (port->mType == PORTT_INTERACTIVE)
+	else 
 	{
-		FLinePortal *portd = port->mDestination->portalindex < linePortals.Size()? &linePortals[port->mDestination->portalindex] : nullptr;
-		if (portd != nullptr && portd->mType == PORTT_INTERACTIVE && portd->mDestination == line)
+		if (port->mType == PORTT_INTERACTIVE)
 		{
-			// this is a 2-way interactive portal
-			port->mFlags = port->mDefFlags | PORTF_INTERACTIVE;
-			portd->mFlags = portd->mDefFlags | PORTF_INTERACTIVE;
+			FLinePortal *portd = port->mDestination->portalindex < linePortals.Size()? &linePortals[port->mDestination->portalindex] : nullptr;
+			if (portd != nullptr && portd->mType == PORTT_INTERACTIVE && portd->mDestination == line)
+			{
+				// this is a 2-way interactive portal
+				port->mFlags = port->mDefFlags | PORTF_INTERACTIVE;
+				portd->mFlags = portd->mDefFlags | PORTF_INTERACTIVE;
+			}
+			else
+			{
+				port->mFlags = port->mDefFlags;
+			}
+			SetRotation(portd);
 		}
 		else
 		{
-			port->mFlags = port->mDefFlags;
+			if (port->mType == PORTT_VISUAL || port->mType == PORTT_TELEPORT)
+			{ 
+				port->mFlags = port->mDefFlags;
+			}
 		}
-		SetRotation(portd);
 	}
 	SetRotation(port);
 	return true;


### PR DESCRIPTION
Changing a portal destination at runtime with Line_SetPortalTarget after it was temporarily disabled with destination 0 (zero) only worked for PORTF_INTERACTIVE and not for PORTT_VISUAL & PORTT_TELEPORT, while the WIKI states that it's only not allowed for static portals (type 3 & 4, see https://zdoom.org/wiki/Line_SetPortal).
Actually the only thing that was missing was restoring the mFlags for the Visual & Teleport types.

I have tested this change with a build on my system with a test wad which I will upload to the ZDoom forums. Since this is my first contribution the GZDoom code ever I will humble await the verdict of the more experienced programmers :)
[PortalMAP01.zip](https://github.com/coelckers/gzdoom/files/1329649/PortalMAP01.zip)

I have included a small testwad that disables a portal after map startup; the switch in the foreground will bring it back, and with the switch in the background it can be hidden again. This did not work with the original code for Visual & Teleport types.