### PR TITLE
Line trace function

### DIFF
--- a/src/p_linetracedata.h
+++ b/src/p_linetracedata.h
@@ -1,0 +1,25 @@
+#ifndef P_LTRACEDATA_H
+#define P_LTRACEDATA_H
+
+//============================================================================
+//
+// Structure for passing detailed results of LineTrace to ZScript
+//
+//============================================================================
+struct FLineTraceData
+{
+	AActor *HitActor;
+	line_t *HitLine;
+	sector_t *HitSector;
+	F3DFloor *Hit3DFloor;
+	FTextureID HitTexture;
+	DVector3 HitLocation;
+	double Distance;
+	int NumPortals;
+	int LineSide;
+	int LinePart;
+	int SectorPlane;
+	ETraceResult HitType;
+};
+
+#endif

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -336,6 +336,18 @@ enum	// P_LineAttack flags
 AActor *P_LineAttack(AActor *t1, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, PClassActor *pufftype, int flags = 0, FTranslatedLineTarget *victim = NULL, int *actualdamage = NULL, double sz = 0.0, double offsetforward = 0.0, double offsetside = 0.0);
 AActor *P_LineAttack(AActor *t1, DAngle angle, double distance, DAngle pitch, int damage, FName damageType, FName pufftype, int flags = 0, FTranslatedLineTarget *victim = NULL, int *actualdamage = NULL, double sz = 0.0, double offsetforward = 0.0, double offsetside = 0.0);
 
+enum	// P_LineTrace flags
+{
+	TRF_ABSPOSITION = 1,
+	TRF_ABSOFFSET = 2,
+	TRF_THRUSPECIES = 4,
+	TRF_THRUACTORS = 8,
+	TRF_THRUBLOCK = 16,
+	TRF_THRUHITSCAN = 32,
+	TRF_NOSKY = 64,
+	TRF_ALLACTORS = 128,
+};
+
 void	P_TraceBleed(int damage, const DVector3 &pos, AActor *target, DAngle angle, DAngle pitch);
 void	P_TraceBleed(int damage, AActor *target, DAngle angle, DAngle pitch);
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4820,7 +4820,7 @@ DEFINE_ACTION_FUNCTION(AActor, LineAttack)
 // P_LineTrace
 //
 //==========================================================================
-struct LineTraceData
+struct CheckLineData
 {
 	AActor *Caller;
 	bool ThruSpecies;
@@ -4830,7 +4830,7 @@ struct LineTraceData
 
 static ETraceStatus CheckLineTrace(FTraceResults &res, void *userdata)
 {
-	LineTraceData *TData = (LineTraceData *)userdata;
+	CheckLineData *TData = (CheckLineData *)userdata;
 	if ( res.HitType == TRACE_CrossingPortal )
 	{
 		TData->NumPortals++;
@@ -4852,7 +4852,7 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 	double offsetside, FLineTraceData *outdata)
 {
 	FTraceResults trace;
-	LineTraceData TData;
+	CheckLineData TData;
 	TData.Caller = t1;
 	TData.ThruSpecies = (flags & TRF_THRUSPECIES);
 	TData.ThruActors = (flags & TRF_THRUACTORS);

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -29,6 +29,32 @@ struct FCheckPosition
 	native void ClearLastRipped();
 }
 
+struct FLineTraceData
+{
+	enum ETraceResult
+	{
+		TRACE_HitNone,
+		TRACE_HitFloor,
+		TRACE_HitCeiling,
+		TRACE_HitWall,
+		TRACE_HitActor,
+		TRACE_CrossingPortal
+	};
+
+	Actor HitActor;
+	Line HitLine;
+	Sector HitSector;
+	F3DFloor Hit3DFloor;
+	TextureID HitTexture;
+	Vector3 HitLocation;
+	double Distance;
+	int NumPortals;
+	int LineSide;
+	int LinePart;
+	int SectorPlane;
+	int HitType;
+}
+
 struct LinkContext
 {
 	voidptr sector_list;	// really msecnode but that's not exported yet.
@@ -602,6 +628,7 @@ class Actor : Thinker native
 	native void PoisonMobj (Actor inflictor, Actor source, int damage, int duration, int period, Name type);
 	native double AimLineAttack(double angle, double distance, out FTranslatedLineTarget pLineTarget = null, double vrange = 0., int flags = 0, Actor target = null, Actor friender = null);
 	native Actor, int LineAttack(double angle, double distance, double pitch, int damage, Name damageType, class<Actor> pufftype, int flags = 0, out FTranslatedLineTarget victim = null, double offsetz = 0., double offsetforward = 0., double offsetside = 0.);
+	native bool LineTrace(double angle, double distance, double pitch, int flags = 0, double offsetz = 0., double offsetforward = 0., double offsetside = 0., out FLineTraceData data = null);
 	native bool CheckSight(Actor target, int flags = 0);
 	native bool IsVisible(Actor other, bool allaround, LookExParams params = null);
 	native bool HitFriend();

--- a/wadsrc/static/zscript/constants.txt
+++ b/wadsrc/static/zscript/constants.txt
@@ -897,6 +897,18 @@ enum ELineAttackFlags
 	LAF_ABSPOSITION    = 1 << 7,
 }
 
+enum ELineTraceFlags
+{
+	TRF_ABSPOSITION = 1,
+	TRF_ABSOFFSET = 2,
+	TRF_THRUSPECIES = 4,
+	TRF_THRUACTORS = 8,
+	TRF_THRUBLOCK = 16,
+	TRF_THRUHITSCAN = 32,
+	TRF_NOSKY = 64,
+	TRF_ALLACTORS = 128,
+}
+
 const DEFMELEERANGE = 64;
 const SAWRANGE = (64.+(1./65536.));	// use meleerange + 1 so the puff doesn't skip the flash (i.e. plays all states)
 const MISSILERANGE = (32*64);


### PR DESCRIPTION
Adds P_LineTrace, along with a ZScript LineTrace function on the Actor class. Unlike LineAttack, this is more of a "general" tracer that only gives details on what was hit, including lines, sectors, and 3d floors.

It's obviously far from the export of Trace everyone dreamed of, but I think this should suffice for most users until that's possible.