### PR TITLE
Fixed broken portals after loading saved game

### DIFF
--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -994,7 +994,7 @@ void G_SerializeLevel(FSerializer &arc, bool hubload)
 	arc("zones", level.Zones);
 	arc("lineportals", level.linePortals);
 	arc("sectorportals", level.sectorPortals);
-	if (arc.isReading()) P_CollectLinkedPortals();
+	if (arc.isReading()) P_FinalizePortals();
 
 	// [ZZ] serialize events
 	E_SerializeEvents(arc);

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -4141,7 +4141,8 @@ void P_SetupLevel (const char *lumpname, int position)
 	times[16].Clock();
 	if (reloop) P_LoopSidedefs (false);
 	PO_Init ();				// Initialize the polyobjs
-	P_FinalizePortals();	// finalize line portals after polyobjects have been initialized. This info is needed for properly flagging them.
+	if (!savegamerestore)
+		P_FinalizePortals();	// finalize line portals after polyobjects have been initialized. This info is needed for properly flagging them.
 	times[16].Unclock();
 
 	assert(sidetemp != NULL);


### PR DESCRIPTION
Portals disabled initially and activated by scripting must be fully restored after loading of saved game

https://forum.zdoom.org/viewtopic.php?t=59999