### PR TITLE
Default newradius in A_SetSize

### DIFF
--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -6765,7 +6765,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CheckTerrain)
 DEFINE_ACTION_FUNCTION(AActor, A_SetSize)
 {
 	PARAM_SELF_PROLOGUE(AActor);
-	PARAM_FLOAT(newradius);
+	PARAM_FLOAT_DEF(newradius);
 	PARAM_FLOAT_DEF(newheight);
 	PARAM_BOOL_DEF(testpos);
 

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -1145,7 +1145,7 @@ class Actor : Thinker native
 	native bool A_CopySpriteFrame(int from, int to, int flags = 0);
 	native bool A_SetVisibleRotation(double anglestart = 0, double angleend = 0, double pitchstart = 0, double pitchend = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
 	native void A_SetTranslation(name transname);
-	native bool A_SetSize(double newradius, double newheight = -1, bool testpos = false);
+	native bool A_SetSize(double newradius = -1, double newheight = -1, bool testpos = false);
 	native void A_SprayDecal(String name, double dist = 172);
 	native void A_SetMugshotState(String name);
 


### PR DESCRIPTION
Allows one to use A_SetSize without a new radius.