### PR TITLE
Add RenderStyle API

### DIFF
--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -287,6 +287,36 @@ struct Translation version("2.4")
 	}
 }
 
+struct RenderStyle
+{
+	static int CreateLegacy(ERenderStyle style)
+	{
+		switch(style)
+		{
+		case STYLE_None: return Create(STYLEOP_None, STYLEALPHA_Zero, STYLEALPHA_Zero, 0);
+		case STYLE_Normal: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_InvSrc, STYLEF_Alpha1);
+		case STYLE_Fuzzy: return Create(STYLEOP_Fuzz, STYLEALPHA_Src, STYLEALPHA_InvSrc, 0);
+		case STYLE_SoulTrans: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_InvSrc, STYLEF_TransSoulsAlpha);
+		case STYLE_OptFuzzy: return Create(STYLEOP_FuzzOrAdd, STYLEALPHA_Src, STYLEALPHA_InvSrc, 0);
+		case STYLE_Stencil: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_InvSrc, STYLEF_Alpha1 | STYLEF_ColorIsFixed);
+		case STYLE_Translucent: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_InvSrc, 0);
+		case STYLE_Add: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_One, 0);
+		case STYLE_Shaded: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_InvSrc, STYLEF_RedIsAlpha | STYLEF_ColorIsFixed);
+		case STYLE_TranslucentStencil: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_InvSrc, STYLEF_ColorIsFixed);
+		case STYLE_Shadow: return Create(STYLEOP_Shadow, 0, 0, 0);
+		case STYLE_Subtract: return Create(STYLEOP_RevSub, STYLEALPHA_Src, STYLEALPHA_One, 0);
+		case STYLE_AddStencil: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_One, STYLEF_Alpha1 | STYLEF_ColorIsFixed);
+		case STYLE_AddShaded: return Create(STYLEOP_Add, STYLEALPHA_Src, STYLEALPHA_One, STYLEF_RedIsAlpha | STYLEF_ColorIsFixed);
+		default: Object.ThrowAbortException("Unsupported or invalid legacy render style."); return 0;
+		}
+	}
+
+	static int Create(ERenderOp blendOp, ERenderAlpha srcAlpha, ERenderAlpha dstAlpha, ERenderFlags flags)
+	{
+		return blendOp | (srcAlpha << 8) | (dstAlpha << 16) | (flags << 24);
+	}
+}
+
 struct Console native
 {
 	native static void HideConsole();

--- a/wadsrc/static/zscript/constants.txt
+++ b/wadsrc/static/zscript/constants.txt
@@ -850,6 +850,61 @@ enum ERenderStyle
 	STYLE_AddShaded,
 };
 
+enum ERenderOp
+{
+	STYLEOP_None,         // Do not draw
+	STYLEOP_Add,          // Add source to destination
+	STYLEOP_Sub,          // Subtract source from destination
+	STYLEOP_RevSub,       // Subtract destination from source
+	STYLEOP_Fuzz,         // Draw fuzzy on top of destination - ignores alpha and color
+	STYLEOP_FuzzOrAdd,    // Draw fuzzy or add, based on user preference
+	STYLEOP_FuzzOrSub,    // Draw fuzzy or subtract, based on user preference
+	STYLEOP_FuzzOrRevSub, // Draw fuzzy or reverse subtract, based on user preference
+
+	// special styles
+	STYLEOP_Shadow,            
+};
+
+enum ERenderAlpha
+{
+	STYLEALPHA_Zero,   // Blend factor is 0.0
+	STYLEALPHA_One,    // Blend factor is 1.0
+	STYLEALPHA_Src,    // Blend factor is alpha
+	STYLEALPHA_InvSrc, // Blend factor is 1.0 - alpha
+};
+
+enum ERenderFlags
+{
+	// Use value of transsouls as alpha.
+	STYLEF_TransSoulsAlpha = 1,
+
+	// Force alpha to 1. Not the same as STYLEALPHA_One, since that also
+	// ignores alpha from the texture.
+	STYLEF_Alpha1 = 2,
+
+	// Use red component from grayscale/RGB texture as alpha. If the texture
+	// is paletted, the palette is ignored and it is treated as grayscale.
+	// This should generally be combined with STYLEF_ColorIsFixed, since that's
+	// all the software renderer supports, but hardware acceleration can do
+	// them separately should you want to do that for some reason.
+	STYLEF_RedIsAlpha = 4,
+
+	// Ignore texture for RGB output. Color comes from fillcolor for actors
+	// or DTA_FillColor for DrawTexture().
+	STYLEF_ColorIsFixed = 8,
+
+	// Invert source color, either the texture color or the fixed color.
+	STYLEF_InvertSource = 16,
+
+	// Invert overlay color. This is the fade for actors and DTA_ColorOverlay
+	// for DrawTexture().
+	STYLEF_InvertOverlay = 32,
+
+	// Actors only: Ignore sector fade and fade to black. To fade to white,
+	// combine this with STYLEF_InvertOverlay.
+	STYLEF_FadeToBlack = 64,
+};
+
 // Type definition for the implicit 'callingstate' parameter that gets passed to action functions.
 enum EStateType
 {


### PR DESCRIPTION
Currently, ZScript has no API for working with non-legacy render styles, which poses an issue when working with the Screen.* API, as it expects the 4-component representation of a render style when using DTA_RenderStyle.

This PR solves the issue by offering two new functions.

* `RenderStyle.CreateLegacy(ERenderStyle style)`
    * Creates a 4-component render style from a legacy render style, throws an abort exception if an invalid legacy render style is supplied
* `RenderStyle.Create(ERenderOp blendOp, ERenderAlpha srcAlpha, ERenderAlpha dstAlpha, ERenderFlags flags)`
    * Creates a 4-component render style from the values provided