### PR TITLE
Add PostUiTick, to handle changes in play within the same tic

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -509,6 +509,7 @@ DEFINE_EVENT_LOOPER(RenderFrame)
 DEFINE_EVENT_LOOPER(WorldLightning)
 DEFINE_EVENT_LOOPER(WorldTick)
 DEFINE_EVENT_LOOPER(UiTick)
+DEFINE_EVENT_LOOPER(PostUiTick)
 
 // declarations
 IMPLEMENT_CLASS(DStaticEventHandler, false, true);
@@ -640,6 +641,7 @@ DEFINE_EMPTY_HANDLER(DStaticEventHandler, PlayerDisconnected)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, UiProcess);
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, InputProcess);
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, UiTick);
+DEFINE_EMPTY_HANDLER(DStaticEventHandler, PostUiTick);
 
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, ConsoleProcess);
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, NetworkProcess);
@@ -1015,6 +1017,18 @@ void DStaticEventHandler::UiTick()
 	{
 		// don't create excessive DObjects if not going to be processed anyway
 		if (func == DStaticEventHandler_UiTick_VMPtr)
+			return;
+		VMValue params[1] = { (DStaticEventHandler*)this };
+		VMCall(func, params, 1, nullptr, 0);
+	}
+}
+
+void DStaticEventHandler::PostUiTick()
+{
+	IFVIRTUAL(DStaticEventHandler, PostUiTick)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (func == DStaticEventHandler_PostUiTick_VMPtr)
 			return;
 		VMValue params[1] = { (DStaticEventHandler*)this };
 		VMCall(func, params, 1, nullptr, 0);

--- a/src/events.h
+++ b/src/events.h
@@ -46,6 +46,8 @@ void E_WorldLightning();
 void E_WorldTick();
 // this executes on every tick on UI side, always
 void E_UiTick();
+// this executes on every tick on UI side, always AND immediately after everything else
+void E_PostUiTick();
 // called on each render frame once.
 void E_RenderFrame();
 // called after everything's been rendered, but before console/menus
@@ -154,6 +156,7 @@ public:
 	bool InputProcess(const event_t* ev);
 	bool UiProcess(const event_t* ev);
 	void UiTick();
+	void PostUiTick();
 	
 	// 
 	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual);

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1256,6 +1256,9 @@ void G_Ticker ()
 	default:
 		break;
 	}
+
+	// [MK] Additional ticker for UI events right after all others
+	E_PostUiTick();
 }
 
 

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -317,6 +317,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual native ui bool UiProcess(UiEvent e);
     virtual native ui bool InputProcess(InputEvent e);
     virtual native ui void UiTick();
+    virtual native ui void PostUiTick();
     
     //
     virtual native ui void ConsoleProcess(ConsoleEvent e);


### PR DESCRIPTION
Due to the "1 tic delay" inconvenience of when UiTick happens, and in order to not screw up any existing mods, I decided to add a "PostUiTick" that happens immediately after all other tickers.

With this it's pretty simple to "send" data from play to ui instantly.