### PR TITLE
Add missing line specials to ActionSpecials.h

### DIFF
--- a/src/actionspecials.h
+++ b/src/actionspecials.h
@@ -266,5 +266,7 @@ DEFINE_SPECIAL(Sector_SetFloorGlow, 277, 5, 5, 5)
 DEFINE_SPECIAL(Sector_SetCeilingGlow, 278, 5, 5, 5)
 DEFINE_SPECIAL(Floor_MoveToValueAndCrush, 279, 4, 5, 5)
 DEFINE_SPECIAL(Ceiling_MoveToValueAndCrush, 280, 4, 5, 5)
+DEFINE_SPECIAL(Line_SetAutomapFlags, 281, 2, 3, 3)
+DEFINE_SPECIAL(Line_SetAutomapStyle, 282, 2, 2, 2)
 
 #undef DEFINE_SPECIAL


### PR DESCRIPTION
Apparently RockstarRaccoon forgot to add line specials to this file, so I did it.