### PR TITLE
Fix wrapped midtexture holes in Carmack renderer

### DIFF
--- a/src/swrenderer/line/r_renderdrawsegment.cpp
+++ b/src/swrenderer/line/r_renderdrawsegment.cpp
@@ -155,11 +155,8 @@ namespace swrenderer
 		{
 			if (clip3d->fake3D & FAKE3D_REFRESHCLIP)
 			{
-				if (!wrap)
-				{
-					assert(ds->bkup != nullptr);
-					memcpy(ds->sprtopclip, ds->bkup, (ds->x2 - ds->x1) * 2);
-				}
+				assert(ds->bkup != nullptr);
+				memcpy(ds->sprtopclip, ds->bkup, (ds->x2 - ds->x1) * 2);
 			}
 			else
 			{


### PR DESCRIPTION
Per [this thread](https://forum.zdoom.org/viewtopic.php?f=56&t=59355), wrapped midtextures get "holes" punched into them by sprites when a 3D floor is in view.  This regression was introduced in GZDoom 2.2.0, and is the result of an [old bugfix* commit](https://github.com/coelckers/gzdoom/commit/f3d273c94f791a0813ff7d8ffce0414c2192d6c4) of Randi's; this PR simply removes the added check, restoring the previous (working) behavior.

[*I've searched around and couldn't find any reference to the bug Randi fixed on the forums, nor have I seen the symptoms described in that commit in the wild. Suffice to say the change made things way worse, so it's best to revert to the last known working behavior given the circumstances.]