### PR TITLE
Ceiling portal crash bug fix

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -2707,7 +2707,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 		FLinkContext ctx;
 		DVector3 oldpos = thing->Pos();
 		thing->UnlinkFromWorld(&ctx);
-		thing->SetXYZ(thing->PosRelative(thing->Sector->GetOppositePortalGroup(sector_t::ceiling)));
+		thing->SetXYZ(thing->PosRelative(oldsec->GetOppositePortalGroup(sector_t::ceiling)));
 		thing->Prev = thing->Pos() - oldpos;
 		thing->Sector = P_PointInSector(thing->Pos());
 		thing->PrevPortalGroup = thing->Sector->PortalGroup;


### PR DESCRIPTION
This change fixes the issue presented here: https://forum.zdoom.org/viewtopic.php?f=2&t=58193
In Brutal Doom, shooting at ledges of ceiling portals caused hard crashes (e.g. with two rooms atop each other with a ceiling hole between them). Debugging my way through, it seems that a thing (probably a spark from the assault rifle) not only moved vertically, but also horizontally at the same time, leaving the original sector and ultimately causing this lookup to fail with an invalid memory access.
I can't be totally sure that this is the way to fix it, but it fits with
- "oldsec" is in use in the preceding section (// [RH] Check for crossing fake floor/ceiling, for the purpose of crossing a ceiling portal)
- "oldpos" in use in close proximity (next line)
--
This is my first ever pull request on Github. I registered just so I could suggest this solution. :>