### PR TITLE
Make the ACS string pool reserve more strings

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -1284,7 +1284,7 @@ int ACSStringPool::InsertString(FString &str, unsigned int h, unsigned int bucke
 	}
 	if (index == Pool.Size())
 	{ // There were no free entries; make a new one.
-		Pool.Reserve(1);
+		Pool.Reserve(MIN_GC_SIZE);
 		FirstFreeEntry++;
 	}
 	else


### PR DESCRIPTION
Due to only reserving a single new string when growing the string pool, any ACS code that generates lots of strings will eventually cause massive amounts of lag, to the point where ACSStringPool takes up *most of the execution time*. The proposed change fixes this issue.