### PR TITLE
Front Face culling fixes

### DIFF
--- a/src/gl/models/gl_models.cpp
+++ b/src/gl/models/gl_models.cpp
@@ -65,7 +65,7 @@ void FGLModelRenderer::BeginDrawModel(AActor *actor, FSpriteModelFrame *smf, con
 	if (!(actor->RenderStyle == LegacyRenderStyles[STYLE_Normal]) && !(smf->flags & MDL_DONTCULLBACKFACES))
 	{
 		glEnable(GL_CULL_FACE);
-		glFrontFace((mirrored ^ GLPortal::isMirrored()) ? GL_CW : GL_CCW);
+		glFrontFace((mirrored ^ GLPortal::isMirrored()) ? GL_CCW : GL_CW);
 	}
 
 	gl_RenderState.mModelMatrix = objectToWorldMatrix;
@@ -91,7 +91,7 @@ void FGLModelRenderer::BeginDrawHUDModel(AActor *actor, const VSMatrix &objectTo
 	if (!(actor->RenderStyle == LegacyRenderStyles[STYLE_Normal]))
 	{
 		glEnable(GL_CULL_FACE);
-		glFrontFace((mirrored ^ GLPortal::isMirrored()) ? GL_CW : GL_CCW);
+		glFrontFace((mirrored ^ GLPortal::isMirrored()) ? GL_CCW : GL_CW);
 	}
 
 	gl_RenderState.mModelMatrix = objectToWorldMatrix;

--- a/src/polyrenderer/scene/poly_model.cpp
+++ b/src/polyrenderer/scene/poly_model.cpp
@@ -59,12 +59,14 @@ void PolyModelRenderer::BeginDrawModel(AActor *actor, FSpriteModelFrame *smf, co
 
 	if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal] || !!(smf->flags & MDL_DONTCULLBACKFACES))
 		PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, true);
+	PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, !mirrored);
 }
 
 void PolyModelRenderer::EndDrawModel(AActor *actor, FSpriteModelFrame *smf)
 {
 	if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal] || !!(smf->flags & MDL_DONTCULLBACKFACES))
 		PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, false);
+	PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, true);
 
 	ModelActor = nullptr;
 }
@@ -107,6 +109,7 @@ void PolyModelRenderer::BeginDrawHUDModel(AActor *actor, const VSMatrix &objectT
 
 	if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal])
 		PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, true);
+	PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, !mirrored);
 }
 
 void PolyModelRenderer::EndDrawHUDModel(AActor *actor)
@@ -116,6 +119,7 @@ void PolyModelRenderer::EndDrawHUDModel(AActor *actor)
 
 	if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal])
 		PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, false);
+	PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, true);
 }
 
 void PolyModelRenderer::SetInterpolation(double interpolation)

--- a/src/swrenderer/things/r_model.cpp
+++ b/src/swrenderer/things/r_model.cpp
@@ -123,12 +123,14 @@ namespace swrenderer
 
 		if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal] || !!(smf->flags & MDL_DONTCULLBACKFACES))
 			PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, true);
+		PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, !mirrored);
 	}
 
 	void SWModelRenderer::EndDrawModel(AActor *actor, FSpriteModelFrame *smf)
 	{
 		if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal] || !!(smf->flags & MDL_DONTCULLBACKFACES))
 			PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, false);
+		PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, true);
 
 		ModelActor = nullptr;
 	}
@@ -192,6 +194,7 @@ namespace swrenderer
 
 		if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal])
 			PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, true);
+		PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, !mirrored);
 	}
 
 	void SWModelRenderer::EndDrawHUDModel(AActor *actor)
@@ -201,6 +204,7 @@ namespace swrenderer
 
 		if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal])
 			PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, false);
+		PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, true);
 	}
 
 	void SWModelRenderer::SetInterpolation(double interpolation)


### PR DESCRIPTION
GL model drawer should use CCW for non-mirrored and CW for mirrored. This is the default in pretty much every single other 3D application in the world.

Also, while I was at it, I added handling of mirroring to software models, too.

This has been tested and works properly across all renderers on both a [sphere mesh from Unreal 1](https://marisakirisa.me/tmp/modelflip_m.pk3) and a [MD3 freshly exported from Blender](https://marisakirisa.me/tmp/modelflip_md3_m.pk3). Both cases use, of course, counter-clockwise order for front faces.