### PR TITLE
Line_SetFlags implementation (See Comment!)

### DIFF
--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -2768,56 +2768,11 @@ FUNC(LS_Line_SetBlocking)
 FUNC(LS_Line_SetFlags)
 // Line_SetFlags (id, setflags, clearflags)
 {
-/*	static const uint32_t flagtrans[] =
-	{
-		ML_BLOCKING,
-		ML_BLOCKMONSTERS,
-		ML_TWOSIDED,
-		ML_DONTPEGTOP,
-		ML_DONTPEGBOTTOM,
-		ML_SECRET,
-		ML_SOUNDBLOCK,
-		ML_DONTDRAW,
-		ML_MAPPED,
-		ML_REPEAT_SPECIAL,
-		ML_ADDTRANS,
-		ML_MONSTERSCANACTIVATE,
-		ML_BLOCK_PLAYERS,
-		ML_BLOCKEVERYTHING,
-		ML_ZONEBOUNDARY,
-		ML_RAILING,
-		ML_BLOCK_FLOATERS,
-		ML_CLIP_MIDTEX,
-		ML_WRAP_MIDTEX,
-		ML_3DMIDTEX,
-		ML_CHECKSWITCHRANGE,
-		ML_FIRSTSIDEONLY,
-		ML_BLOCKPROJECTILE,
-		ML_BLOCKUSE,
-		ML_BLOCKSIGHT,
-		ML_BLOCKHITSCAN,
-		ML_3DMIDTEX_IMPASS,
-		ML_REVEALED,
-		ML_PORTALCONNECT, // UNUSABLE, Here to block off that for loop
-	};*/
-
-//	if (arg0 == 0) return false;
-	
-/*	int setflags = 0;
-	int clearflags = 0;
-
-	for (int i = 0; flagtrans[i] != ML_PORTALCONNECT; i++, arg1 >>= 1, arg2 >>= 1)
-	{
-		if (arg1 > 0) setflags |= flagtrans[i];
-		if (arg2 > 0) clearflags |= flagtrans[i];
-	}*/
-
 	FLineIdIterator itr(arg0);
 	int line;
 	while ((line = itr.Next()) >= 0)
 	{
 		level.lines[line].flags = (level.lines[line].flags & ~arg2) | arg1;
-//		level.lines[line].flags = (level.lines[line].flags & ~clearflags) | setflags;
 	}
 
 	return true;

--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -2765,6 +2765,63 @@ FUNC(LS_Line_SetBlocking)
 	return true;
 }
 
+FUNC(LS_Line_SetFlags)
+// Line_SetFlags (id, setflags, clearflags)
+{
+/*	static const uint32_t flagtrans[] =
+	{
+		ML_BLOCKING,
+		ML_BLOCKMONSTERS,
+		ML_TWOSIDED,
+		ML_DONTPEGTOP,
+		ML_DONTPEGBOTTOM,
+		ML_SECRET,
+		ML_SOUNDBLOCK,
+		ML_DONTDRAW,
+		ML_MAPPED,
+		ML_REPEAT_SPECIAL,
+		ML_ADDTRANS,
+		ML_MONSTERSCANACTIVATE,
+		ML_BLOCK_PLAYERS,
+		ML_BLOCKEVERYTHING,
+		ML_ZONEBOUNDARY,
+		ML_RAILING,
+		ML_BLOCK_FLOATERS,
+		ML_CLIP_MIDTEX,
+		ML_WRAP_MIDTEX,
+		ML_3DMIDTEX,
+		ML_CHECKSWITCHRANGE,
+		ML_FIRSTSIDEONLY,
+		ML_BLOCKPROJECTILE,
+		ML_BLOCKUSE,
+		ML_BLOCKSIGHT,
+		ML_BLOCKHITSCAN,
+		ML_3DMIDTEX_IMPASS,
+		ML_REVEALED,
+		ML_PORTALCONNECT, // UNUSABLE, Here to block off that for loop
+	};*/
+
+//	if (arg0 == 0) return false;
+	
+/*	int setflags = 0;
+	int clearflags = 0;
+
+	for (int i = 0; flagtrans[i] != ML_PORTALCONNECT; i++, arg1 >>= 1, arg2 >>= 1)
+	{
+		if (arg1 > 0) setflags |= flagtrans[i];
+		if (arg2 > 0) clearflags |= flagtrans[i];
+	}*/
+
+	FLineIdIterator itr(arg0);
+	int line;
+	while ((line = itr.Next()) >= 0)
+	{
+		level.lines[line].flags = (level.lines[line].flags & ~arg2) | arg1;
+//		level.lines[line].flags = (level.lines[line].flags & ~clearflags) | setflags;
+	}
+
+	return true;
+}
 
 
 FUNC(LS_ChangeCamera)
@@ -3713,7 +3770,7 @@ static lnSpecFunc LineSpecials[] =
 	/* 278 */ LS_Sector_SetCeilingGlow,
 	/* 279 */ LS_Floor_MoveToValueAndCrush,
 	/* 280 */ LS_Ceiling_MoveToValueAndCrush,
-
+	/* 281 */ LS_Line_SetFlags,
 
 };
 


### PR DESCRIPTION
NOTE: Please look at the way I did this before you accept it, because while I find it to be an efficient implementation, you might look at it and be like "no fucking way are we letting the mapper have DIRECT CONTROL over an internal variable from a line special."

Alternatively, you may also want to change the special number, possibly to make it available in a non-UDMF format...

That said...
This is an implementation of a Line_SetFlags special as mentioned in the following threads...
https://forum.zdoom.org/viewtopic.php?f=15&t=59808&start=15#p1044417
https://forum.zdoom.org/viewtopic.php?f=15&t=60315&p=1055471#p1050959
It works by simply taking a line tag, a set of flags to set, and a set of flags to unset, all of which basically correspond directly to the internal mapping of said flags.