### PR TITLE
Fix incorrect HitTexture reassignment in LineTrace

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4898,17 +4898,8 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 		outdata->HitLine = trace.Line;
 		outdata->HitSector = trace.Sector;
 		outdata->Hit3DFloor = trace.ffloor;
-		switch ( trace.HitType )
+		if ( trace.HitType == TRACE_HitWall )
 		{
-		case TRACE_HitFloor:
-			outdata->SectorPlane = 0;
-			outdata->HitTexture = trace.Sector->planes[0].Texture;
-			break;
-		case TRACE_HitCeiling:
-			outdata->SectorPlane = 1;
-			outdata->HitTexture = trace.Sector->planes[1].Texture;
-			break;
-		case TRACE_HitWall:
 			outdata->LineSide = trace.Side;
 			int txpart;
 			switch ( trace.Tier )
@@ -4930,9 +4921,8 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 				outdata->HitTexture = trace.ffloor->master->sidedef[0]->textures[txpart].texture;
 				break;
 			}
-		default:
-			break;
 		}
+		else outdata->HitTexture = trace.HitTexture;
 		outdata->HitLocation = trace.HitPos;
 		outdata->Distance = trace.Distance;
 		outdata->NumPortals = TData.NumPortals;


### PR DESCRIPTION
My LineTrace actor function was returning the wrong texture when hitting 3D floor planes, mostly because I made the wrong assumptions about how Trace worked. This has been corrected now.