### PR TITLE
On *nix, add gzdoom.pk3 installation directory to FileSearch.Directories

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -150,6 +150,10 @@ FGameConfigFile::FGameConfigFile ()
 #else
 		SetValueForKey ("Path", "~/" GAME_DIR, true);
 		SetValueForKey ("Path", SHARE_DIR, true);
+		SetValueForKey ("Path", "/usr/local/share/doom", true);
+		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
+		SetValueForKey ("Path", "/usr/share/doom", true);
+		SetValueForKey ("Path", "/usr/share/games/doom", true);
 #endif
 		SetValueForKey ("Path", "$DOOMWADDIR", true);
 	}


### PR DESCRIPTION
This fixes the following bug:

On *nix, by default, GZDoom installs gzdoom.pk3 into $PREFIX/share/games/doom. When it starts, it looks in the Paths under FileSearch.Directories for gzdoom.pk3. However, it does not, by default, have the directory actually containing gzdoom.pk3 as one of the FileSearch.Directories paths. Thus it prints the error message "Cannot find gzdoom.pk3" and refuses to start.

Most people packaging gzdoom for Linux have dealt with this by setting -DSHARE_DIR=... when building gzdoom. If you don't set that #define, then the above is what happens.