### PR TITLE
Setup for ADLMIDI and OPNMIDI and some fixes

### DIFF
--- a/src/menu/menudef.cpp
+++ b/src/menu/menudef.cpp
@@ -1381,7 +1381,11 @@ static void InitCrosshairsList()
 // Initialize the music configuration submenus
 //
 //=============================================================================
-extern const char* const banknames[74];
+extern "C"
+{
+	extern int adl_getBanksCount();
+	extern const char *const *adl_getBankNames();
+}
 
 static void InitMusicMenus()
 {
@@ -1427,11 +1431,12 @@ static void InitMusicMenus()
 	{
 		if (soundfonts.Size() > 0)
 		{
-			for(int i=0;i<74;i++)
+			int adl_banks_count = adl_getBanksCount();
+			const char *const *adl_bank_names = adl_getBankNames();
+			for(int i=0; i < adl_banks_count; i++)
 			{
-				auto it = CreateOptionMenuItemCommand(banknames[i], FStringf("adl_bank %d", i), true);
+				auto it = CreateOptionMenuItemCommand(adl_bank_names[i], FStringf("adl_bank %d", i), true);
 				static_cast<DOptionMenuDescriptor*>(*menu)->mItems.Push(it);
-				i++;
 			}
 		}
 	}

--- a/src/sound/mididevices/music_adlmidi_mididevice.cpp
+++ b/src/sound/mididevices/music_adlmidi_mididevice.cpp
@@ -54,7 +54,23 @@ enum
 	ME_PITCHWHEEL = 0xE0
 };
 
+CUSTOM_CVAR(Int, adl_chips_count, 6, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (currSong != nullptr && currSong->GetDeviceType() == MDEV_ADL)
+	{
+		MIDIDeviceChanged(-1, true);
+	}
+}
+
 CUSTOM_CVAR(Int, adl_bank, 14, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (currSong != nullptr && currSong->GetDeviceType() == MDEV_ADL)
+	{
+		MIDIDeviceChanged(-1, true);
+	}
+}
+
+CUSTOM_CVAR(Int, adl_volume_model, ADLMIDI_VolumeModel_DMX, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
 	if (currSong != nullptr && currSong->GetDeviceType() == MDEV_ADL)
 	{
@@ -74,7 +90,9 @@ ADLMIDIDevice::ADLMIDIDevice(const char *args)
 	Renderer = adl_init(44100);	// todo: make it configurable
 	if (Renderer != nullptr)
 	{
-		adl_setBank(Renderer, 14);
+		adl_setBank(Renderer, (int)adl_bank);
+		adl_setNumChips(Renderer, (int)adl_chips_count);
+		adl_setVolumeRangeModel(Renderer, (int)adl_volume_model);
 	}
 }
 

--- a/src/sound/mididevices/music_opnmidi_mididevice.cpp
+++ b/src/sound/mididevices/music_opnmidi_mididevice.cpp
@@ -55,6 +55,14 @@ enum
 	ME_PITCHWHEEL = 0xE0
 };
 
+CUSTOM_CVAR(Int, opn_chips_count, 8, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (currSong != nullptr && currSong->GetDeviceType() == MDEV_OPN)
+	{
+		MIDIDeviceChanged(-1, true);
+	}
+}
+
 //==========================================================================
 //
 // OPNMIDIDevice Constructor
@@ -73,7 +81,8 @@ OPNMIDIDevice::OPNMIDIDevice(const char *args)
 			I_Error("No OPN bank found");
 		}
 		FMemLump data = Wads.ReadLump(lump);
-		opn2_openBankData(Renderer, data.GetMem(), data.GetSize());
+		opn2_openBankData(Renderer, data.GetMem(), (long)data.GetSize());
+		opn2_setNumChips(Renderer, opn_chips_count);
 	}
 }
 

--- a/src/sound/mididevices/music_opnmidi_mididevice.cpp
+++ b/src/sound/mididevices/music_opnmidi_mididevice.cpp
@@ -70,7 +70,7 @@ OPNMIDIDevice::OPNMIDIDevice(const char *args)
 		int lump = Wads.CheckNumForFullName("xg.wopn");
 		if (lump < 0)
 		{
-			I_Error("No OPL bank found");
+			I_Error("No OPN bank found");
 		}
 		FMemLump data = Wads.ReadLump(lump);
 		opn2_openBankData(Renderer, data.GetMem(), data.GetSize());

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -792,31 +792,31 @@ OB_MPPSKULLROD = "%k poured %p hellstaff on %o.";
 OB_MPPPHOENIXROD = "%o was burned down by %k's phoenix staff.";
 OB_MPPMACE = "%o was squished by %k's giant mace sphere.";
 
-OB_MPFWEAPFIST = "%o was beaten to a pulp by %k's bare fists."; 
-OB_MPFWEAPAXE = "%o got the axe from %k."; 
-OB_MPFWEAPHAMMERM = "%o had %p head caved in by %k's hammer."; 
-OB_MPFWEAPHAMMERR = "%o's soul was forged anew by %k's hammer."; 
-OB_MPFWEAPQUIETUS = "%o was silenced by %k's mighty Quietus."; 
-OB_MPCWEAPMACE = "%o got a mace to the face from %k."; 
-OB_MPCWEAPSTAFFM = "%o was bitten by %k's serpent staff."; 
-OB_MPCWEAPSTAFFR = "%o choked on %k's serpent staff."; 
-OB_MPCWEAPFLAME = "%o was lit up by %k's flames."; 
-OB_MPCWEAPWRAITHVERGE = "%o was cleansed by %k's Wraithverge."; 
-OB_MPMWEAPWAND = "%o took one too many sapphire beams from %k."; 
-OB_MPMWEAPFROST = "%o was turned into a frosty fellow by %k."; 
-OB_MPMWEAPLIGHTNING = "%o recieved a shocking revelation from %k."; 
+OB_MPFWEAPFIST = "%o was beaten to a pulp by %k's bare fists.";
+OB_MPFWEAPAXE = "%o got the axe from %k.";
+OB_MPFWEAPHAMMERM = "%o had %p head caved in by %k's hammer.";
+OB_MPFWEAPHAMMERR = "%o's soul was forged anew by %k's hammer.";
+OB_MPFWEAPQUIETUS = "%o was silenced by %k's mighty Quietus.";
+OB_MPCWEAPMACE = "%o got a mace to the face from %k.";
+OB_MPCWEAPSTAFFM = "%o was bitten by %k's serpent staff.";
+OB_MPCWEAPSTAFFR = "%o choked on %k's serpent staff.";
+OB_MPCWEAPFLAME = "%o was lit up by %k's flames.";
+OB_MPCWEAPWRAITHVERGE = "%o was cleansed by %k's Wraithverge.";
+OB_MPMWEAPWAND = "%o took one too many sapphire beams from %k.";
+OB_MPMWEAPFROST = "%o was turned into a frosty fellow by %k.";
+OB_MPMWEAPLIGHTNING = "%o recieved a shocking revelation from %k.";
 OB_MPMWEAPBLOODSCOURGE = "%o was wiped off the face of the universe by %k's Bloodscourge.";
 
-OB_MPPUNCHDAGGER = "%o was unwittingly backstabbed by %k."; 
-OB_MPELECTRICBOLT = "%o got bolted to the wall by %k."; 
-OB_MPPOISONBOLT = "%o recieved a lethal dose of %k's wrath."; 
-OB_MPASSAULTGUN = "%o was drilled full of holes by %k's assault gun."; 
-OB_MPMINIMISSILELAUNCHER = "%o gulped down %k's missile."; 
-OB_MPSTRIFEGRENADE = "%o was inverted by %k's H-E grenade."; 
-OB_MPPHOSPHOROUSGRENADE = "%o took a flame bath in %k's phosphorous pyre."; 
-OB_MPFLAMETHROWER = "%o was barbecued by %k."; 
+OB_MPPUNCHDAGGER = "%o was unwittingly backstabbed by %k.";
+OB_MPELECTRICBOLT = "%o got bolted to the wall by %k.";
+OB_MPPOISONBOLT = "%o recieved a lethal dose of %k's wrath.";
+OB_MPASSAULTGUN = "%o was drilled full of holes by %k's assault gun.";
+OB_MPMINIMISSILELAUNCHER = "%o gulped down %k's missile.";
+OB_MPSTRIFEGRENADE = "%o was inverted by %k's H-E grenade.";
+OB_MPPHOSPHOROUSGRENADE = "%o took a flame bath in %k's phosphorous pyre.";
+OB_MPFLAMETHROWER = "%o was barbecued by %k.";
 OB_MPMAULER1 = "%o was zapped by %k.";
-OB_MPMAULER = "%o was viciously vaporized by %k."; 
+OB_MPMAULER = "%o was viciously vaporized by %k.";
 OB_MPSIGIL = "%o bowed down to the sheer power of %k's Sigil.";
 
 // Same as OB_MPTELEFRAG, but shown when a monster telefrags you
@@ -1626,13 +1626,13 @@ MNU_KNIGHT			= "KNIGHT";
 MNU_WARRIOR			= "WARRIOR";
 MNU_BERSERKER		= "BERSERKER";
 MNU_TITAN			= "TITAN";
-                                    
+
 MNU_ALTARBOY		= "ALTAR BOY";
 MNU_ACOLYTE			= "ACOLYTE";
 MNU_PRIEST			= "PRIEST";
 MNU_CARDINAL		= "CARDINAL";
 MNU_POPE			= "POPE";
-                                    
+
 MNU_APPRENTICE		= "APPRENTICE";
 MNU_ENCHANTER		= "ENCHANTER";
 MNU_SORCERER        = "SORCERER";
@@ -1968,13 +1968,13 @@ MAPCOLORMNU_TITLE 						= "CUSTOMIZE MAP COLORS";
 MAPCOLORMNU_DEFAULTMAPCOLORS			= "Restore default custom colors";
 MAPCOLORMNU_BACKCOLOR 					= "Background";
 MAPCOLORMNU_YOURCOLOR 					= "You";
-MAPCOLORMNU_WALLCOLOR 					= "1-sided walls";	
-MAPCOLORMNU_FDWALLCOLOR 				= "2-sided walls with different floors";		
+MAPCOLORMNU_WALLCOLOR 					= "1-sided walls";
+MAPCOLORMNU_FDWALLCOLOR 				= "2-sided walls with different floors";
 MAPCOLORMNU_CDWALLCOLOR 				= "2-sided walls with different ceilings";
-MAPCOLORMNU_EFWALLCOLOR 				= "2-sided walls with 3D floors";	
+MAPCOLORMNU_EFWALLCOLOR 				= "2-sided walls with 3D floors";
 MAPCOLORMNU_GRIDCOLOR 					= "Map grid";
 MAPCOLORMNU_XHAIRCOLOR 					= "Center point";
-MAPCOLORMNU_NOTSEENCOLOR 				= "Not-yet-seen walls";		
+MAPCOLORMNU_NOTSEENCOLOR 				= "Not-yet-seen walls";
 MAPCOLORMNU_LOCKEDCOLOR 				= "Locked doors";
 MAPCOLORMNU_INTRALEVELCOLOR				= "Teleporter to the same map";
 MAPCOLORMNU_INTERLEVELCOLOR 			= "Teleporter to a different map";
@@ -1982,7 +1982,7 @@ MAPCOLORMNU_SECRETSECTORCOLOR 			= "Secret sector";
 MAPCOLORMNU_UNEXPLOREDSECRETCOLOR 		= "Unexplored secret";
 MAPCOLORMNU_SPECIALWALLCOLOR			= "Special trigger lines";
 MAPCOLORMNU_CHEATMODE					= "Cheat Mode";
-MAPCOLORMNU_TSWALLCOLOR					= "Invisible 2-sided walls";	
+MAPCOLORMNU_TSWALLCOLOR					= "Invisible 2-sided walls";
 MAPCOLORMNU_SECRETWALLCOLOR				= "Secret walls";
 MAPCOLORMNU_THINGCOLOR					= "Actors";
 MAPCOLORMNU_MONSTERCOLOR				= "Monsters";
@@ -2024,7 +2024,7 @@ SCRBRDMNU_TEAMDEATHMATCH	= "Team Deathmatch Options";
 
 // Gameplay Menu
 GMPLYMNU_TITLE				= "GAMEPLAY OPTIONS";
-GMPLYMNU_TEAMPLAY			= "Teamplay";		
+GMPLYMNU_TEAMPLAY			= "Teamplay";
 GMPLYMNU_TEAMDAMAGE			= "Team damage scalar";
 GMPLYMNU_SMARTAUTOAIM		= "Smart Autoaim";
 GMPLYMNU_FALLINGDAMAGE		= "Falling damage";
@@ -2184,6 +2184,17 @@ ADVSNDMNU_FREEVERB			= "Freeverb";
 ADVSNDMNU_GLOBAL_FREEVERB	= "Global Freeverb";
 ADVSNDMNU_ADVRESAMPLING		= "Advanced Resampling";
 ADVSNDMNU_OPLBANK			= "OPL Bank";
+ADVSNDMNU_ADLNUMCHIPS		= "Number of emulated OPL chips";
+ADVSNDMNU_VLMODEL			= "Volume model";
+ADVSNDMNU_OPNNUMCHIPS		= "Number of emulated OPN chips";
+
+// ADLMIDI's volume models
+ADLVLMODEL_AUTO				= "Auto (Use setup of bank)";
+ADLVLMODEL_GENERIC			= "Generic";
+ADLVLMODEL_NATIVE			= "OPL Native";
+ADLVLMODEL_DMX				= "DMX";
+ADLVLMODEL_APOGEE			= "Apogee";
+ADLVLMODEL_WIN9X			= "Win9X-like";
 
 // Module Replayer Options
 MODMNU_TITLE			= "MODULE REPLAYER OPTIONS";
@@ -2607,8 +2618,8 @@ OB_MPLAZ_BOOM = "%o fell prey to %k's LAZ device.";
 OB_MPLAZ_SPLASH = "%o was lazzed by %k.";
 
 // Music names for Doom. These are needed in the string table only so that they can
-// be replaced by Dehacked. 
-// Note that these names are not prefixed with 'd_' because that's how Dehacked patches 
+// be replaced by Dehacked.
+// Note that these names are not prefixed with 'd_' because that's how Dehacked patches
 // expect them.
 
 MUSIC_E1M1 = "e1m1";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -65,7 +65,7 @@ LISTMENU "MainMenu"
 		StaticPatch 278, 80, "FBULA0"
 		Position 110, 56
 	}
-	
+
 	IfGame(Doom, Strife, Chex)
 	{
 		PatchItem "M_NGAME", "n", "PlayerclassMenu"
@@ -87,7 +87,7 @@ LISTMENU "MainMenu"
 		}
 		PatchItem "M_QUITG", "q", "QuitMenu"
 	}
-	
+
 	IfGame(Heretic, Hexen)
 	{
 		TextItem "$MNU_NEWGAME", "n", "PlayerclassMenu"
@@ -399,7 +399,7 @@ ListMenu "PlayerMenu"
 		MouseWindow 0, 220
 		PlayerDisplay 220, 80, "00 07 00", "40 53 40", 1, "PlayerDisplay"
 	}
-	
+
 	ValueText "$PLYRMNU_TEAM", "Team"
 	ValueText "$PLYRMNU_PLAYERCOLOR", "Color"
 	Linespacing 10
@@ -581,7 +581,7 @@ OptionMenu "JoystickOptionsDefaults" protected
 	StaticTextSwitchable "$JOYMNU_NOCON", "$JOYMNU_CONFIG", "ConfigureMessage"
 	StaticTextSwitchable " ", "$JOYMNU_DISABLED1", "ConnectMessage1"
 	StaticTextSwitchable " ", "$JOYMNU_DISABLED2", "ConnectMessage2"
-	
+
 	// The rest will be filled in by joystick code if devices get connected or disconnected
 }
 
@@ -702,7 +702,7 @@ OptionValue GPUSwitch
 {
 	0.0, "$OPTVAL_DEFAULT"
 	1.0, "$OPTVAL_DEDICATED"
-	2.0, "$OPTVAL_INTEGRATED"	
+	2.0, "$OPTVAL_INTEGRATED"
 }
 
 
@@ -731,7 +731,7 @@ OptionMenu "SWROptions" protected
 OptionMenu "VideoOptions" protected
 {
 	Title "$DSPLYMNU_TITLE"
-	
+
 	Submenu "$DSPLYMNU_GLOPT", 			"OpenGLOptions"
 	Submenu "$DSPLYMNU_SWOPT", 			"SWROptions"
 	Submenu "$GLMNU_DYNLIGHT",			"GLLightOptions"
@@ -758,7 +758,7 @@ OptionMenu "VideoOptions" protected
 	{
 		Option	"$DSPLYMNU_SHOWENDOOM",			"showendoom", "Endoom"
 	}
-	
+
 	Option "$DSPLYMNU_DRAWFUZZ",				"r_drawfuzz", "Fuzziness"
 	Option "$DSPLYMNU_OLDTRANS",				"r_vanillatrans", "VanillaTrans"
 	Slider "$DSPLYMNU_TRANSSOUL",				"transsouls", 0.25, 1.0, 0.05, 2
@@ -791,7 +791,7 @@ OptionMenu "VideoOptions" protected
 //
 //-------------------------------------------------------------------------------------------
 
-OptionValue DisplayTagsTypes 
+OptionValue DisplayTagsTypes
 {
 	0.0, "$OPTVAL_NONE"
 	1.0, "$OPTVAL_ITEMS"
@@ -1144,44 +1144,44 @@ OptionMenu MapColorMenu protected
 	Title "$MAPCOLORMNU_TITLE"
 	SafeCommand "$MAPCOLORMNU_DEFAULTMAPCOLORS", 		"am_restorecolors"
 	StaticText " "
-	ColorPicker "$MAPCOLORMNU_BACKCOLOR",				"am_backcolor"		
-	ColorPicker "$MAPCOLORMNU_YOURCOLOR",				"am_yourcolor"		
-	ColorPicker "$MAPCOLORMNU_WALLCOLOR",				"am_wallcolor"		
-	ColorPicker "$MAPCOLORMNU_FDWALLCOLOR",				"am_fdwallcolor"		
-	ColorPicker "$MAPCOLORMNU_CDWALLCOLOR",				"am_cdwallcolor"		
-	ColorPicker "$MAPCOLORMNU_EFWALLCOLOR",				"am_efwallcolor"		
-	ColorPicker "$MAPCOLORMNU_GRIDCOLOR",				"am_gridcolor"		
-	ColorPicker "$MAPCOLORMNU_XHAIRCOLOR",				"am_xhaircolor"		
-	ColorPicker "$MAPCOLORMNU_NOTSEENCOLOR",			"am_notseencolor"		
-	ColorPicker "$MAPCOLORMNU_LOCKEDCOLOR",				"am_lockedcolor"		
-	ColorPicker "$MAPCOLORMNU_INTRALEVELCOLOR",			"am_intralevelcolor"	
-	ColorPicker "$MAPCOLORMNU_INTERLEVELCOLOR",			"am_interlevelcolor"	
-	ColorPicker "$MAPCOLORMNU_SECRETSECTORCOLOR",		"am_secretsectorcolor"	
-	ColorPicker "$MAPCOLORMNU_UNEXPLOREDSECRETCOLOR",	"am_unexploredsecretcolor"	
+	ColorPicker "$MAPCOLORMNU_BACKCOLOR",				"am_backcolor"
+	ColorPicker "$MAPCOLORMNU_YOURCOLOR",				"am_yourcolor"
+	ColorPicker "$MAPCOLORMNU_WALLCOLOR",				"am_wallcolor"
+	ColorPicker "$MAPCOLORMNU_FDWALLCOLOR",				"am_fdwallcolor"
+	ColorPicker "$MAPCOLORMNU_CDWALLCOLOR",				"am_cdwallcolor"
+	ColorPicker "$MAPCOLORMNU_EFWALLCOLOR",				"am_efwallcolor"
+	ColorPicker "$MAPCOLORMNU_GRIDCOLOR",				"am_gridcolor"
+	ColorPicker "$MAPCOLORMNU_XHAIRCOLOR",				"am_xhaircolor"
+	ColorPicker "$MAPCOLORMNU_NOTSEENCOLOR",			"am_notseencolor"
+	ColorPicker "$MAPCOLORMNU_LOCKEDCOLOR",				"am_lockedcolor"
+	ColorPicker "$MAPCOLORMNU_INTRALEVELCOLOR",			"am_intralevelcolor"
+	ColorPicker "$MAPCOLORMNU_INTERLEVELCOLOR",			"am_interlevelcolor"
+	ColorPicker "$MAPCOLORMNU_SECRETSECTORCOLOR",		"am_secretsectorcolor"
+	ColorPicker "$MAPCOLORMNU_UNEXPLOREDSECRETCOLOR",	"am_unexploredsecretcolor"
 	ColorPicker "$MAPCOLORMNU_SPECIALWALLCOLOR",		"am_specialwallcolor"
 	ColorPicker "$MAPCOLORMNU_PORTAL",					"am_portalcolor"
 	StaticText " "
 	StaticText "$MAPCOLORMNU_CHEATMODE", 1
-	ColorPicker "$MAPCOLORMNU_TSWALLCOLOR",				"am_tswallcolor"		
-	ColorPicker "$MAPCOLORMNU_SECRETWALLCOLOR",			"am_secretwallcolor"	
-	ColorPicker "$MAPCOLORMNU_THINGCOLOR",				"am_thingcolor"		
-	ColorPicker "$MAPCOLORMNU_MONSTERCOLOR",			"am_thingcolor_monster"		
-	ColorPicker "$MAPCOLORMNU_NONCOUNTINGMONSTERCOLOR",	"am_thingcolor_ncmonster"		
-	ColorPicker "$MAPCOLORMNU_FRIENDCOLOR",				"am_thingcolor_friend"		
-	ColorPicker "$MAPCOLORMNU_ITEMCOLOR",				"am_thingcolor_item"			
-	ColorPicker "$MAPCOLORMNU_COUNTITEMCOLOR",			"am_thingcolor_citem"			
+	ColorPicker "$MAPCOLORMNU_TSWALLCOLOR",				"am_tswallcolor"
+	ColorPicker "$MAPCOLORMNU_SECRETWALLCOLOR",			"am_secretwallcolor"
+	ColorPicker "$MAPCOLORMNU_THINGCOLOR",				"am_thingcolor"
+	ColorPicker "$MAPCOLORMNU_MONSTERCOLOR",			"am_thingcolor_monster"
+	ColorPicker "$MAPCOLORMNU_NONCOUNTINGMONSTERCOLOR",	"am_thingcolor_ncmonster"
+	ColorPicker "$MAPCOLORMNU_FRIENDCOLOR",				"am_thingcolor_friend"
+	ColorPicker "$MAPCOLORMNU_ITEMCOLOR",				"am_thingcolor_item"
+	ColorPicker "$MAPCOLORMNU_COUNTITEMCOLOR",			"am_thingcolor_citem"
 	StaticText " "
 	StaticText "$MAPCOLORMNU_OVERLAY", 1
-	ColorPicker "$MAPCOLORMNU_YOURCOLOR",				"am_ovyourcolor"		
-	ColorPicker "$MAPCOLORMNU_WALLCOLOR",				"am_ovwallcolor"		
-	ColorPicker "$MAPCOLORMNU_FDWALLCOLOR",				"am_ovfdwallcolor"		
-	ColorPicker "$MAPCOLORMNU_CDWALLCOLOR",				"am_ovcdwallcolor"		
-	ColorPicker "$MAPCOLORMNU_EFWALLCOLOR",				"am_ovefwallcolor"		
-	ColorPicker "$MAPCOLORMNU_NOTSEENCOLOR",			"am_ovunseencolor"	
+	ColorPicker "$MAPCOLORMNU_YOURCOLOR",				"am_ovyourcolor"
+	ColorPicker "$MAPCOLORMNU_WALLCOLOR",				"am_ovwallcolor"
+	ColorPicker "$MAPCOLORMNU_FDWALLCOLOR",				"am_ovfdwallcolor"
+	ColorPicker "$MAPCOLORMNU_CDWALLCOLOR",				"am_ovcdwallcolor"
+	ColorPicker "$MAPCOLORMNU_EFWALLCOLOR",				"am_ovefwallcolor"
+	ColorPicker "$MAPCOLORMNU_NOTSEENCOLOR",			"am_ovunseencolor"
 	ColorPicker "$MAPCOLORMNU_LOCKEDCOLOR",				"am_ovlockedcolor"
-	ColorPicker "$MAPCOLORMNU_INTRALEVELCOLOR",			"am_ovtelecolor"		
-	ColorPicker "$MAPCOLORMNU_INTERLEVELCOLOR",			"am_ovinterlevelcolor"	
-	ColorPicker "$MAPCOLORMNU_SECRETSECTORCOLOR",		"am_ovsecretsectorcolor"	
+	ColorPicker "$MAPCOLORMNU_INTRALEVELCOLOR",			"am_ovtelecolor"
+	ColorPicker "$MAPCOLORMNU_INTERLEVELCOLOR",			"am_ovinterlevelcolor"
+	ColorPicker "$MAPCOLORMNU_SECRETSECTORCOLOR",		"am_ovsecretsectorcolor"
 	ColorPicker "$MAPCOLORMNU_SPECIALWALLCOLOR",		"am_ovspecialwallcolor"
 	ColorPicker "$MAPCOLORMNU_PORTAL",					"am_ovportalcolor"
 	StaticText " "
@@ -1190,10 +1190,10 @@ OptionMenu MapColorMenu protected
 	ColorPicker "$MAPCOLORMNU_SECRETWALLCOLOR",			"am_ovsecretwallcolor"
 	ColorPicker "$MAPCOLORMNU_THINGCOLOR",				"am_ovthingcolor"
 	ColorPicker "$MAPCOLORMNU_MONSTERCOLOR",			"am_ovthingcolor_monster"
-	ColorPicker "$MAPCOLORMNU_NONCOUNTINGMONSTERCOLOR",	"am_ovthingcolor_ncmonster"	
+	ColorPicker "$MAPCOLORMNU_NONCOUNTINGMONSTERCOLOR",	"am_ovthingcolor_ncmonster"
 	ColorPicker "$MAPCOLORMNU_FRIENDCOLOR",				"am_ovthingcolor_friend"
-	ColorPicker "$MAPCOLORMNU_ITEMCOLOR",				"am_ovthingcolor_item"	
-	ColorPicker "$MAPCOLORMNU_COUNTITEMCOLOR",			"am_ovthingcolor_citem"	
+	ColorPicker "$MAPCOLORMNU_ITEMCOLOR",				"am_ovthingcolor_item"
+	ColorPicker "$MAPCOLORMNU_COUNTITEMCOLOR",			"am_ovthingcolor_citem"
 }
 
 //-------------------------------------------------------------------------------------------
@@ -1290,7 +1290,7 @@ OptionMenu ScoreboardOptions protected
  * Gameplay Options (dmflags) Menu
  *
  *=======================================*/
- 
+
 OptionValue  SmartAim
 {
 	0.0, "$OPTVAL_OFF"
@@ -1404,10 +1404,10 @@ OptionMenu "CompatibilityOptions" protected
 {
 	Title "$CMPTMNU_TITLE"
 	Option "$CMPTMNU_MODE",							"compatmode", "CompatModes", "", 1
-	
+
 	StaticText " "
 	StaticText "$CMPTMNU_ACTORBEHAVIOR",1
-	Option "$CMPTMNU_CORPSEGIBS",					"compat_CORPSEGIBS", "YesNo"	
+	Option "$CMPTMNU_CORPSEGIBS",					"compat_CORPSEGIBS", "YesNo"
 	Option "$CMPTMNU_NOBLOCKFRIENDS",				"compat_NOBLOCKFRIENDS", "YesNo"
 	Option "$CMPTMNU_LIMITPAIN",					"compat_LIMITPAIN", "YesNo"
 	Option "$CMPTMNU_MBFMONSTERMOVE",				"compat_MBFMONSTERMOVE", "YesNo"
@@ -1416,12 +1416,12 @@ OptionMenu "CompatibilityOptions" protected
 	Option "$CMPTMNU_INVISIBILITY",					"compat_INVISIBILITY", "YesNo"
 	Option "$CMPTMNU_MINOTAUR",						"compat_MINOTAUR", "YesNo"
 	Option "$CMPTMNU_NOTOSSDROPS",					"compat_NOTOSSDROPS", "YesNo"
-	
+
 	StaticText " "
 	StaticText "$CMPTMNU_DEHACKEDBEHAVIOR",1
 	Option "$CMPTMNU_DEHHEALTH",					"compat_DEHHEALTH", "YesNo"
 	Option "$CMPTMNU_MUSHROOM",						"compat_MUSHROOM", "YesNo"
-	
+
 	StaticText " "
 	StaticText "$CMPTMNU_MAPACTIONBEHAVIOR",1
 	Option "$CMPTMNU_USEBLOCKING",					"compat_USEBLOCKING", "YesNo"
@@ -1435,7 +1435,7 @@ OptionMenu "CompatibilityOptions" protected
 	Option "$CMPTMNU_MULTIEXIT",					"compat_multiexit", "YesNo"
 	Option "$CMPTMNU_TELEPORT",						"compat_teleport", "YesNo"
 	Option "$CMPTMNU_PUSHWINDOW",					"compat_pushwindow", "YesNo"
-	
+
 	StaticText " "
 	StaticText "$CMPTMNU_PHYSICSBEHAVIOR",1
 	Option "$CMPTMNU_NOPASSOVER",					"compat_nopassover", "YesNo"
@@ -1447,13 +1447,13 @@ OptionMenu "CompatibilityOptions" protected
 	Option "$CMPTMNU_HITSCAN",						"compat_HITSCAN", "YesNo"
 	Option "$CMPTMNU_MISSILECLIP",					"compat_MISSILECLIP", "YesNo"
 
-	
+
 	StaticText " "
 	StaticText "$CMPTMNU_RENDERINGBEHAVIOR",1
 	Option "$CMPTMNU_POLYOBJ",						"compat_POLYOBJ", "YesNo"
 	Option "$CMPTMNU_MASKEDMIDTEX",					"compat_MASKEDMIDTEX", "YesNo"
 	Option "$CMPTMNU_SPRITESORT",					"compat_SPRITESORT", "YesNo"
-	
+
 	StaticText " "
 	StaticText "$CMPTMNU_SOUNDBEHAVIOR",1
 	Option "$CMPTMNU_SOUNDSLOTS",					"compat_soundslots", "YesNo"
@@ -1462,7 +1462,7 @@ OptionMenu "CompatibilityOptions" protected
 	Option "$CMPTMNU_SECTORSOUNDS",					"compat_SECTORSOUNDS", "YesNo"
 	Option "$CMPTMNU_SOUNDCUTOFF",					"compat_soundcutoff", "YesNo"
 	Option "$CMPTMNU_SOUNDTARGET",					"compat_SOUNDTARGET", "YesNo"
-	
+
 	Class "CompatibilityMenu"
 }
 
@@ -1471,7 +1471,7 @@ OptionMenu "CompatibilityOptions" protected
  * Sound Options Menu
  *
  *=======================================*/
- 
+
 OptionValue SampleRates
 {
 	0,		"$OPTVAL_DEFAULT"
@@ -1746,7 +1746,7 @@ OptionMenu ModReplayerOptions protected
  * MIDI player
  *
  *=======================================*/
- 
+
  OptionValue TimidityReverb
  {
 	0, "$OPTVAL_OFF"
@@ -1755,7 +1755,7 @@ OptionMenu ModReplayerOptions protected
 	3, "$ADVSNDMNU_FREEVERB"
 	4, "$ADVSNDMNU_GLOBAL_FREEVERB"
  }
- 
+
   OptionMenu MidiPlayerOptions protected
  {
 	Title "$SNDMNU_MIDIPLAYER"
@@ -1765,6 +1765,7 @@ OptionMenu ModReplayerOptions protected
 	Submenu "$ADVSNDMNU_WILDMIDI", "WildMidiOptions", 0, 1
 	Submenu "$ADVSNDMNU_OPLSYNTHESIS", "OPLOptions", 0, 1
 	Submenu "$ADVSNDMNU_ADLMIDI", "ADLOptions", 0, 1
+	Submenu "$ADVSNDMNU_OPNMIDI", "OPNOptions", 0, 1
  }
 
  OptionMenu FluidsynthOptions protected
@@ -1777,7 +1778,7 @@ OptionMenu ModReplayerOptions protected
 	Slider "$ADVSNDMNU_MIDIVOICES", 		"fluid_voices", 16, 4096, 16, 0
 	// other CVARs need to be revieved for usefulness
  }
- 
+
  OptionMenu TimidityOptions protected
  {
 	Title "$ADVSNDMNU_TIMIDITY"
@@ -1796,7 +1797,7 @@ OptionMenu ModReplayerOptions protected
 	Option "$ADVSNDMNU_DMXGUS", 			"midi_dmxgus", "OnOff"
 	Option "$ADVSNDMNU_GUSMEMSIZE", 		"gus_memsize", "GusMemory"
  }
- 
+
   OptionMenu WildMidiOptions protected
  {
 	Title "$ADVSNDMNU_WILDMIDI"
@@ -1804,19 +1805,37 @@ OptionMenu ModReplayerOptions protected
 	Option "$ADVSNDMNU_REVERB", 			"wildmidi_reverb", "OnOff"
 	Option "$ADVSNDMNU_ADVRESAMPLING",		"wildmidi_enhanced_resampling", "OnOff"
  }
- 
+
  OptionMenu OPLOptions protected
  {
  	Title "$ADVSNDMNU_OPLSYNTHESIS"
 	Option "$ADVSNDMNU_OPLCORES", 			"opl_core", "OplCores"
 	Slider "$ADVSNDMNU_OPLNUMCHIPS", 		"opl_numchips", 1, 8, 1, 0
 	Option "$ADVSNDMNU_OPLFULLPAN",			"opl_fullpan", "OnOff"
-}
+ }
+
+ OptionValue AdlVolumeModels
+ {
+	0, "$ADLVLMODEL_AUTO"
+	1, "$ADLVLMODEL_GENERIC"
+	2, "$ADLVLMODEL_NATIVE"
+	3, "$ADLVLMODEL_DMX"
+	4, "$ADLVLMODEL_APOGEE"
+	5, "$ADLVLMODEL_WIN9X"
+ }
 
  OptionMenu ADLOptions protected
  {
  	Title "$ADVSNDMNU_ADLMIDI"
-	LabeledSubmenu "$ADVSNDMNU_OPLBANK", "adl_bank", "ADLBankMenu"
+ 	LabeledSubmenu "$ADVSNDMNU_OPLBANK", "adl_bank", "ADLBankMenu"
+ 	Slider "$ADVSNDMNU_ADLNUMCHIPS", 	 "adl_chips_count", 1, 32, 1, 0
+ 	Option "$ADVSNDMNU_VLMODEL",		 "adl_volume_model", "AdlVolumeModels"
+ }
+
+ OptionMenu OPNOptions protected
+ {
+ 	Title "$ADVSNDMNU_OPNMIDI"
+ 	Slider "$ADVSNDMNU_OPNNUMCHIPS", 	 "opn_chips_count", 1, 32, 1, 0
  }
 
 /*=======================================
@@ -1918,19 +1937,19 @@ OptionValue CropAspect
 OptionMenu VideoModeMenu protected
 {
 	Title "$VIDMNU_TITLE"
-	
+
 	Option "$VIDMNU_FULLSCREEN",		"fullscreen", "YesNo"
-	
+
 	IfOption(Mac)
 	{
 		Option "$VIDMNU_HIDPI",			"vid_hidpi", "YesNo"
 	}
-	
+
 	IfOption(Windows)
 	{
 		Option "$VIDMNU_BRDLSS",		"win_borderless", "YesNo"
 	}
-	
+
 	Option "$VIDMNU_ASPECTRATIO",		"menu_screenratios", "Ratios"
 	Option "$VIDMNU_FORCEASPECT",		"vid_aspect", "ForceRatios"
 	Option "$VIDMNU_CROPASPECT",		"vid_cropaspect", "CropAspect"
@@ -1971,7 +1990,7 @@ OptionMenu NetworkOptions protected
 	StaticText "$NETMNU_HOSTOPTIONS", 1
 	Option "$NETMNU_EXTRATICS",				"net_extratic", "ExtraTicMode"
 	Option "$NETMNU_TICBALANCE",			"net_ticbalance", "OnOff"
-	
+
 }
 
 OptionValue ExtraTicMode


### PR DESCRIPTION
Just now I have added ability to setup emulated chips count (both) and volume model (ADL only)!

Notes:
* ADL: The DMX volume model was set as default to unify volumes on all bank. Otherwise, if you will use 'Generic' or 'Win9x', the sound will became too loud than wanted. Each bank has own default volume model which is used when 'Auto' is set.
* ADL: 6 chips is optimal to work with default banks
* OPN: 8 chips are set to provide 48 polyphony channels. (each OPN2 chip has 6 channels only)
* Text files: junk spaces from end of lines are was auto-removed.

In your code I have found double-incrementing. I.e.:
```cpp
for(int i = 0; i < xxx; i++)
{
    //...
    i++; //Woops :-P
}
```
which was a reason of weird ADLMIDI embedded banks list I fixed in your code. Also, instead of direct access to data array, I have used functions (are bound as `extern "C"`) are giving count of banks and then pointer to array of banks. That is much more save as embedded banks are can be easily added or removed without of changing banks count value on "some deep place" code.