### PR TITLE
Fix for Unreal meshes that don't have sequential texture numbers

### DIFF
--- a/src/r_data/models/models_ue1.cpp
+++ b/src/r_data/models/models_ue1.cpp
@@ -75,11 +75,16 @@ bool FUE1Model::Load( const char *filename, int lumpnum, const char *buffer, int
 	numFrames = ahead->numframes;
 	numPolys = dhead->numpolys;
 	numGroups = 0;
+	groupIndices.Reset();
 	uint8_t used[256] = {0};
 	for ( int i=0; i<numPolys; i++ )
 		used[dpolys[i].texnum] = 1;
 	for ( int i=0; i<256; i++ )
-		if ( used[i] ) numGroups++;
+	{
+		if ( !used[i] ) continue;
+		groupIndices.Push(i);
+		numGroups++;
+	}
 	LoadGeometry();
 	return true;
 }
@@ -166,7 +171,7 @@ void FUE1Model::LoadGeometry()
 		Group.numPolys = 0;
 		for ( int j=0; j<numPolys; j++ )
 		{
-			if ( polys[j].texNum != i )
+			if ( polys[j].texNum != groupIndices[i] )
 				continue;
 			Group.P.Push(j);
 			Group.numPolys++;
@@ -208,8 +213,8 @@ void FUE1Model::RenderFrame( FModelRenderer *renderer, FTexture *skin, int frame
 				sskin = TexMan(curSpriteMDLFrame->surfaceskinIDs[curMDLIndex][i]);
 			if ( !sskin )
 			{
-				continue;
 				vofs += vsize;
+				continue;
 			}
 		}
 		renderer->SetMaterial(sskin,false,translation);

--- a/src/r_data/models/models_ue1.h
+++ b/src/r_data/models/models_ue1.h
@@ -88,4 +88,5 @@ private:
 	TArray<UE1Vertex> verts;
 	TArray<UE1Poly> polys;
 	TArray<UE1Group> groups;
+	TArray<int> groupIndices;
 };


### PR DESCRIPTION
This didn't make it in time. It's an important fix for a couple meshes where the texture indices don't start at 0 (or have their indices in some other strange order, which can happen).