### PR TITLE
Blend cancellation fix

### DIFF
--- a/src/g_shared/a_flashfader.cpp
+++ b/src/g_shared/a_flashfader.cpp
@@ -50,16 +50,17 @@ DFlashFader::DFlashFader ()
 
 DFlashFader::DFlashFader (float r1, float g1, float b1, float a1,
 						  float r2, float g2, float b2, float a2,
-						  float time, AActor *who)
+						  float time, AActor *who, bool terminate)
 	: TotalTics ((int)(time*TICRATE)), StartTic (level.time), ForWho (who)
 {
 	Blends[0][0]=r1; Blends[0][1]=g1; Blends[0][2]=b1; Blends[0][3]=a1;
 	Blends[1][0]=r2; Blends[1][1]=g2; Blends[1][2]=b2; Blends[1][3]=a2;
+	Terminate = terminate;
 }
 
 void DFlashFader::OnDestroy ()
 {
-	Blends[1][3] = 0.f; // Needed in order to cancel out the secondary fade.
+	if (Terminate) Blends[1][3] = 0.f; // Needed in order to cancel out the secondary fade.
 	SetBlend (1.f);
 	Super::OnDestroy();
 }

--- a/src/g_shared/a_sharedglobal.h
+++ b/src/g_shared/a_sharedglobal.h
@@ -84,19 +84,20 @@ class DFlashFader : public DThinker
 public:
 	DFlashFader (float r1, float g1, float b1, float a1,
 				 float r2, float g2, float b2, float a2,
-				 float time, AActor *who);
+				 float time, AActor *who, bool terminate = false);
 	void OnDestroy() override;
 	void Serialize(FSerializer &arc);
 	void Tick ();
 	AActor *WhoFor() { return ForWho; }
 	void Cancel ();
+	
 
 protected:
 	float Blends[2][4];
 	int TotalTics;
 	int StartTic;
 	TObjPtr<AActor*> ForWho;
-
+	bool Terminate;
 	void SetBlend (float time);
 	DFlashFader ();
 };

--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -3586,7 +3586,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_SetBlend)
 
 	Create<DFlashFader>(color.r/255.f, color.g/255.f, color.b/255.f, float(alpha),
 					color2.r/255.f, color2.g/255.f, color2.b/255.f, float(alpha2),
-					float(tics)/TICRATE, self);
+					float(tics)/TICRATE, self, true);
 	return 0;
 }
 


### PR DESCRIPTION
- Fade cancelling should only always be active for A_SetBlend fades, not always for everything else (such as ACS fades).