### PR TITLE
Fix typo that made DepleteAmmo always use Secondary Ammo

### DIFF
--- a/src/g_inventory/a_weapons.cpp
+++ b/src/g_inventory/a_weapons.cpp
@@ -324,7 +324,7 @@ bool AWeapon::DepleteAmmo(bool altFire, bool checkEnough, int ammouse)
 {
 	IFVIRTUAL(AWeapon, DepleteAmmo)
 	{
-		VMValue params[] = { (DObject*)this, AltFire, checkEnough, ammouse };
+		VMValue params[] = { (DObject*)this, altFire, checkEnough, ammouse };
 		VMReturn ret;
 		int retval;
 		ret.IntAt(&retval);


### PR DESCRIPTION
https://forum.zdoom.org/viewtopic.php?f=2&p=1038209