### PR TITLE
Fixed walkthrough blocker in Sin City 2 via compatibility entry

### DIFF
--- a/src/compatibility.cpp
+++ b/src/compatibility.cpp
@@ -51,6 +51,7 @@
 #include "textures.h"
 #include "g_levellocals.h"
 #include "vm.h"
+#include "actor.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -447,6 +448,13 @@ DEFINE_ACTION_FUNCTION(DLevelCompatibility, SetLineSectorRef)
 	}
 	ForceNodeBuild = true;
 	return 0;
+}
+
+DEFINE_ACTION_FUNCTION(DLevelCompatibility, GetDefaultActor)
+{
+	PARAM_PROLOGUE;
+	PARAM_NAME(actorclass);
+	ACTION_RETURN_OBJECT(GetDefaultByName(actorclass));
 }
 
 

--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -689,6 +689,13 @@ class LevelCompatibility play
 				SetThingSkills(115, 31);
 				break;
 			}
+
+			case 'CCF699953746087E46185B2A40D9F8AF': // satanx.wad map01
+			{
+				// Restore monster cross flag for DeHackEd friendly marine
+				GetDefaultActor('WolfensteinSS').bActivateMCross = true;
+				break;
+			}
 		}
 	}
 
@@ -701,6 +708,7 @@ class LevelCompatibility play
 	private static native void SetThingFlags(int thing, int flags);
 	private static native void SetVertex(uint vertex, double x, double y);
 	private static native void SetLineSectorRef(uint line, uint side, uint sector);
+	private static native Actor GetDefaultActor(Name actorclass);
 	
 	private static void SetWallTexture(int line, int side, int texpart, String texture)
 	{


### PR DESCRIPTION
It was impossible to complete Sin City 2 The Satan Complex without cheating since ZDoom 2.6.0
Change in applying of DeHackEd patches from 77a4b9a29bfdfb8a772a85c27d67399097d241d0 broke triggering of important linedef that pushes friendly marine to exit switch

https://www.doomworld.com/idgames/levels/doom2/Ports/s-u/satanx