### PR TITLE
WorldThingPrePickedup & WorldThingPickedup (incomplete)

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -403,6 +403,18 @@ void E_WorldThingDestroyed(AActor* actor)
 		handler->WorldThingDestroyed(actor);
 }
 
+void E_WorldThingPrePickedUp(AActor* actor, AActor* toucher, bool* shouldpickup)
+{
+	for (DStaticEventHandler* handler = E_FirstEventHandler; handler; handler = handler->next)
+		handler->WorldThingPrePickedUp(actor, toucher, shouldpickup);
+}
+
+void E_WorldThingPickedUp(AActor* actor, AActor* toucher)
+{
+	for (DStaticEventHandler* handler = E_FirstEventHandler; handler; handler = handler->next)
+		handler->WorldThingPickedUp(actor, toucher);
+}
+
 void E_WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate)
 {
 	for (DStaticEventHandler* handler = E_FirstEventHandler; handler; handler = handler->next)
@@ -546,6 +558,8 @@ DEFINE_FIELD_X(WorldEvent, FWorldEvent, DamageAngle);
 DEFINE_FIELD_X(WorldEvent, FWorldEvent, ActivatedLine);
 DEFINE_FIELD_X(WorldEvent, FWorldEvent, ActivationType);
 DEFINE_FIELD_X(WorldEvent, FWorldEvent, ShouldActivate);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, Toucher);
+DEFINE_FIELD_X(WorldEvent, FWorldEvent, ShouldPickup);
 
 DEFINE_FIELD_X(PlayerEvent, FPlayerEvent, PlayerNumber);
 DEFINE_FIELD_X(PlayerEvent, FPlayerEvent, IsReturn);
@@ -632,6 +646,8 @@ DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldThingDied)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldThingRevived)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldThingDamaged)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldThingDestroyed)
+DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldThingPrePickedUp)
+DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldThingPickedUp)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldLinePreActivated)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldLineActivated)
 DEFINE_EMPTY_HANDLER(DStaticEventHandler, WorldLightning)
@@ -790,6 +806,36 @@ void DStaticEventHandler::WorldThingDestroyed(AActor* actor)
 			return;
 		FWorldEvent e = E_SetupWorldEvent();
 		e.Thing = actor;
+		VMValue params[2] = { (DStaticEventHandler*)this, &e };
+		VMCall(func, params, 2, nullptr, 0);
+	}
+}
+
+void DStaticEventHandler::WorldThingPrePickedUp(AActor* actor, AActor* toucher, bool* shouldpickup)
+{
+	IFVIRTUAL(DStaticEventHandler, WorldThingPrePickedUp)
+	{
+		if (func == DStaticEventHandler_WorldThingPrePickedUp_VMPtr)
+			return;
+		FWorldEvent e = E_SetupWorldEvent();
+		e.Thing = actor;
+		e.Toucher = toucher;
+		e.ShouldPickup = *shouldpickup;
+		VMValue params[2] = { (DStaticEventHandler*)this, &e };
+		VMCall(func, params, 2, nullptr, 0);
+		*shouldpickup = e.ShouldPickup;
+	}
+}
+
+void DStaticEventHandler::WorldThingPickedUp(AActor* actor, AActor* toucher)
+{
+	IFVIRTUAL(DStaticEventHandler, WorldThingPickedUp)
+	{
+		if (func == DStaticEventHandler_WorldThingPickedUp_VMPtr)
+			return;
+		FWorldEvent e = E_SetupWorldEvent();
+		e.Thing = actor;
+		e.Toucher = toucher;
 		VMValue params[2] = { (DStaticEventHandler*)this, &e };
 		VMCall(func, params, 2, nullptr, 0);
 	}

--- a/src/events.h
+++ b/src/events.h
@@ -40,6 +40,10 @@ void E_WorldThingRevived(AActor* actor);
 void E_WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 // called before AActor::Destroy of each actor.
 void E_WorldThingDestroyed(AActor* actor);
+// 
+void E_WorldThingPrePickedUp(AActor* actor, AActor* owner, bool* shouldpickup);
+// 
+void E_WorldThingPickedUp(AActor* actor, AActor* owner);
 // called in P_ActivateLine before executing special, set shouldactivate to false to prevent activation.
 void E_WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 // called in P_ActivateLine after successful special execution.
@@ -143,6 +147,8 @@ public:
 	void WorldThingRevived(AActor* actor);
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 	void WorldThingDestroyed(AActor* actor);
+	void WorldThingPrePickedUp(AActor* actor, AActor* toucher, bool* shouldpickup);
+	void WorldThingPickedUp(AActor* actor, AActor* owner);
 	void WorldLinePreActivated(line_t* line, AActor* actor, int activationType, bool* shouldactivate);
 	void WorldLineActivated(line_t* line, AActor* actor, int activationType);
 	void WorldLightning();
@@ -205,6 +211,8 @@ struct FWorldEvent
 	line_t* ActivatedLine = nullptr;
 	int ActivationType = 0;
 	bool ShouldActivate = true;
+	AActor* Toucher = nullptr;
+	bool ShouldPickup = true;
 };
 
 struct FPlayerEvent

--- a/src/g_inventory/a_pickups.cpp
+++ b/src/g_inventory/a_pickups.cpp
@@ -51,6 +51,7 @@
 #include "vm.h"
 #include "c_functions.h"
 #include "g_levellocals.h"
+#include "events.h"
 
 EXTERN_CVAR(Bool, sv_unlimited_pickup)
 

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -29,6 +29,8 @@ struct WorldEvent native play version("2.4")
     native readonly Line ActivatedLine;
 	native readonly int ActivationType;
     native bool ShouldActivate;
+	native readonly Actor Toucher;
+	native readonly bool ShouldPickup;
 }
 
 struct PlayerEvent native play version("2.4")
@@ -304,6 +306,8 @@ class StaticEventHandler : Object native play version("2.4")
     virtual native void WorldThingRevived(WorldEvent e);
     virtual native void WorldThingDamaged(WorldEvent e);
     virtual native void WorldThingDestroyed(WorldEvent e);
+	virtual native void WorldThingPrePickedUp(WorldEvent e);
+	virtual native void WorldThingPickedUp(WorldEvent e);
     virtual native void WorldLinePreActivated(WorldEvent e);
     virtual native void WorldLineActivated(WorldEvent e);
     virtual native void WorldLightning(WorldEvent e); // for the sake of completeness.

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -30,7 +30,7 @@ struct WorldEvent native play version("2.4")
 	native readonly int ActivationType;
     native bool ShouldActivate;
 	native readonly Actor Toucher;
-	native readonly bool ShouldPickup;
+	native bool ShouldPickup;
 }
 
 struct PlayerEvent native play version("2.4")


### PR DESCRIPTION
This implements WorldThingPrePickedUp and WorldThingPickedUp as events for the Event handlers, however, as pretty much all of the inventory handling is virtualized I was unsure where to place the corresponding functions, so I will leave that up to you.

WorldThingPrePickedUp is right before the item would be going into the inventory. If "shouldpickup" return false in the event, it will be prevented.