### PR TITLE
Custom hardware shaders now can use custom texture units

### DIFF
--- a/src/hwrenderer/textures/hw_material.cpp
+++ b/src/hwrenderer/textures/hw_material.cpp
@@ -154,6 +154,12 @@ FMaterial::FMaterial(FTexture * tx, bool expanded)
 	{
 		if (tx->shaderindex >= FIRST_USER_SHADER)
 		{
+			for (auto &texture : tx->CustomShaderTextures)
+			{
+				if(texture == nullptr) continue;
+				ValidateSysTexture(texture, expanded);
+				mTextureLayers.Push({ texture, false });
+			}
 			mShaderIndex = tx->shaderindex;
 		}
 		else

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1350,7 +1350,7 @@ class GLDefsParser
 					sc.MustGetString();
 					FString textureSource = sc.String;
 
-					shaderdesc.Textures[textureName] = textureSource;
+
 				}
 				else if (sc.Compare("enabled"))
 				{
@@ -1397,6 +1397,24 @@ class GLDefsParser
 				{
 					sc.MustGetFloat();
 					speed = float(sc.Float);
+				}
+				else if (sc.Compare("texture"))
+				{
+					sc.MustGetString();
+					bool okay = false;
+					for(int i = 0; i < MAX_CUSTOM_HW_SHADER_TEXTURES; i++) {
+						if(!tex->CustomShaderTextures[i]) {
+							tex->CustomShaderTextures[i] = TexMan.FindTexture(sc.String, ETextureType::Any, FTextureManager::TEXMAN_TryAny);
+							if (!tex->CustomShaderTextures[i]) {
+								sc.ScriptError("Custom hardware shader texture '%s' not found in texture '%s'\n", sc.String, tex? tex->Name.GetChars() : "(null)");
+							}
+							okay = true;
+							break;
+						}
+					}
+					if(!okay) {
+						sc.ScriptError("Error: out of texture units in texture '%s'", tex? tex->Name.GetChars() : "(null)");
+					}
 				}
 			}
 			if (!tex)

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1350,7 +1350,7 @@ class GLDefsParser
 					sc.MustGetString();
 					FString textureSource = sc.String;
 
-
+					shaderdesc.Textures[textureName] = textureSource;
 				}
 				else if (sc.Compare("enabled"))
 				{

--- a/src/textures/textures.h
+++ b/src/textures/textures.h
@@ -44,6 +44,9 @@
 #include "r_data/r_translate.h"
 #include <vector>
 
+// 15 because 0th texture is our texture
+#define MAX_CUSTOM_HW_SHADER_TEXTURES 15
+
 typedef TMap<int, bool> SpriteHits;
 
 enum MaterialShaderIndex
@@ -244,6 +247,8 @@ public:
 	FTexture *Metallic = nullptr;						// Metalness texture for the physically based rendering (PBR) light model
 	FTexture *Roughness = nullptr;						// Roughness texture for PBR
 	FTexture *AmbientOcclusion = nullptr;				// Ambient occlusion texture for PBR
+	
+	FTexture *CustomShaderTextures[MAX_CUSTOM_HW_SHADER_TEXTURES] = { nullptr }; // Custom texture maps for custom hardware shaders
 
 	FString Name;
 	ETextureType UseType;	// This texture's primary purpose


### PR DESCRIPTION
Custom hardware shaders now can use custom texture units.

To use this feature, do like this:

```
HardwareShader Texture REDTEX
{
	Shader "lol.glsl"
	Speed 1
	Texture "AAAA"
	Texture "BBBB"
}
```

You will get textures `AAAA` and `BBBB` as `sampler2D`s `texture2` and `texture3`, respectively.