### PR TITLE
Restore pre-ZScript behaviour of A_BrainExplode and A_BrainScream.

### DIFF
--- a/wadsrc/static/zscript/doom/bossbrain.txt
+++ b/wadsrc/static/zscript/doom/bossbrain.txt
@@ -31,6 +31,10 @@ class BossBrain : Actor
 		BBRN AA 10;
 		BBRN A -1 A_BrainDie;
 		Stop;
+	BrainExplode:
+		MISL BC 10 Bright;
+		MISL D 10 A_BrainExplode;
+		Stop;
 	}
 }
 
@@ -153,17 +157,41 @@ extend class Actor
 
 	private static void BrainishExplosion(vector3 pos)
 	{
-		Actor boom = Actor.Spawn("Rocket", pos, NO_REPLACE);
-		if (boom)
+		Actor boom = Actor.Spawn("BossBrain", pos, ALLOW_REPLACE);
+		if (boom && boom.ResolveState("Brainexplode"))
 		{
 			boom.DeathSound = "misc/brainexplode";
 			boom.Vel.z = random[BrainScream](0, 255)/128.;
 
 			boom.SetStateLabel ("Brainexplode");
 			boom.bRocketTrail = false;
+			boom.bNOGRAVITY = true;
+			boom.bSOLID = false;
+			boom.bSHOOTABLE = false;
+			boom.A_SetMass(100);
 			boom.SetDamage(0);	// disables collision detection which is not wanted here
 			boom.tics -= random[BrainScream](0, 7);
 			if (boom.tics < 1) boom.tics = 1;
+		}
+		else 
+		{
+			boom.Destroy();
+			Actor boom = Actor.Spawn("BossBrain",pos,NO_REPLACE);
+			if (boom && boom.ResolveState("Brainexplode"))
+			{
+				boom.DeathSound = "misc/brainexplode";
+				boom.Vel.z = random[BrainScream](0, 255)/128.;
+
+				boom.SetStateLabel ("Brainexplode");
+				boom.bRocketTrail = false;
+				boom.bNOGRAVITY = true;
+				boom.bSOLID = false;
+				boom.bSHOOTABLE = false;
+				boom.A_SetMass(100);
+				boom.SetDamage(0);	// disables collision detection which is not wanted here
+				boom.tics -= random[BrainScream](0, 7);
+				if (boom.tics < 1) boom.tics = 1;
+			}
 		}
 	}
 	

--- a/wadsrc/static/zscript/doom/weaponrlaunch.txt
+++ b/wadsrc/static/zscript/doom/weaponrlaunch.txt
@@ -70,10 +70,6 @@ class Rocket : Actor
 		MISL C 6 Bright;
 		MISL D 4 Bright;
 		Stop;
-	BrainExplode:
-		MISL BC 10 Bright;
-		MISL D 10 A_BrainExplode;
-		Stop;
 	}
 }
 


### PR DESCRIPTION
This should allow mods to replace BossBrain in DECORATE without having to mess with ZScript functions.