### PR TITLE
Fixups for UE1 (cleaned)

### DIFF
--- a/src/r_data/models/models_ue1.cpp
+++ b/src/r_data/models/models_ue1.cpp
@@ -98,9 +98,9 @@ void FUE1Model::LoadGeometry()
 		{
 			UE1Vertex Vert;
 			// unpack position
-			Vert.Pos.X = unpackuvert(averts[j+i*numVerts],0);
-			Vert.Pos.Y = unpackuvert(averts[j+i*numVerts],1);
-			Vert.Pos.Z = unpackuvert(averts[j+i*numVerts],2);
+			Vert.Pos = FVector3(unpackuvert(averts[j+i*numVerts],0),
+				unpackuvert(averts[j+i*numVerts],1),
+				unpackuvert(averts[j+i*numVerts],2));
 			// push vertex (without normals, will be calculated later)
 			verts.Push(Vert);
 		}
@@ -114,10 +114,7 @@ void FUE1Model::LoadGeometry()
 			Poly.V[j] = dpolys[i].vertices[j];
 		// unpack coords
 		for ( int j=0; j<3; j++ )
-		{
-			Poly.C[j].S = dpolys[i].uv[j][0]/255.f;
-			Poly.C[j].T = dpolys[i].uv[j][1]/255.f;
-		}
+			Poly.C[j] = FVector2(dpolys[i].uv[j][0]/255.f,dpolys[i].uv[j][1]/255.f);
 		Poly.texNum = dpolys[i].texnum;
 		// push
 		polys.Push(Poly);
@@ -129,39 +126,22 @@ void FUE1Model::LoadGeometry()
 	{
 		for ( int j=0; j<numVerts; j++ )
 		{
-			UE1Vector nsum = {0,0,0};
-			float total = 0.;
+			FVector3 nsum = FVector3(0,0,0);
 			for ( int k=0; k<numPolys; k++ )
 			{
 				if ( (polys[k].V[0] != j) && (polys[k].V[1] != j) && (polys[k].V[2] != j) ) continue;
-				UE1Vector vert[3], dir[2], norm;
+				FVector3 vert[3], dir[2], norm;
 				// compute facet normal
 				for ( int l=0; l<3; l++ )
 					vert[l] = verts[polys[k].V[l]+numVerts*i].Pos;
-				dir[0].X = vert[1].X-vert[0].X;
-				dir[0].Y = vert[1].Y-vert[0].Y;
-				dir[0].Z = vert[1].Z-vert[0].Z;
-				dir[1].X = vert[2].X-vert[0].X;
-				dir[1].Y = vert[2].Y-vert[0].Y;
-				dir[1].Z = vert[2].Z-vert[0].Z;
-				norm.X = dir[0].Y*dir[1].Z-dir[0].Z*dir[1].Y;
-				norm.Y = dir[0].Z*dir[1].X-dir[0].X*dir[1].Z;
-				norm.Z = dir[0].X*dir[1].Y-dir[0].Y*dir[1].X;
-				float s = (float)sqrt(norm.X*norm.X+norm.Y*norm.Y+norm.Z*norm.Z);
-				if ( s != 0.f )
-				{
-					norm.X /= s;
-					norm.Y /= s;
-					norm.Z /= s;
-				}
-				nsum.X += norm.X;
-				nsum.Y += norm.Y;
-				nsum.Z += norm.Z;
-				total+=1.f;
+				dir[0] = vert[1]-vert[0];
+				dir[1] = vert[2]-vert[0];
+				dir[0].MakeUnit();
+				dir[1].MakeUnit();
+				norm = dir[0]^dir[1];
+				nsum += norm.Unit();
 			}
-			verts[j+numVerts*i].Normal.X = nsum.X/total;
-			verts[j+numVerts*i].Normal.Y = nsum.Y/total;
-			verts[j+numVerts*i].Normal.Z = nsum.Z/total;
+			verts[j+numVerts*i].Normal = nsum.Unit();
 		}
 	}
 	// populate skin groups
@@ -242,12 +222,12 @@ void FUE1Model::BuildVertexBuffer( FModelRenderer *renderer )
 		{
 			for ( int k=0; k<groups[j].numPolys; k++ )
 			{
-				for ( int l=0; l<3; l++ )
+				for ( int l=2; l>=0; l-- )
 				{
 					UE1Vertex V = verts[polys[groups[j].P[k]].V[l]+i*numVerts];
-					UE1Coord C = polys[groups[j].P[k]].C[l];
+					FVector2 C = polys[groups[j].P[k]].C[l];
 					FModelVertex *vert = &vptr[vidx++];
-					vert->Set(V.Pos.X,V.Pos.Y,V.Pos.Z,C.S,C.T);
+					vert->Set(V.Pos.X,V.Pos.Y,V.Pos.Z,C.X,C.Y);
 					vert->SetNormal(V.Normal.X,V.Normal.Y,V.Normal.Z);
 				}
 			}

--- a/src/r_data/models/models_ue1.h
+++ b/src/r_data/models/models_ue1.h
@@ -56,22 +56,14 @@ private:
 	uint32_t * averts;
 
 	// converted data structures
-	struct UE1Coord
-	{
-		float S, T;
-	};
-	struct UE1Vector
-	{
-		float X, Y, Z;
-	};
 	struct UE1Vertex
 	{
-		UE1Vector Pos, Normal;
+		FVector3 Pos, Normal;
 	};
 	struct UE1Poly
 	{
 		int V[3];
-		UE1Coord C[3];
+		FVector2 C[3];
 		int texNum;
 	};
 	struct UE1Group


### PR DESCRIPTION
- Cleaned UE1 math by using FVector classes.
- Reversed winding order on vertex buffer creation as UE1 uses CCW.