### PR TITLE
Increase size of the savegame comment area

### DIFF
--- a/src/menu/loadsavemenu.cpp
+++ b/src/menu/loadsavemenu.cpp
@@ -487,7 +487,7 @@ unsigned FSavegameManager::ExtractSaveData(int index)
 			arc("Comment", pcomment);
 
 			comment = time;
-			if (time.Len() > 0) comment += "\n\n";
+			if (time.Len() > 0) comment += "\n";
 			comment += pcomment;
 
 			SaveComment = V_BreakLines(SmallFont, WindowSize, comment.GetChars());
@@ -619,10 +619,12 @@ void FSavegameManager::DrawSaveComment(FFont *font, int cr, int x, int y, int sc
 
 	CleanXfac = CleanYfac = scalefactor;
 
+	int maxlines = screen->GetHeight()>400?10:screen->GetHeight()>240?7:screen->GetHeight()>200?8:5;
+	if (SmallFont->GetHeight() > 9) maxlines--; // not Doom
 	// I'm not sure why SaveComment would go nullptr in this loop, but I got
 	// a crash report where it was nullptr when i reached 1, so now I check
 	// for that.
-	for (int i = 0; SaveComment != nullptr && SaveComment[i].Width >= 0 && i < 6; ++i)
+	for (int i = 0; SaveComment != nullptr && SaveComment[i].Width >= 0 && i < maxlines; ++i)
 	{
 		screen->DrawText(font, cr, x, y + font->GetHeight() * i * scalefactor, SaveComment[i].Text,	DTA_CleanNoMove, true, TAG_DONE);
 	}

--- a/wadsrc/static/zscript/menu/loadsavemenu.txt
+++ b/wadsrc/static/zscript/menu/loadsavemenu.txt
@@ -132,7 +132,8 @@ class LoadSaveMenu : ListMenu
 		commentLeft = savepicLeft;
 		commentTop = savepicTop + savepicHeight + 16;
 		commentWidth = savepicWidth;
-		commentHeight = (51+(screen.GetHeight()>200?10:0))*CleanYfac;
+		//commentHeight = (51+(screen.GetHeight()>200?10:0))*CleanYfac;
+		commentHeight = listboxHeight - savepicHeight - 16;
 		commentRight = commentLeft + commentWidth;
 		commentBottom = commentTop + commentHeight;
 	}


### PR DESCRIPTION
 This effectively increases the number of lines in the savegame comment area from 5 to 10 (less at low resolutions) since some level names didn't fit. Some ancient code there.