### PR TITLE
add tags for Doom and Heretic monsters

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -598,6 +598,27 @@ CC_SPIDER = "THE SPIDER MASTERMIND";
 CC_CYBER = "THE CYBERDEMON";
 CC_HERO = "OUR HERO";
 
+// Friendly names
+FN_ZOMBIE = "Zombieman";
+FN_SHOTGUN = "Sergeant";
+FN_HEAVY = "Chaingunner";
+FN_IMP = "Imp";
+FN_DEMON = "Demon";
+FN_SPECTRE = "Spectre";
+FN_LOST = "Lost Soul";
+FN_CACO = "Cacodemon";
+FN_HELL = "Hell Knight";
+FN_BARON = "Baron of Hell";
+FN_ARACH = "Arachnotron";
+FN_PAIN = "Pain Elemental";
+FN_REVEN = "Revenant";
+FN_MANCU = "Mancubus";
+FN_ARCH = "Arch-vile";
+FN_SPIDER = "Spider Mastermind";
+FN_CYBER = "Cyberdemon";
+FN_WOLFSS = "Nazi";
+FN_DOG = "Dog";
+
 // New strings from BOOM
 PD_BLUEC = "You need a blue card to open this door";
 PD_REDC = "You need a red card to open this door";
@@ -1299,6 +1320,20 @@ TXT_IMSECRETS = "SECRETS";
 TXT_IMTIME = "TIME";
 
 RAVENQUITMSG = "ARE YOU SURE YOU WANT TO QUIT?";
+
+// Friendly names
+FN_CHICKEN = "Chicken";
+FN_BEAST = "Weredragon";
+FN_CLINK = "Sabreclaw";
+FN_DSPARIL = "D'Sparil";
+FN_HERETICIMP = "Gargoyle";
+FN_IRONLICH = "Ironlich";
+FN_BONEKNIGHT = "Undead Warrior";
+FN_MINOTAUR = "Maulotaur";
+FN_MUMMY = "Golem";
+FN_MUMMYLEADER = "Nitrogolem";
+FN_SNAKE = "Ophidian";
+FN_WIZARD = "Wizard";
 
 // Hexen strings
 

--- a/wadsrc/static/zscript/doom/arachnotron.txt
+++ b/wadsrc/static/zscript/doom/arachnotron.txt
@@ -21,6 +21,7 @@ class Arachnotron : Actor
 		DeathSound "baby/death";
 		ActiveSound "baby/active";
 		Obituary "$OB_BABY";
+		Tag "$FN_ARACH";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/archvile.txt
+++ b/wadsrc/static/zscript/doom/archvile.txt
@@ -25,6 +25,7 @@ class Archvile : Actor
 		ActiveSound "vile/active";
 		MeleeSound "vile/stop";
 		Obituary "$OB_VILE";
+		Tag "$FN_ARCH";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/bruiser.txt
+++ b/wadsrc/static/zscript/doom/bruiser.txt
@@ -22,6 +22,7 @@ class BaronOfHell : Actor
 		ActiveSound "baron/active";
 		Obituary "$OB_BARON";
 		HitObituary "$OB_BARONHIT";
+		Tag "$FN_BARON";
 	}
 	States
 	{
@@ -72,6 +73,7 @@ class HellKnight : BaronOfHell
 		DeathSound "knight/death";
 		HitObituary "$OB_KNIGHTHIT";
 		Obituary "$OB_KNIGHT";
+		Tag "$FN_HELL";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/cacodemon.txt
+++ b/wadsrc/static/zscript/doom/cacodemon.txt
@@ -21,6 +21,7 @@ class Cacodemon : Actor
 		ActiveSound "caco/active";
 		Obituary "$OB_CACO";
 		HitObituary "$OB_CACOHIT";
+		Tag "$FN_CACO";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/cyberdemon.txt
+++ b/wadsrc/static/zscript/doom/cyberdemon.txt
@@ -27,6 +27,7 @@ class Cyberdemon : Actor
 		DeathSound "cyber/death";
 		ActiveSound "cyber/active";
 		Obituary "$OB_CYBORG";
+		Tag "$FN_CYBER";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/demon.txt
+++ b/wadsrc/static/zscript/doom/demon.txt
@@ -21,6 +21,7 @@ class Demon : Actor
 		DeathSound "demon/death";
 		ActiveSound "demon/active";
 		Obituary "$OB_DEMONHIT";
+		Tag "$FN_DEMON";
 	}
 	States
 	{
@@ -71,6 +72,7 @@ class Spectre : Demon
 		DeathSound "spectre/death";
 		ActiveSound "spectre/active";
 		HitObituary "$OB_SPECTREHIT";
+		Tag "$FN_SPECTRE";
 	}
 }
 

--- a/wadsrc/static/zscript/doom/doomimp.txt
+++ b/wadsrc/static/zscript/doom/doomimp.txt
@@ -21,6 +21,7 @@ class DoomImp : Actor
 		ActiveSound "imp/active";
 		HitObituary "$OB_IMPHIT";
 		Obituary "$OB_IMP";
+		Tag "$FN_IMP";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/fatso.txt
+++ b/wadsrc/static/zscript/doom/fatso.txt
@@ -21,6 +21,7 @@ class Fatso : Actor
 		DeathSound "fatso/death";
 		ActiveSound "fatso/active";
 		Obituary "$OB_FATSO";
+		Tag "$FN_MANCU";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/lostsoul.txt
+++ b/wadsrc/static/zscript/doom/lostsoul.txt
@@ -22,6 +22,7 @@ class LostSoul : Actor
 		ActiveSound "skull/active";
 		RenderStyle "SoulTrans";
 		Obituary "$OB_SKULL";
+		Tag "$FN_LOST";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/painelemental.txt
+++ b/wadsrc/static/zscript/doom/painelemental.txt
@@ -20,6 +20,7 @@ class PainElemental : Actor
 		PainSound "pain/pain";
 		DeathSound "pain/death";
 		ActiveSound "pain/active";
+		Tag "$FN_PAIN";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/possessed.txt
+++ b/wadsrc/static/zscript/doom/possessed.txt
@@ -21,6 +21,7 @@ class ZombieMan : Actor
 		DeathSound "grunt/death";
 		ActiveSound "grunt/active";
 		Obituary "$OB_ZOMBIE";
+		Tag "$FN_ZOMBIE";
 		DropItem "Clip";
 	}
 	States
@@ -84,6 +85,7 @@ class ShotgunGuy : Actor
 		DeathSound "shotguy/death";
 		ActiveSound "shotguy/active";
 		Obituary "$OB_SHOTGUY";
+		Tag "$FN_SHOTGUN";
 		DropItem "Shotgun";
 	}
 	States
@@ -147,6 +149,7 @@ class ChaingunGuy : Actor
 		ActiveSound "chainguy/active";
 		AttackSound "chainguy/attack";
 		Obituary "$OB_CHAINGUY";
+		Tag "$FN_HEAVY";
 		Dropitem "Chaingun";
 	}
 	States
@@ -209,6 +212,7 @@ class WolfensteinSS : Actor
 		ActiveSound "wolfss/active";
 		AttackSound "wolfss/attack";
 		Obituary "$OB_WOLFSS";
+		Tag "$FN_WOLFSS";
 		Dropitem "Clip";
 	}
 	States

--- a/wadsrc/static/zscript/doom/revenant.txt
+++ b/wadsrc/static/zscript/doom/revenant.txt
@@ -24,6 +24,7 @@ class Revenant : Actor
 		MeleeSound "skeleton/melee";
 		HitObituary "$OB_UNDEADHIT";
 		Obituary "$OB_UNDEAD";
+		Tag "$FN_REVEN";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/doom/spidermaster.txt
+++ b/wadsrc/static/zscript/doom/spidermaster.txt
@@ -26,6 +26,7 @@ class SpiderMastermind : Actor
 		DeathSound "spider/death";
 		ActiveSound "spider/active";
 		Obituary "$OB_SPIDER";
+		Tag "$FN_SPIDER";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/heretic/beast.txt
+++ b/wadsrc/static/zscript/heretic/beast.txt
@@ -19,6 +19,7 @@ class Beast : Actor
 		DeathSound "beast/death";
 		ActiveSound "beast/active";
 		Obituary "$OB_BEAST";
+		Tag "$FN_BEAST";
 		DropItem "CrossbowAmmo", 84, 10;
 	}
 	States

--- a/wadsrc/static/zscript/heretic/chicken.txt
+++ b/wadsrc/static/zscript/heretic/chicken.txt
@@ -256,6 +256,7 @@ class Chicken : MorphedMonster
 		DeathSound "chicken/death";
 		ActiveSound "chicken/active";
 		Obituary "$OB_CHICKEN";
+		Tag "$FN_CHICKEN";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/heretic/clink.txt
+++ b/wadsrc/static/zscript/heretic/clink.txt
@@ -17,6 +17,7 @@ class Clink : Actor
 		DeathSound "clink/death";
 		ActiveSound "clink/active";
 		Obituary "$OB_CLINK";
+		Tag "$FN_CLINK";
 		DropItem "SkullRodAmmo", 84, 20;
 	}
 	States

--- a/wadsrc/static/zscript/heretic/dsparil.txt
+++ b/wadsrc/static/zscript/heretic/dsparil.txt
@@ -36,6 +36,7 @@ class Sorcerer1 : Actor
 		ActiveSound "dsparilserpent/active";
 		Obituary "$OB_DSPARIL1";
 		HitObituary "$OB_DSPARIL1HIT";
+		Tag "$FN_DSPARIL";
 	}
 
 
@@ -237,6 +238,7 @@ class Sorcerer2 : Actor
 		ActiveSound "dsparil/active";
 		Obituary "$OB_DSPARIL2";
 		HitObituary "$OB_DSPARIL2HIT";
+		Tag "$FN_DSPARIL";
 	}
 
 

--- a/wadsrc/static/zscript/heretic/hereticimp.txt
+++ b/wadsrc/static/zscript/heretic/hereticimp.txt
@@ -26,6 +26,7 @@ class HereticImp : Actor
 		ActiveSound "himp/active";
 		Obituary "$OB_HERETICIMP";
 		HitObituary "$OB_HERETICIMPHIT";
+		Tag "$FN_HERETICIMP";
 	}
 	
 	States

--- a/wadsrc/static/zscript/heretic/ironlich.txt
+++ b/wadsrc/static/zscript/heretic/ironlich.txt
@@ -23,6 +23,7 @@ class Ironlich : Actor
 		ActiveSound "ironlich/active";
 		Obituary "$OB_IRONLICH";
 		HitObituary "$OB_IRONLICHHIT";
+		Tag "$FN_IRONLICH";
 		DropItem "BlasterAmmo", 84, 10;
 		DropItem "ArtiEgg", 51, 0;
 	}

--- a/wadsrc/static/zscript/heretic/knight.txt
+++ b/wadsrc/static/zscript/heretic/knight.txt
@@ -20,6 +20,7 @@ class Knight : Actor
 		ActiveSound "hknight/active";
 		Obituary "$OB_BONEKNIGHT";
 		HitObituary "$OB_BONEKNIGHTHIT";
+		Tag "$FN_BONEKNIGHT";
 		DropItem "CrossbowAmmo", 84, 5;
 	}
 	

--- a/wadsrc/static/zscript/heretic/mummy.txt
+++ b/wadsrc/static/zscript/heretic/mummy.txt
@@ -19,6 +19,7 @@ class Mummy : Actor
 		DeathSound "mummy/death";
 		ActiveSound "mummy/active";
 		HitObituary "$OB_MUMMY";
+		Tag "$FN_MUMMY";
 		DropItem "GoldWandAmmo", 84, 3;
 	}
 	States
@@ -60,6 +61,7 @@ class MummyLeader : Mummy
 		Health 100;
 		Painchance 64;
 		Obituary "$OB_MUMMYLEADER";
+		Tag "$FN_MUMMYLEADER";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/heretic/snake.txt
+++ b/wadsrc/static/zscript/heretic/snake.txt
@@ -16,6 +16,7 @@ class Snake : Actor
 		DeathSound "snake/death";
 		ActiveSound "snake/active";
 		Obituary "$OB_SNAKE";
+		Tag "$FN_SNAKE";
 		DropItem "PhoenixRodAmmo", 84, 5;
 	}
 	States

--- a/wadsrc/static/zscript/heretic/wizard.txt
+++ b/wadsrc/static/zscript/heretic/wizard.txt
@@ -22,6 +22,7 @@ class Wizard : Actor
 		ActiveSound "wizard/active";
 		Obituary "$OB_WIZARD";
 		HitObituary "$OB_WIZARDHIT";
+		Tag "$FN_WIZARD";
 		DropItem "BlasterAmmo", 84, 10;
 		DropItem "ArtiTomeOfPower", 4, 0;
 	}

--- a/wadsrc/static/zscript/raven/minotaur.txt
+++ b/wadsrc/static/zscript/raven/minotaur.txt
@@ -30,6 +30,7 @@ class Minotaur : Actor
 		DropItem "PhoenixRodAmmo", 84, 10;
 		Obituary "$OB_MINOTAUR";
 		HitObituary "$OB_MINOTAURHIT";
+		Tag "$FN_MINOTAUR";
 	}
 
 	States

--- a/wadsrc/static/zscript/shared/dog.txt
+++ b/wadsrc/static/zscript/shared/dog.txt
@@ -16,6 +16,7 @@ class MBFHelperDog : Actor
 		PainSound "dog/pain";
 		SeeSound "dog/sight";
 		Obituary "$OB_DOG";
+		Tag "$FN_DOG";
 	}
 	States
 	{


### PR DESCRIPTION
Why? So mods that reveal enemy names don't show internal monster class names.

Tags are based on language.enu lump obituaries.