### PR TITLE
Adds WorldLineActivated to event handlers

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -40,6 +40,8 @@ void E_WorldThingRevived(AActor* actor);
 void E_WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 // called before AActor::Destroy of each actor.
 void E_WorldThingDestroyed(AActor* actor);
+// called in P_ActivateLine after successful special execution.
+void E_WorldLineActivated(line_t* line, AActor* actor);
 // same as ACS SCRIPT_Lightning
 void E_WorldLightning();
 // this executes on every tick, before everything, only when in valid level and not paused
@@ -137,6 +139,7 @@ public:
 	void WorldThingRevived(AActor*);
 	void WorldThingDamaged(AActor*, AActor*, AActor*, int, FName, int, DAngle);
 	void WorldThingDestroyed(AActor*);
+	void WorldLineActivated(line_t*, AActor*);
 	void WorldLightning();
 	void WorldTick();
 
@@ -192,6 +195,8 @@ struct FWorldEvent
 	FName DamageType;
 	int DamageFlags = 0;
 	DAngle DamageAngle;
+	// for lineactivated
+	line_t* ActivatedLine = nullptr;
 };
 
 struct FPlayerEvent

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -188,8 +188,10 @@ bool P_ActivateLine (line_t *line, AActor *mo, int side, int activationType, DVe
 	{
 		return false;
 	}
+
 	bool remote = (line->special != 7 && line->special != 8 && (line->special < 11 || line->special > 14));
 	if (line->locknumber > 0 && !P_CheckKeys (mo, line->locknumber, remote)) return false;
+
 	lineActivation = line->activation;
 	repeat = line->flags & ML_REPEAT_SPECIAL;
 	buttonSuccess = false;
@@ -197,6 +199,9 @@ bool P_ActivateLine (line_t *line, AActor *mo, int side, int activationType, DVe
 					line, mo, side == 1, line->args[0],
 					line->args[1], line->args[2],
 					line->args[3], line->args[4]);
+
+	// [MK] Fire up WorldLineActivated
+	if ( buttonSuccess ) E_WorldLineActivated(line, mo);
 
 	special = line->special;
 	if (!repeat && buttonSuccess)

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -25,6 +25,8 @@ struct WorldEvent native play version("2.4")
     native readonly Name DamageType;
     native readonly EDmgFlags DamageFlags;
     native readonly double DamageAngle;
+    // for lineactivated
+    native readonly Line ActivatedLine;
 }
 
 struct PlayerEvent native play version("2.4")
@@ -300,6 +302,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual native void WorldThingRevived(WorldEvent e);
     virtual native void WorldThingDamaged(WorldEvent e);
     virtual native void WorldThingDestroyed(WorldEvent e);
+    virtual native void WorldLineActivated(WorldEvent e);
     virtual native void WorldLightning(WorldEvent e); // for the sake of completeness.
     virtual native void WorldTick();
 


### PR DESCRIPTION
Allows special actions to be performed after successful activation of a line.

Example usage in attached wad (alert monsters when a switch is pressed or a door is opened): [noisyactivation_m.zip](https://github.com/coelckers/gzdoom/files/1826934/noisyactivation_m.zip)