### PR TITLE
Export P_ActivateLine to ZScript

### DIFF
--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -242,6 +242,26 @@ bool P_ActivateLine (line_t *line, AActor *mo, int side, int activationType, DVe
 	return true;
 }
 
+DEFINE_ACTION_FUNCTION(_Line, Activate)
+{
+	PARAM_SELF_PROLOGUE(line_t);
+	PARAM_POINTER(mo, AActor);
+	PARAM_INT(side);
+	PARAM_INT(activationType);
+	PARAM_FLOAT_DEF(optx);
+	PARAM_FLOAT_DEF(opty);
+	PARAM_FLOAT_DEF(optz);
+	if ( optx == opty == optz == NAN )
+	{
+		ACTION_RETURN_BOOL(P_ActivateLine(self, mo, side, activationType, NULL));
+	}
+	else
+	{
+		DVector3 optpos = DVector3(optx, opty, optz);
+		ACTION_RETURN_BOOL(P_ActivateLine(self, mo, side, activationType, &optpos));
+	}
+}
+
 //============================================================================
 //
 // P_TestActivateLine

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -244,7 +244,7 @@ bool P_ActivateLine (line_t *line, AActor *mo, int side, int activationType, DVe
 
 DEFINE_ACTION_FUNCTION(_Line, Activate)
 {
-	PARAM_SELF_PROLOGUE(line_t);
+	PARAM_SELF_STRUCT_PROLOGUE(line_t);
 	PARAM_POINTER(mo, AActor);
 	PARAM_INT(side);
 	PARAM_INT(activationType);
@@ -253,7 +253,7 @@ DEFINE_ACTION_FUNCTION(_Line, Activate)
 
 DEFINE_ACTION_FUNCTION(_Line, RemoteActivate)
 {
-	PARAM_SELF_PROLOGUE(line_t);
+	PARAM_SELF_STRUCT_PROLOGUE(line_t);
 	PARAM_POINTER(mo, AActor);
 	PARAM_INT(side);
 	PARAM_INT(activationType);

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -248,18 +248,20 @@ DEFINE_ACTION_FUNCTION(_Line, Activate)
 	PARAM_POINTER(mo, AActor);
 	PARAM_INT(side);
 	PARAM_INT(activationType);
-	PARAM_FLOAT_DEF(optx);
-	PARAM_FLOAT_DEF(opty);
-	PARAM_FLOAT_DEF(optz);
-	if ( optx == opty == optz == NAN )
-	{
-		ACTION_RETURN_BOOL(P_ActivateLine(self, mo, side, activationType, NULL));
-	}
-	else
-	{
-		DVector3 optpos = DVector3(optx, opty, optz);
-		ACTION_RETURN_BOOL(P_ActivateLine(self, mo, side, activationType, &optpos));
-	}
+	ACTION_RETURN_BOOL(P_ActivateLine(self, mo, side, activationType, NULL));
+}
+
+DEFINE_ACTION_FUNCTION(_Line, RemoteActivate)
+{
+	PARAM_SELF_PROLOGUE(line_t);
+	PARAM_POINTER(mo, AActor);
+	PARAM_INT(side);
+	PARAM_INT(activationType);
+	PARAM_FLOAT(optx);
+	PARAM_FLOAT(opty);
+	PARAM_FLOAT(optz);
+	DVector3 optpos = DVector3(optx, opty, optz);
+	ACTION_RETURN_BOOL(P_ActivateLine(self, mo, side, activationType, &optpos));
 }
 
 //============================================================================

--- a/wadsrc/static/zscript/constants.txt
+++ b/wadsrc/static/zscript/constants.txt
@@ -1223,3 +1223,21 @@ enum ActorRenderFeatureFlag
 	RFF_VOXELS		= 1<<12, // renderer is capable of voxels
 };
 
+// Special activation types
+enum SPAC
+{
+	SPAC_Cross = 1<<0,		// when player crosses line
+	SPAC_Use = 1<<1,		// when player uses line
+	SPAC_MCross = 1<<2,		// when monster crosses line
+	SPAC_Impact = 1<<3,		// when projectile hits line
+	SPAC_Push = 1<<4,		// when player pushes line	
+	SPAC_PCross = 1<<5,		// when projectile crosses line
+	SPAC_UseThrough = 1<<6,	// when player uses line (doesn't block)
+	// SPAC_PTOUCH is mapped to SPAC_PCross|SPAC_Impact
+	SPAC_AnyCross = 1<<7,	// when anything without the MF2_TELEPORT flag crosses the line
+	SPAC_MUse = 1<<8,		// monsters can use
+	SPAC_MPush = 1<<9,		// monsters can push
+	SPAC_UseBack = 1<<10,	// Can be used from the backside
+
+	SPAC_PlayerActivate = (SPAC_Cross|SPAC_Use|SPAC_Impact|SPAC_Push|SPAC_AnyCross|SPAC_UseThrough|SPAC_UseBack),
+};

--- a/wadsrc/static/zscript/mapdata.txt
+++ b/wadsrc/static/zscript/mapdata.txt
@@ -156,7 +156,8 @@ struct Line native play
 	native Line getPortalDestination();
 	native int getPortalAlignment();
 	native int Index();
-	native bool Activate(Actor activator, int side, int type, Vector3 pos = (double.nan, double.nan, double.nan));
+	native bool Activate(Actor activator, int side, int type);
+	native bool RemoteActivate(Actor activator, int side, int type, Vector3 pos);
 	
 	int GetUDMFInt(Name nm)
 	{

--- a/wadsrc/static/zscript/mapdata.txt
+++ b/wadsrc/static/zscript/mapdata.txt
@@ -156,6 +156,7 @@ struct Line native play
 	native Line getPortalDestination();
 	native int getPortalAlignment();
 	native int Index();
+	native bool Activate(Actor activator, int side, int type, Vector3 pos = (double.nan, double.nan, double.nan));
 	
 	int GetUDMFInt(Name nm)
 	{


### PR DESCRIPTION
Also exports the special activation types enum, for convenience.

It's implemented as two separate functions of the `Line` struct: `Activate` and `RemoteActivate`.

The main difference is that the former passes null to the `optpos` parameter, while the latter passes a defined vector. This parameter is used in the switch range check, so I thought this was the most intuitive way to handle it (especially since there's no way that I'm aware of to have a "pointer to a vector" in zscript).

Example wad: [lineactivatetest_m.zip](https://github.com/coelckers/gzdoom/files/1886460/lineactivatetest_m.zip)

Use `give TestWeapon` and try shooting at lines. Those that can be activated by either shooting or use should trigger, others will result in grunting.