### PR TITLE
Actor.OnGiveSecret virtual function for customising secret finding behaviour

### DIFF
--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -607,7 +607,15 @@ void P_GiveSecret(AActor *actor, bool printmessage, bool playsound, int sectornu
 		{
 			actor->player->secretcount++;
 		}
-		if (cl_showsecretmessage && actor->CheckLocalView(consoleplayer))
+		int retval = 1;
+		IFVIRTUALPTR(actor, AActor, OnGiveSecret)
+		{
+			VMValue params[] = { actor, printmessage, playsound };
+			VMReturn ret;
+			ret.IntAt(&retval);
+			VMCall(func, params, countof(params), &ret, 1);
+		}
+		if (retval && cl_showsecretmessage && actor->CheckLocalView(consoleplayer))
 		{
 			if (printmessage)
 			{
@@ -633,6 +641,7 @@ DEFINE_ACTION_FUNCTION(AActor, GiveSecret)
 	P_GiveSecret(self, printmessage, playsound, -1);
 	return 0;
 }
+
 
 DEFINE_ACTION_FUNCTION(FLevelLocals, GiveSecret)
 {

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -537,6 +537,9 @@ class Actor : Thinker native
 	{
 		return damage;
 	}
+
+	// called on getting a secret, return false to disable default "secret found" message/sound
+	virtual bool OnGiveSecret(bool printmsg, bool playsound);
 	
 	native virtual bool OkayToSwitchTarget(Actor other);
 	native static class<Actor> GetReplacement(class<Actor> cls);


### PR DESCRIPTION
With this virtual function one can change what happens when a secret is found by overriding it in a playerclass. I set it up so returning false disables the normal "secret found" message + sound.

Here's an example wad with a simple map for getting a secret right away. Stepping on the red square should trigger the custom effect: [secret_m.zip](https://github.com/coelckers/gzdoom/files/1899519/secret_m.zip)
