### PR TITLE
- added Screen.getViewWindow function

### DIFF
--- a/src/v_draw.cpp
+++ b/src/v_draw.cpp
@@ -230,6 +230,15 @@ DEFINE_ACTION_FUNCTION(_Screen, GetClipRect)
 	return MIN(numret, 4);
 }
 
+DEFINE_ACTION_FUNCTION(_Screen, GetViewWindow)
+{
+	PARAM_PROLOGUE;
+	if (numret > 0) ret[0].SetInt(viewwindowx);
+	if (numret > 1) ret[1].SetInt(viewwindowy);
+	if (numret > 2) ret[2].SetInt(viewwidth);
+	if (numret > 3) ret[3].SetInt(viewheight);
+	return MIN(numret, 4);
+}
 
 bool DCanvas::SetTextureParms(DrawParms *parms, FTexture *img, double xx, double yy) const
 {

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -175,6 +175,7 @@ struct Screen native
 	native static void SetClipRect(int x, int y, int w, int h);
 	native static void ClearClipRect();
 	native static int, int, int, int GetClipRect();
+	native static int, int, int, int GetViewWindow();
 	
 	
 	// This is a leftover of the abandoned Inventory.DrawPowerup method.


### PR DESCRIPTION
Adds a getViewWindow function which allows the modder to draw inside the area of the screen that the player can see the game in.