### PR TITLE
Mirroring should be flipped on HUD models

### DIFF
--- a/src/gl/models/gl_models.cpp
+++ b/src/gl/models/gl_models.cpp
@@ -91,7 +91,7 @@ void FGLModelRenderer::BeginDrawHUDModel(AActor *actor, const VSMatrix &objectTo
 	if (!(actor->RenderStyle == LegacyRenderStyles[STYLE_Normal]))
 	{
 		glEnable(GL_CULL_FACE);
-		glFrontFace((mirrored ^ GLPortal::isMirrored()) ? GL_CCW : GL_CW);
+		glFrontFace((mirrored ^ GLPortal::isMirrored()) ? GL_CW : GL_CCW);
 	}
 
 	gl_RenderState.mModelMatrix = objectToWorldMatrix;

--- a/src/polyrenderer/scene/poly_model.cpp
+++ b/src/polyrenderer/scene/poly_model.cpp
@@ -109,7 +109,7 @@ void PolyModelRenderer::BeginDrawHUDModel(AActor *actor, const VSMatrix &objectT
 
 	if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal])
 		PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, true);
-	PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, !mirrored);
+	PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, mirrored);
 }
 
 void PolyModelRenderer::EndDrawHUDModel(AActor *actor)

--- a/src/swrenderer/things/r_model.cpp
+++ b/src/swrenderer/things/r_model.cpp
@@ -194,7 +194,7 @@ namespace swrenderer
 
 		if (actor->RenderStyle == LegacyRenderStyles[STYLE_Normal])
 			PolyTriangleDrawer::SetTwoSided(Thread->DrawQueue, true);
-		PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, !mirrored);
+		PolyTriangleDrawer::SetCullCCW(Thread->DrawQueue, mirrored);
 	}
 
 	void SWModelRenderer::EndDrawHUDModel(AActor *actor)


### PR DESCRIPTION
The view to world space transform always inverts the X axis, so this should be factored in for the mirroring behaviour. This 100% fixes HUD models with transparent renderstyles.

I guess I didn't really test my previous PR thoroughly.