### PR TITLE
Cross-platform sound pause on app deactivation

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -640,6 +640,7 @@ CVAR (Flag, compat_teleport,			compatflags2, COMPATF2_TELEPORT);
 CVAR (Flag, compat_pushwindow,			compatflags2, COMPATF2_PUSHWINDOW);
 
 CVAR(Bool, vid_activeinbackground, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Bool, i_soundinbackground, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 //==========================================================================
 //
@@ -971,6 +972,22 @@ void D_ErrorCleanup ()
 	insave = false;
 }
 
+static void UpdateSoundPauseState()
+{
+	if (i_soundinbackground)
+	{
+		return;
+	}
+
+	static bool prevAppActive = AppActive;
+
+	if (prevAppActive != AppActive)
+	{
+		S_SetSoundPaused(AppActive);
+		prevAppActive = AppActive;
+	}
+}
+
 //==========================================================================
 //
 // D_DoomLoop
@@ -1001,6 +1018,8 @@ void D_DoomLoop ()
 				I_StartFrame ();
 			}
 			I_SetFrameTime();
+
+			UpdateSoundPauseState();
 
 			// process one or more tics
 			if (singletics)

--- a/src/posix/cocoa/i_main.mm
+++ b/src/posix/cocoa/i_main.mm
@@ -57,7 +57,6 @@
 // ---------------------------------------------------------------------------
 
 
-CVAR (Bool, i_soundinbackground, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 EXTERN_CVAR(Int,  vid_defwidth )
 EXTERN_CVAR(Int,  vid_defheight)
 EXTERN_CVAR(Bool, vid_vsync    )
@@ -301,8 +300,6 @@ extern bool AppActive;
 - (void)applicationDidBecomeActive:(NSNotification*)aNotification
 {
 	ZD_UNUSED(aNotification);
-	
-	S_SetSoundPaused(1);
 
 	AppActive = true;
 }
@@ -310,8 +307,6 @@ extern bool AppActive;
 - (void)applicationWillResignActive:(NSNotification*)aNotification
 {
 	ZD_UNUSED(aNotification);
-	
-	S_SetSoundPaused(i_soundinbackground);
 
 	AppActive = false;
 }

--- a/src/posix/sdl/i_input.cpp
+++ b/src/posix/sdl/i_input.cpp
@@ -42,7 +42,6 @@
 #include "d_gui.h"
 #include "c_console.h"
 #include "dikeys.h"
-#include "s_sound.h"
 #include "events.h"
 
 static void I_CheckGUICapture ();
@@ -56,7 +55,6 @@ extern int paused;
 CVAR (Bool,  use_mouse,				true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Bool,  m_noprescale,			false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Bool,	 m_filter,				false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-CVAR (Bool, i_soundinbackground, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
 EXTERN_CVAR (Bool, fullscreen)
 
@@ -305,16 +303,10 @@ void MessagePump (const SDL_Event &sev)
 	case SDL_WINDOWEVENT:
 		switch (sev.window.event)
 		{
-			extern bool AppActive;
-
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
-				S_SetSoundPaused(1);
-				AppActive = true;
-				break;
-
 			case SDL_WINDOWEVENT_FOCUS_LOST:
-				S_SetSoundPaused(i_soundinbackground);
-				AppActive = false;
+				extern bool AppActive;
+				AppActive = sev.window.event == SDL_WINDOWEVENT_FOCUS_GAINED;
 				break;
 		}
 		break;

--- a/src/win32/i_input.cpp
+++ b/src/win32/i_input.cpp
@@ -82,7 +82,6 @@
 #include "d_main.h"
 #include "d_gui.h"
 #include "c_console.h"
-#include "s_sound.h"
 #include "gameconfigfile.h"
 #include "hardware.h"
 #include "d_event.h"
@@ -148,7 +147,6 @@ extern bool AppActive;
 int SessionState = 0;
 int BlockMouseMove; 
 
-CVAR (Bool, i_soundinbackground, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Bool, k_allowfullscreentoggle, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
 CUSTOM_CVAR(Bool, norawinput, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
@@ -536,7 +534,6 @@ LRESULT CALLBACK WndProc (HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		{
 			SetPriorityClass (GetCurrentProcess (), IDLE_PRIORITY_CLASS);
 		}
-		S_SetSoundPaused ((!!i_soundinbackground) || wParam);
 		break;
 
 	case WM_WTSSESSION_CHANGE:


### PR DESCRIPTION
What I don't really like in this solution is code added to `D_DoomLoop()`