### PR TITLE
Add support for string and float user properties in UDMF things

### DIFF
--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5065,10 +5065,10 @@ bool GetVarAddrType(AActor *self, FName varname, int index, void *&addr, PType *
 	}
 	addr = baddr;
 	// We don't want Int subclasses like Name or Color to be accessible here.
-	if (!type->isInt() && !type->isFloat() && type != TypeBool)
+	if (!type->isInt() && !type->isFloat() && type != TypeBool && type != TypeString)
 	{
-		// For reading, we also support Name and String types.
-		if (readonly && (type == TypeName || type == TypeString))
+		// For reading, we also support Name types.
+		if (readonly && (type == TypeName))
 		{
 			return true;
 		}
@@ -5084,13 +5084,18 @@ static void SetUserVariable(AActor *self, FName varname, int index, int value)
 
 	if (GetVarAddrType(self, varname, index, addr, type, false))
 	{
-		if (!type->isFloat())
+		if (type == TypeString)
 		{
-			type->SetValue(addr, value);
+			FString str = FBehavior::StaticLookupString(value);
+			type->InitializeValue(addr, &str);
+		}
+		else if (type->isFloat())
+		{
+			type->SetValue(addr, ACSToDouble(value));
 		}
 		else
 		{
-			type->SetValue(addr, ACSToDouble(value));
+			type->SetValue(addr, value);
 		}
 	}
 }

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -1658,7 +1658,7 @@ static void SetMapThingUserData(AActor *actor, unsigned udi)
 		else
 		{ // Set the value of the specified user variable.
 			void *addr = reinterpret_cast<uint8_t *>(actor) + var->Offset;
-			if (var->Type->isString())
+			if (var->Type == TypeString)
 			{
 				var->Type->InitializeValue(addr, &MapThingsUserData[udi].StringVal);
 			}
@@ -1666,7 +1666,7 @@ static void SetMapThingUserData(AActor *actor, unsigned udi)
 			{
 				var->Type->SetValue(addr, MapThingsUserData[udi].FloatVal);
 			}
-			else if (var->Type->isIntCompatible())
+			else if (var->Type->isInt() || var->Type == TypeBool)
 			{
 				var->Type->SetValue(addr, MapThingsUserData[udi].IntVal);
 			}

--- a/src/p_setup.h
+++ b/src/p_setup.h
@@ -30,6 +30,7 @@
 
 #include "resourcefiles/resourcefile.h"
 #include "doomdata.h"
+#include "r_defs.h"
 
 
 struct MapData
@@ -180,14 +181,8 @@ struct FMissingCount
 };
 typedef TMap<FString,FMissingCount> FMissingTextureTracker;
 
-// Record of user data for UDMF maps
-struct FMapThingUserData
-{
-	FName Property;
-	int Value;
-};
 extern TMap<unsigned,unsigned> MapThingsUserDataIndex;	// from mapthing idx -> user data idx
-extern TArray<FMapThingUserData> MapThingsUserData;
+extern TArray<FUDMFKey> MapThingsUserData;
 
 
 #endif

--- a/src/p_udmf.cpp
+++ b/src/p_udmf.cpp
@@ -476,38 +476,7 @@ public:
 		fogMap = normMap = NULL;
 	}
 
-	void AddUserKey(FName key, int kind, int index)
-	{
-		FUDMFKeys &keyarray = UDMFKeys[kind][index];
-
-		for(unsigned i=0; i < keyarray.Size(); i++)
-		{
-			if (keyarray[i].Key == key)
-			{
-				switch (sc.TokenType)
-				{
-				case TK_IntConst:
-					keyarray[i] = sc.Number;
-					break;
-				case TK_FloatConst:
-					keyarray[i] = sc.Float;
-					break;
-				default:
-				case TK_StringConst:
-					keyarray[i] = parsedString;
-					break;
-				case TK_True:
-					keyarray[i] = 1;
-					break;
-				case TK_False:
-					keyarray[i] = 0;
-					break;
-				}
-				return;
-			}
-		}
-		FUDMFKey ukey;
-		ukey.Key = key;
+  void ReadUserKey(FUDMFKey &ukey) {
 		switch (sc.TokenType)
 		{
 		case TK_IntConst:
@@ -527,6 +496,22 @@ public:
 			ukey = 0;
 			break;
 		}
+  }
+	void AddUserKey(FName key, int kind, int index)
+	{
+		FUDMFKeys &keyarray = UDMFKeys[kind][index];
+
+		for(unsigned i=0; i < keyarray.Size(); i++)
+		{
+			if (keyarray[i].Key == key)
+			{
+				ReadUserKey(keyarray[i]);
+				return;
+			}
+		}
+		FUDMFKey ukey;
+		ukey.Key = key;
+		ReadUserKey(ukey);
 		keyarray.Push(ukey);
 	}
 
@@ -809,10 +794,10 @@ public:
 				CHECK_N(Zd | Zdt)
 				if (0 == strnicmp("user_", key.GetChars(), 5))
 				{ // Custom user key - Sets an actor's user variable directly
-					FMapThingUserData ud;
-					ud.Property = key;
-					ud.Value = CheckInt(key);
-					MapThingsUserData.Push(ud);
+					FUDMFKey ukey;
+					ukey.Key = key;
+					ReadUserKey(ukey);
+					MapThingsUserData.Push(ukey);
 				}
 				break;
 			}
@@ -2111,10 +2096,10 @@ public:
 				{ // User data added
 					MapThingsUserDataIndex[MapThingsConverted.Size()-1] = userdatastart;
 					// Mark end of the user data for this map thing
-					FMapThingUserData ud;
-					ud.Property = NAME_None;
-					ud.Value = 0;
-					MapThingsUserData.Push(ud);
+					FUDMFKey ukey;
+					ukey.Key = NAME_None;
+					ukey = 0;
+					MapThingsUserData.Push(ukey);
 				}
 			}
 			else if (sc.Compare("linedef"))

--- a/src/scripting/types.h
+++ b/src/scripting/types.h
@@ -200,6 +200,7 @@ public:
 	bool isStruct() const { return TypeTableType == NAME_Struct; }
 	bool isClass() const { return TypeTableType == NAME_Object; }
 	bool isPrototype() const { return TypeTableType == NAME_Prototype; }
+	bool isString() const { return TypeTableType == NAME_String; }
 
 	PContainerType *toContainer() { return isContainer() ? (PContainerType*)this : nullptr; }
 	PPointer *toPointer() { return isPointer() ? (PPointer*)this : nullptr; }

--- a/src/scripting/types.h
+++ b/src/scripting/types.h
@@ -200,7 +200,6 @@ public:
 	bool isStruct() const { return TypeTableType == NAME_Struct; }
 	bool isClass() const { return TypeTableType == NAME_Object; }
 	bool isPrototype() const { return TypeTableType == NAME_Prototype; }
-	bool isString() const { return TypeTableType == NAME_String; }
 
 	PContainerType *toContainer() { return isContainer() ? (PContainerType*)this : nullptr; }
 	PPointer *toPointer() { return isPointer() ? (PPointer*)this : nullptr; }


### PR DESCRIPTION
Previously the UDMF parser only accepted integer values for thing properties prefixed with "user_", even though strings and floats were supported in linedef/sidedef/sector properties. With this patch things support those extra types now too.

Test map: [udmfusertest.zip](https://github.com/coelckers/gzdoom/files/1825445/udmfusertest.zip)
