### PR TITLE
Fixed bugs with Line_PortalSetTarget and added more portal geometry warnings

### DIFF
--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -363,7 +363,7 @@ void P_UpdatePortal(FLinePortal *port)
 	{
 		Printf(TEXTCOLOR_RED "Warning: Traversable portals must have a back-sector and empty space behind them (or be on a polyobject)! Changing line %d to visual-portal!\n", port->mOrigin->Index());
 		port->mType = PORTT_VISUAL;
-		port->mDefFlags &= ~(PORTF_PASSABLE | PORTF_SOUNDTRAVERSE);
+		port->mDefFlags &= ~(PORTF_PASSABLE | PORTF_SOUNDTRAVERSE | PORTF_INTERACTIVE);
 	}
 
 	if (port->mDestination == nullptr)


### PR DESCRIPTION
- A bug exists where portals that have been deactivated with Line_PortalSetTarget cannot be reactivated, even if given a valid target.
- Another bug exists where portals that were created in an inactive state (using a target line tag of 0) could never be activated. (Even with the above bugfix.)
- Linked portals that have been demoted to teleport portals because they do not have a return portal now emit a warning.
- Portals that are supposed to be traversable, but do not have a back-sector now demote to visual portals and emit a warning, because nothing could ever possibly traverse them anyway.

I see now that there's another pull request (#372) to fix the first bug in a slightly different way. I'm not sure which change is more appropriate, since I'm barely familiar with the portal code, but this is my take on it. It looks like the mFlags member is the main method of tracking whether portals are active, so it looks like it should always updated in the ChangePortalLine function.

I updated Gez's original portal test map from the original portal [thread](https://forum.zdoom.org/viewtopic.php?f=18&t=46916). I got everything working except for the switchable portals, which is what caused me to stumble on these bugs. Here's the updated version for testing: [zdoomx_test0_upd.zip](https://github.com/AntiBlueQuirk/gzdoom/files/1346167/zdoomx_test0_upd.zip)