### PR TITLE
Add lineFlags parameter to LineTracer.Trace

### DIFF
--- a/src/p_trace.cpp
+++ b/src/p_trace.cpp
@@ -992,16 +992,18 @@ DEFINE_ACTION_FUNCTION(DLineTracer, Trace)
 	PARAM_FLOAT(direction_y);
 	PARAM_FLOAT(direction_z);
 	PARAM_FLOAT(maxDist);
-	// actor flags and wall flags are not supported due to how flags are implemented on the ZScript side.
+	// actor flags are not supported due to how flags are implemented on the ZScript side.
 	// say thanks to oversimplifying the user API.
 	PARAM_INT(traceFlags);
+	// line flags ARE supported, actually -- Marisa
+	PARAM_INT(lineFlags);
 
 	// these are internal hacks.
 	traceFlags &= ~(TRACE_PCross | TRACE_Impact);
 
-	// Trace(vector3 start, Sector sector, vector3 direction, double maxDist, ETraceFlags traceFlags)
+	// Trace(vector3 start, Sector sector, vector3 direction, double maxDist, ETraceFlags traceFlags, uint lineFlags)
 	bool res = Trace(DVector3(start_x, start_y, start_z), sector, DVector3(direction_x, direction_y, direction_z), maxDist,
-					 (ActorFlag)0xFFFFFFFF, 0xFFFFFFFF, nullptr, self->Results, traceFlags, &DLineTracer::TraceCallback, self);
+					 (ActorFlag)0xFFFFFFFF, lineFlags, nullptr, self->Results, traceFlags, &DLineTracer::TraceCallback, self);
 	ACTION_RETURN_BOOL(res);
 }
 

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -527,7 +527,7 @@ struct TraceResults native
 class LineTracer : Object native
 {
 	native @TraceResults Results;
-	native bool Trace(vector3 start, Sector sec, vector3 direction, double maxDist, ETraceFlags traceFlags);
+	native bool Trace(vector3 start, Sector sec, vector3 direction, double maxDist, ETraceFlags traceFlags, uint lineFlags);
 
 	virtual ETraceStatus TraceCallback()
 	{


### PR DESCRIPTION
ZZYZX made LineTracer use the mask 0xffffffff. This was problematic because with that, 3D floors get ignored during trace traversal, as the trace stops at any line before first checking for them (see [here](https://github.com/coelckers/gzdoom/blob/master/src/p_trace.cpp#L475-L492)).

I guess one could change the internal behaviour of FTraceInfo::LineCheck to perform the 3D floor check beforehand, but I don't want to risk breaking the whole engine by doing that.

Anyway, by actually letting the user set the line flags mask to stop at, this can be prevented.