### PR TITLE
- added LevelLocals vec2/3Offset(Z) functions for portal-aware…

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -2045,6 +2045,67 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, Vec3Diff)
 	ACTION_RETURN_VEC3(VecDiff(DVector3(x1, y1, z1), DVector3(x2, y2, z2)));
 }
 
+DEFINE_ACTION_FUNCTION(FLevelLocals, Vec2Offset)
+{
+	PARAM_PROLOGUE;
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	PARAM_FLOAT(dx);
+	PARAM_FLOAT(dy);
+	PARAM_BOOL_DEF(absolute);
+	if (absolute)
+	{
+		ACTION_RETURN_VEC2(DVector2(x + dx, y + dy));
+	}
+	else
+	{
+		DVector2 v = P_GetOffsetPosition(x, y, dx, dy);
+		ACTION_RETURN_VEC2(v);
+	}
+}
+
+DEFINE_ACTION_FUNCTION(FLevelLocals, Vec2OffsetZ)
+{
+	PARAM_PROLOGUE;
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	PARAM_FLOAT(dx);
+	PARAM_FLOAT(dy);
+	PARAM_FLOAT(atz);
+	PARAM_BOOL_DEF(absolute);
+	if (absolute)
+	{
+		ACTION_RETURN_VEC3(DVector3(x + dx, y + dy, atz));
+	}
+	else
+	{
+		DVector2 v = P_GetOffsetPosition(x, y, dx, dy);
+		ACTION_RETURN_VEC3(DVector3(v, atz));
+	}
+}
+
+DEFINE_ACTION_FUNCTION(FLevelLocals, Vec3Offset)
+{
+	PARAM_PROLOGUE;
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	PARAM_FLOAT(z);
+	PARAM_FLOAT(dx);
+	PARAM_FLOAT(dy);
+	PARAM_FLOAT(dz);
+	PARAM_BOOL_DEF(absolute);
+	if (absolute)
+	{
+		ACTION_RETURN_VEC3(DVector3(x + dx, y + dy, z + dz));
+	}
+	else
+	{
+		DVector2 v = P_GetOffsetPosition(x, y, dx, dy);
+		ACTION_RETURN_VEC3(DVector3(v, z + dz));
+	}
+}
+
+
 //==========================================================================
 //
 //

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -650,6 +650,10 @@ struct LevelLocals native
 
 	native static clearscope vector2 Vec2Diff(vector2 v1, vector2 v2);
 	native static clearscope vector3 Vec3Diff(vector3 v1, vector3 v2);
+	
+	native static clearscope vector2 Vec2Offset(vector2 pos, vector2 dir, bool absolute = false);
+	native static clearscope vector3 Vec2OffsetZ(vector2 pos, vector2 dir, double atz, bool absolute = false);
+	native static clearscope vector3 Vec3Offset(vector3 pos, vector3 dir, bool absolute = false);
 
 	native String GetChecksum() const;
 


### PR DESCRIPTION
…offsetting without needing actors

For cases where you need to get a position offsetted from a location, have it go through portals, and actors are either not available, such as in UI scope, or impractical for performance reasons, much like the previous vec2/3Diff pull request.