### PR TITLE
Various map and compatibility fixes

### DIFF
--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -59,6 +59,7 @@ F84AB4557464A383E93F37CD3A82AC48 // MM2 map03
 71C2E6D9CFA3D8750C6A9599FB2453BD // Hacx map03: There are some switches behind 
 96368EB950E33AF62EA6423434E3CEF7 // HacX map17: shootable covers in these levels
 BA530202AF0BA0C6CBAE6A0C7076FB72 // Requiem map04
+E2819F69CB79BA66E0ACBCD7DE652F9D // Hell to Pay MAP32: Exit switch pressable through lasers
 {
 	useblocking
 }

--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -401,6 +401,26 @@ class LevelCompatibility play
 				}
 				break;
 			}
+			
+			case '915409A89746D6BFD92C7956BE6A0A2D': // Doom II: BFG Edition MAP33
+			{
+				// Missing textures on sector with a Super Shotgun at map start.
+				TextureID rock2 = TexMan.CheckForTexture("ROCK2", TexMan.Type_Wall);
+				for(int i=0; i<4; i++)
+				{
+					SetWallTextureID(567+i, Line.front, Side.bottom, ROCK2);
+					SetWallTextureID(567+i, Line.back, Side.top, ROCK2);
+				}
+				// Tags the linedefs on the teleporter at the end of the level so that
+				// it's possible to leave the room near the yellow keycard door.
+				for(int i=0; i<2; i++)
+				{
+					SetLineSpecial(400+i, Teleport, 0, 36);
+					SetLineSpecial(559+i, Teleport, 0, 36);
+				}
+				break;
+			}
+
 			case 'ABC4EB5A1535ECCD0061AD14F3547908': // Plutonia Experiment, map26
 			{
 				SetSectorSpecial(156, 0);
@@ -700,6 +720,48 @@ class LevelCompatibility play
 			{
 				// Restore monster cross flag for DeHackEd friendly marine
 				GetDefaultActor('WolfensteinSS').bActivateMCross = true;
+				break;
+			}
+			
+			case 'D67CECE3F60083383DF992B8C824E4AC': // Icarus: Alien Vanuguard MAP13
+			{
+				// Moves sector special to platform with Berserk powerup. The
+				// map's only secret can now be scored.
+				SetSectorSpecial(119, 0);
+				SetSectorSpecial(122, 1024);
+				break;
+			}
+			
+			case '61373587339A768854E2912CC99A4781': // Icarus: Alien Vanuguard MAP15
+			{
+				// Can press use on the lift to reveal the secret Shotgun,
+				// making 100% secrets possible.
+				SetLineSpecial(222, Plat_DownWaitUpStayLip, 11, 64, 105, 0);
+				SetLineActivation(222, SPAC_Use);
+				SetLineFlags(222, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+			
+			case '9F66B0797925A09D4DC0725540F8EEF7': // Icarus: Alien Vanuguard MAP16
+			{
+				// Can press use on the walls at the secret Rocket Launcher in
+				// case of getting stuck.
+				for(int i=0; i<7; i++)
+				{
+					SetLineSpecial(703+i, Plat_DownWaitUpStayLip, 14, 64, 105, 0);
+					SetLineActivation(703+i, SPAC_Use);
+					SetLineFlags(703+i, Line.ML_REPEAT_SPECIAL);
+				}
+				break;
+			}
+			
+			case '09645D198010BF634EF0DE3EFCB0052C': // Flashback to Hell MAP12
+			{
+				// Can press use behind bookshelf in case of getting stuck.
+				SetLineSpecial(4884, Plat_DownWaitUpStayLip, 15, 32, 105, 0);
+				SetLineActivation(4884, SPAC_Use);
+				SetLineActivation(4884, SPAC_UseBack);
+				SetLineFlags(4884, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 		}


### PR DESCRIPTION
Provides fixes to the following:

Doom II: BFG Edition MAP33 - Fixes the infamous teleporter bug and fixes missing textures.
Icarus: Alien Vanguard (ICARUS.WAD) - Fixes secrets for MAP13 and MAP15. It is now possible to get unstuck at MAP16's Rocket Launcher secret.
Flashback to Hell (fth666.wad) - MAP12 bookshelf can be lowered now in case of being locked in the room.
Hell to Pay (HTP-RAW.WAD) - MAP32 compatibility fix. Previously it was possible to press the exit switch without having to raising the "lasers" if compatibility setting is not set to something like "Doom."