### PR TITLE
Getter to allow other objects to read the m_Sector of a SectorEffect

### DIFF
--- a/src/dsectoreffect.cpp
+++ b/src/dsectoreffect.cpp
@@ -79,6 +79,12 @@ void DSectorEffect::Serialize(FSerializer &arc)
 DEFINE_FIELD(DSectorEffect, m_Sector)
 
 
+DEFINE_ACTION_FUNCTION(DSectorEffect, GetSector)
+{
+	PARAM_SELF_PROLOGUE(DSectorEffect);
+	ACTION_RETURN_POINTER(self->m_Sector);
+}
+
 IMPLEMENT_CLASS(DMover, true, true)
 
 IMPLEMENT_POINTERS_START(DMover)

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -789,6 +789,8 @@ struct StringStruct native
 class SectorEffect : Thinker native
 {
 	native protected Sector m_Sector;
+
+	native clearscope Sector GetSector();
 }
 
 class Mover : SectorEffect native


### PR DESCRIPTION
Since the m_Sector variable should be protected, one way to give read-only access to others would clearly be with a "GetSector" function in the class.