### PR TITLE
Fix failure to write under ~/ in confinement

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2138,7 +2138,7 @@ static void AddAutoloadFiles(const char *autoname)
 		D_AddDirectory (allwads, file);
 
 #ifdef __unix__
-		file = NicePath("~/" GAME_DIR "/skins");
+		file = NicePath("$HOME/" GAME_DIR "/skins");
 		D_AddDirectory (allwads, file);
 #endif	
 

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -125,7 +125,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
-		SetValueForKey ("Path", "~/" GAME_DIR, true);
+		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
 		// Arch Linux likes them in /usr/share/doom
 		// Debian likes them in /usr/share/games/doom
 		// I assume other distributions don't do anything radically different
@@ -148,7 +148,7 @@ FGameConfigFile::FGameConfigFile ()
 #elif !defined(__unix__)
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
-		SetValueForKey ("Path", "~/" GAME_DIR, true);
+		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
 		SetValueForKey ("Path", "/usr/local/share/doom", true);
 		SetValueForKey ("Path", "/usr/local/share/games/doom", true);
 		SetValueForKey ("Path", "/usr/share/doom", true);

--- a/src/posix/unix/i_specialpaths.cpp
+++ b/src/posix/unix/i_specialpaths.cpp
@@ -46,30 +46,30 @@ FString GetUserFile (const char *file)
 	FString path;
 	struct stat info;
 
-	path = NicePath("~/" GAME_DIR "/");
+	path = NicePath("$HOME/" GAME_DIR "/");
 
 	if (stat (path, &info) == -1)
 	{
 		struct stat extrainfo;
 
-		// Sanity check for ~/.config
-		FString configPath = NicePath("~/.config/");
+		// Sanity check for $HOME/.config
+		FString configPath = NicePath("$HOME/.config/");
 		if (stat (configPath, &extrainfo) == -1)
 		{
 			if (mkdir (configPath, S_IRUSR | S_IWUSR | S_IXUSR) == -1)
 			{
-				I_FatalError ("Failed to create ~/.config directory:\n%s", strerror(errno));
+				I_FatalError ("Failed to create $HOME/.config directory:\n%s", strerror(errno));
 			}
 		}
 		else if (!S_ISDIR(extrainfo.st_mode))
 		{
-			I_FatalError ("~/.config must be a directory");
+			I_FatalError ("$HOME/.config must be a directory");
 		}
 
 		// This can be removed after a release or two
 		// Transfer the old zdoom directory to the new location
 		bool moved = false;
-		FString oldpath = NicePath("~/." GAMENAMELOWERCASE "/");
+		FString oldpath = NicePath("$HOME/." GAMENAMELOWERCASE "/");
 		if (stat (oldpath, &extrainfo) != -1)
 		{
 			if (rename(oldpath, path) == -1)
@@ -110,7 +110,7 @@ FString M_GetAppDataPath(bool create)
 {
 	// Don't use GAME_DIR and such so that ZDoom and its child ports can
 	// share the node cache.
-	FString path = NicePath("~/.config/" GAMENAMELOWERCASE);
+	FString path = NicePath("$HOME/.config/" GAMENAMELOWERCASE);
 	if (create)
 	{
 		CreatePath(path);
@@ -130,7 +130,7 @@ FString M_GetCachePath(bool create)
 {
 	// Don't use GAME_DIR and such so that ZDoom and its child ports can
 	// share the node cache.
-	FString path = NicePath("~/.config/zdoom/cache");
+	FString path = NicePath("$HOME/.config/zdoom/cache");
 	if (create)
 	{
 		CreatePath(path);
@@ -163,7 +163,7 @@ FString M_GetCajunPath(const char *botfilename)
 {
 	FString path;
 
-	// Check first in ~/.config/zdoom/botfilename.
+	// Check first in $HOME/.config/zdoom/botfilename.
 	path = GetUserFile(botfilename);
 	if (!FileExists(path))
 	{
@@ -203,7 +203,7 @@ FString M_GetConfigPath(bool for_reading)
 
 FString M_GetScreenshotsPath()
 {
-	return NicePath("~/" GAME_DIR "/screenshots/");
+	return NicePath("$HOME/" GAME_DIR "/screenshots/");
 }
 
 //===========================================================================
@@ -216,7 +216,7 @@ FString M_GetScreenshotsPath()
 
 FString M_GetSavegamesPath()
 {
-	return NicePath("~/" GAME_DIR);
+	return NicePath("$HOME/" GAME_DIR);
 }
 
 //===========================================================================
@@ -229,5 +229,5 @@ FString M_GetSavegamesPath()
 
 FString M_GetDocumentsPath()
 {
-	return NicePath("~/" GAME_DIR);
+	return NicePath("$HOME/" GAME_DIR);
 }


### PR DESCRIPTION
When running in a confined environment (such as a snap) it may not be
possible to write to directories such as `~/.config`. By using the $HOME
variable instead of the `~` shortcut, the confined environment can pass
an alternative 'home' directory with write privileges.

I have only changed this for posix/unix and haven't touched code for
MacOS, as I don't know if that behaves differently