### PR TITLE
Localize the word “for” in Strife’s trading dialogs

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -579,7 +579,6 @@ NERVETEXT =
 	"\n"
 	"THIS RIDE IS CLOSED.\n";
 
-
 // Cast list (must appear in this order)
 CC_ZOMBIE = "ZOMBIEMAN";
 CC_SHOTGUN = "SHOTGUN GUY";
@@ -1299,7 +1298,6 @@ TXT_IMITEMS = "ITEMS";
 TXT_IMSECRETS = "SECRETS";
 TXT_IMTIME = "TIME";
 
-
 RAVENQUITMSG = "ARE YOU SURE YOU WANT TO QUIT?";
 
 // Hexen strings
@@ -1459,7 +1457,6 @@ TXT_MAULER = "You picked up the mauler.";
 TXT_GLAUNCHER = "You picked up the Grenade launcher.";
 TXT_SIGIL = "You picked up the SIGIL.";
 
-
 TXT_BASEKEY = "You picked up the Base Key.";
 TXT_GOVSKEY = "You picked up the Govs Key.";
 TXT_PASSCARD = "You picked up the Passcard.";
@@ -1567,6 +1564,7 @@ TXT_GOAWAY			= "Go away!";
 TXT_COMM0			= "Incoming Message";
 TXT_COMM1			= "Incoming Message from BlackBird";
 
+TXT_TRADE			=  " for %u";
 
 AMMO_CLIP			= "Bullets";
 AMMO_SHELLS			= "Shotgun Shells";
@@ -2471,11 +2469,9 @@ OPTSTR_NOINTERPOLATION		= "No interpolation";
 OPTSTR_SPLINE				= "Spline";
 OPTSTR_OPENAL				= "OpenAL";
 
-
 NOTSET				= "Not set";
 SAFEMESSAGE			= "Do you really want to do this?";
 MNU_COLORPICKER		= "SELECT COLOR";
-
 
 WI_FINISHED			= "finished";
 WI_ENTERING			= "Now entering:";
@@ -2851,7 +2847,6 @@ OPTVAL_REVERSEFIRST			= "Reverse";
 DSPLYMNU_TCOPT		= "TrueColor Options";
 
 TCMNU_TITLE		= "TRUECOLOR OPTIONS";
-
 
 TCMNU_TRUECOLOR				= "True color output";
 TCMNU_MINFILTER				= "Linear filter when downscaling";

--- a/wadsrc/static/language.fr
+++ b/wadsrc/static/language.fr
@@ -1646,6 +1646,8 @@ TXT_GOAWAY			= "Allez-vous en!";
 TXT_COMM0			= "Message reçu.";
 TXT_COMM1			= "Message reçu de BlackBird";
 
+TXT_TRADE			=  " pour %u";
+
 AMMO_CLIP			= "Balles";
 AMMO_SHELLS			= "Cartouches";
 AMMO_ROCKETS		= "Roquettes";

--- a/wadsrc/static/zscript/menu/conversationmenu.txt
+++ b/wadsrc/static/zscript/menu/conversationmenu.txt
@@ -137,7 +137,7 @@ class ConversationMenu : Menu
 			mShowGold |= reply.NeedsGold;
 
 			let ReplyText = Stringtable.Localize(reply.Reply);
-			if (reply.NeedsGold) ReplyText.AppendFormat(" for %u", reply.PrintAmount);
+			if (reply.NeedsGold) ReplyText.AppendFormat(Stringtable.Localize("$TXT_TRADE"), reply.PrintAmount);
 
 			let ReplyLines = SmallFont.BreakLines (ReplyText, ReplyWidth);
 


### PR DESCRIPTION
This deals with what seems to be the only hardcoded piece of text in Strife. Also added a translation to the French file and removed a few superfluous line breaks in the English one.

[Before](https://cdn.discordapp.com/attachments/268086704961748992/429651309860356096/unknown.png)
[After](https://cdn.discordapp.com/attachments/396367134927618058/429665963818876938/unknown.png)