### PR TITLE
Export level sky variables to ZScript and add function to change sky

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -2028,6 +2028,10 @@ DEFINE_FIELD(FLevelLocals, F1Pic)
 DEFINE_FIELD(FLevelLocals, maptype)
 DEFINE_FIELD(FLevelLocals, Music)
 DEFINE_FIELD(FLevelLocals, musicorder)
+DEFINE_FIELD(FLevelLocals, skytexture1)
+DEFINE_FIELD(FLevelLocals, skytexture2)
+DEFINE_FIELD(FLevelLocals, skyspeed1)
+DEFINE_FIELD(FLevelLocals, skyspeed2)
 DEFINE_FIELD(FLevelLocals, total_secrets)
 DEFINE_FIELD(FLevelLocals, found_secrets)
 DEFINE_FIELD(FLevelLocals, total_items)
@@ -2093,3 +2097,19 @@ CCMD(skyfog)
 	}
 }
 
+
+//==========================================================================
+//
+// ZScript counterpart to ACS ChangeSky, uses TextureIDs
+//
+//==========================================================================
+DEFINE_ACTION_FUNCTION(FLevelLocals, ChangeSky)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_INT(sky1);
+	PARAM_INT(sky2);
+	sky1texture = self->skytexture1 = FSetTextureID(sky1);
+	sky2texture = self->skytexture2 = FSetTextureID(sky2);
+	R_InitSkyMap();
+	return 0;
+}

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -591,6 +591,10 @@ struct LevelLocals native
 	native readonly int maptype;
 	native readonly String Music;
 	native readonly int musicorder;
+	native readonly TextureID skytexture1;
+	native readonly TextureID skytexture2;
+	native float skyspeed1;
+	native float skyspeed2;
 	native int total_secrets;
 	native int found_secrets;
 	native int total_items;
@@ -640,7 +644,9 @@ struct LevelLocals native
 	native static clearscope vector3 Vec3Diff(vector3 v1, vector3 v2);
 
 	native String GetChecksum() const;
-	
+
+	native void ChangeSky( TextureID sky1, TextureID sky2 );
+
 	String TimeFormatted(bool totals = false)
 	{
 		int sec = Thinker.Tics2Seconds(totals? totaltime : time); 


### PR DESCRIPTION
With this change, it's no longer needed to interface with ACS from ZScript code to perform changes to sky textures and scroll speeds. Additionally, it gives more freedom on what textures can be assigned.