### PR TITLE
Restore pre-ZScript behaviour of A_BrainExplode and A_BrainScream.

### DIFF
--- a/wadsrc/static/zscript/doom/bossbrain.txt
+++ b/wadsrc/static/zscript/doom/bossbrain.txt
@@ -153,17 +153,41 @@ extend class Actor
 
 	private static void BrainishExplosion(vector3 pos)
 	{
-		Actor boom = Actor.Spawn("Rocket", pos, NO_REPLACE);
-		if (boom)
+		Actor boom = Actor.Spawn("BossBrain", pos, ALLOW_REPLACE);
+		if (boom && boom.ResolveState("Brainexplode"))
 		{
 			boom.DeathSound = "misc/brainexplode";
 			boom.Vel.z = random[BrainScream](0, 255)/128.;
 
 			boom.SetStateLabel ("Brainexplode");
 			boom.bRocketTrail = false;
+			boom.bNOGRAVITY = true;
+			boom.bSOLID = false;
+			boom.bSHOOTABLE = false;
+			boom.A_SetMass(100);
 			boom.SetDamage(0);	// disables collision detection which is not wanted here
 			boom.tics -= random[BrainScream](0, 7);
 			if (boom.tics < 1) boom.tics = 1;
+		}
+		else 
+		{
+			boom.Destroy();
+			Actor boom = Actor.Spawn("BossBrain",pos,NO_REPLACE);
+			if (boom && boom.ResolveState("Brainexplode"))
+			{
+				boom.DeathSound = "misc/brainexplode";
+				boom.Vel.z = random[BrainScream](0, 255)/128.;
+
+				boom.SetStateLabel ("Brainexplode");
+				boom.bRocketTrail = false;
+				boom.bNOGRAVITY = true;
+				boom.bSOLID = false;
+				boom.bSHOOTABLE = false;
+				boom.A_SetMass(100);
+				boom.SetDamage(0);	// disables collision detection which is not wanted here
+				boom.tics -= random[BrainScream](0, 7);
+				if (boom.tics < 1) boom.tics = 1;
+			}
 		}
 	}
 	


### PR DESCRIPTION
This should allow mods to replace BossBrain in DECORATE without having to mess with ZScript functions.

I called it pre-ZScript because both A_BrainExplode and A_BrainScream allowed usage of custom BrainExplode states before the switch to ZScript for built-in actors.