### PR TITLE
Make sidedef vertex and secplane height get functions callable from ui

### DIFF
--- a/wadsrc/static/zscript/mapdata.txt
+++ b/wadsrc/static/zscript/mapdata.txt
@@ -80,8 +80,8 @@ struct Side native play
 	//native DInterpolation *SetInterpolation(int position);
 	//native void StopInterpolation(int position);
 
-	native Vertex V1();
-	native Vertex V2();
+	native clearscope Vertex V1();
+	native clearscope Vertex V2();
 
 	native int Index();
 	
@@ -179,7 +179,7 @@ struct SecPlane native play
 	
 	native bool isSlope() const;
 	native int PointOnSide(Vector3 pos) const;
-	native double ZatPoint (Vector2 v) const;
+	native clearscope double ZatPoint (Vector2 v) const;
 	native double ZatPointDist(Vector2 v, double dist) const;
 	native bool isEqual(Secplane other) const;
 	native void ChangeHeight(double hdiff);


### PR DESCRIPTION
With these I can, for example, imitate how Doom64EX highlights usable lines (see [example wad](https://github.com/coelckers/gzdoom/files/1777611/usewalls_m.zip)).

![screenshot_doom_20180303_161227](https://user-images.githubusercontent.com/2286785/36936209-479c6f1a-1f02-11e8-8ac9-5e9326f5495e.png)

Of course without triangle drawing I can't do a proper highlight, but that's something for another time.