### PR TITLE
Fixed HitTexture reassignment in LineTrace (take 2) + Add missing variable for hit direction

### DIFF
--- a/src/p_linetracedata.h
+++ b/src/p_linetracedata.h
@@ -14,6 +14,7 @@ struct FLineTraceData
 	F3DFloor *Hit3DFloor;
 	FTextureID HitTexture;
 	DVector3 HitLocation;
+	DVector3 HitDir;
 	double Distance;
 	int NumPortals;
 	int LineSide;

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4898,17 +4898,8 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 		outdata->HitLine = trace.Line;
 		outdata->HitSector = trace.Sector;
 		outdata->Hit3DFloor = trace.ffloor;
-		switch ( trace.HitType )
+		if ( trace.HitType == TRACE_HitWall )
 		{
-		case TRACE_HitFloor:
-			outdata->SectorPlane = 0;
-			outdata->HitTexture = trace.Sector->planes[0].Texture;
-			break;
-		case TRACE_HitCeiling:
-			outdata->SectorPlane = 1;
-			outdata->HitTexture = trace.Sector->planes[1].Texture;
-			break;
-		case TRACE_HitWall:
 			outdata->LineSide = trace.Side;
 			int txpart;
 			switch ( trace.Tier )
@@ -4930,9 +4921,8 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 				outdata->HitTexture = trace.ffloor->master->sidedef[0]->textures[txpart].texture;
 				break;
 			}
-		default:
-			break;
 		}
+		else outdata->HitTexture = trace.HitTexture;
 		outdata->HitLocation = trace.HitPos;
 		outdata->Distance = trace.Distance;
 		outdata->NumPortals = TData.NumPortals;

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -4898,6 +4898,7 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 		outdata->HitLine = trace.Line;
 		outdata->HitSector = trace.Sector;
 		outdata->Hit3DFloor = trace.ffloor;
+		outdata->SectorPlane = (trace.HitType == TRACE_HitCeiling) ? 1 : 0;
 		if ( trace.HitType == TRACE_HitWall )
 		{
 			outdata->LineSide = trace.Side;
@@ -4924,6 +4925,7 @@ bool P_LineTrace(AActor *t1, DAngle angle, double distance,
 		}
 		else outdata->HitTexture = trace.HitTexture;
 		outdata->HitLocation = trace.HitPos;
+		outdata->HitDir = trace.HitVector;
 		outdata->Distance = trace.Distance;
 		outdata->NumPortals = TData.NumPortals;
 		outdata->HitType = trace.HitType;

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -47,6 +47,7 @@ struct FLineTraceData
 	F3DFloor Hit3DFloor;
 	TextureID HitTexture;
 	Vector3 HitLocation;
+	Vector3 HitDir;
 	double Distance;
 	int NumPortals;
 	int LineSide;


### PR DESCRIPTION
This time I didn't forget about the SectorPlane assignment.

Also, sorry for sneaking it into the same commit, but I added a variable that was missing from the struct: The direction vector of the trace when hitting something. I hadn't realised its importance when I first wrote LineTrace.