### PR TITLE
Custom hardware shaders now can use custom texture units

### DIFF
--- a/src/gl/shaders/gl_shader.cpp
+++ b/src/gl/shaders/gl_shader.cpp
@@ -496,6 +496,7 @@ static const FDefaultShader defaultshaders[]=
 };
 
 TArray<FString> usershaders;
+TArray<FString> usermaterials;
 
 struct FEffectShader
 {
@@ -647,7 +648,7 @@ void FShaderCollection::CompileShaders(EPassType passType)
 		FString name = ExtractFileBase(usershaders[i]);
 		FName sfn = name;
 
-		FShader *shc = Compile(sfn, usershaders[i], "shaders/glsl/material_normal.fp", "", true, passType);
+		FShader *shc = Compile(sfn, usershaders[i], usermaterials[i], "", true, passType);
 		mMaterialShaders.Push(shc);
 	}
 

--- a/src/gl/shaders/gl_shader.cpp
+++ b/src/gl/shaders/gl_shader.cpp
@@ -497,6 +497,7 @@ static const FDefaultShader defaultshaders[]=
 
 TArray<FString> usershaders;
 TArray<FString> usermaterials;
+TArray<FString> usershaderdefs;
 
 struct FEffectShader
 {
@@ -648,7 +649,7 @@ void FShaderCollection::CompileShaders(EPassType passType)
 		FString name = ExtractFileBase(usershaders[i]);
 		FName sfn = name;
 
-		FShader *shc = Compile(sfn, usershaders[i], usermaterials[i], "", true, passType);
+		FShader *shc = Compile(sfn, usershaders[i], usermaterials[i], usershaderdefs[i], true, passType);
 		mMaterialShaders.Push(shc);
 	}
 

--- a/src/hwrenderer/textures/hw_material.cpp
+++ b/src/hwrenderer/textures/hw_material.cpp
@@ -154,6 +154,12 @@ FMaterial::FMaterial(FTexture * tx, bool expanded)
 	{
 		if (tx->shaderindex >= FIRST_USER_SHADER)
 		{
+			for (auto &texture : tx->CustomShaderTextures)
+			{
+				if(texture == nullptr) continue;
+				ValidateSysTexture(texture, expanded);
+				mTextureLayers.Push({ texture, false });
+			}
 			mShaderIndex = tx->shaderindex;
 		}
 		else

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -51,6 +51,7 @@ void AddLightAssociation(const char *actor, const char *frame, const char *light
 void InitializeActorLights(TArray<FLightAssociation> &LightAssociations);
 
 extern TArray<FString> usershaders;
+extern TArray<FString> usermaterials;
 extern TDeletingArray<FLightDefaults *> LightDefaults;
 
 
@@ -1378,6 +1379,7 @@ class GLDefsParser
 			bool iwad = false;
 			int maplump = -1;
 			FString maplumpname;
+			FString materiallumpname = "shaders/glsl/material_normal.fp";
 			float speed = 1.f;
 
 			sc.MustGetString();
@@ -1392,6 +1394,11 @@ class GLDefsParser
 				{
 					sc.MustGetString();
 					maplumpname = sc.String;
+				}
+				else if (sc.Compare("material"))
+				{
+					sc.MustGetString();
+					materiallumpname = sc.String;
 				}
 				else if (sc.Compare("speed"))
 				{
@@ -1432,13 +1439,14 @@ class GLDefsParser
 				tex->shaderspeed = speed;
 				for (unsigned i = 0; i < usershaders.Size(); i++)
 				{
-					if (!usershaders[i].CompareNoCase(maplumpname))
+					if (!usershaders[i].CompareNoCase(maplumpname) && !usermaterials[i].CompareNoCase(materiallumpname))
 					{
 						tex->shaderindex = i + FIRST_USER_SHADER;
 						return;
 					}
 				}
 				tex->shaderindex = usershaders.Push(maplumpname) + FIRST_USER_SHADER;
+				usermaterials.Push(materiallumpname);
 			}
 		}
 	}

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1398,6 +1398,24 @@ class GLDefsParser
 					sc.MustGetFloat();
 					speed = float(sc.Float);
 				}
+				else if (sc.Compare("texture"))
+				{
+					sc.MustGetString();
+					bool okay = false;
+					for(int i = 0; i < MAX_CUSTOM_HW_SHADER_TEXTURES; i++) {
+						if(!tex->CustomShaderTextures[i]) {
+							tex->CustomShaderTextures[i] = TexMan.FindTexture(sc.String, ETextureType::Any, FTextureManager::TEXMAN_TryAny);
+							if (!tex->CustomShaderTextures[i]) {
+								sc.ScriptError("Custom hardware shader texture '%s' not found in texture '%s'\n", sc.String, tex? tex->Name.GetChars() : "(null)");
+							}
+							okay = true;
+							break;
+						}
+					}
+					if(!okay) {
+						sc.ScriptError("Error: out of texture units in texture '%s'", tex? tex->Name.GetChars() : "(null)");
+					}
+				}
 			}
 			if (!tex)
 			{

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1442,6 +1442,18 @@ class GLDefsParser
 						sc.ScriptError("Error: out of texture units in texture '%s'", tex? tex->Name.GetChars() : "(null)");
 					}
 				}
+				else if(sc.Compare("define"))
+				{
+					sc.MustGetString();
+					FString defineName = sc.String;
+					FString defineValue = "";
+					if(sc.CheckToken('='))
+					{
+						sc.MustGetString();
+						defineValue = sc.String;
+					}
+					texnameDefs.AppendFormat("#define %s %s\n", defineName.GetChars(), defineValue.GetChars());
+				}
 			}
 			if (!tex)
 			{

--- a/src/textures/textures.h
+++ b/src/textures/textures.h
@@ -44,6 +44,9 @@
 #include "r_data/r_translate.h"
 #include <vector>
 
+// 15 because 0th texture is our texture
+#define MAX_CUSTOM_HW_SHADER_TEXTURES 15
+
 typedef TMap<int, bool> SpriteHits;
 
 enum MaterialShaderIndex
@@ -244,6 +247,8 @@ public:
 	FTexture *Metallic = nullptr;						// Metalness texture for the physically based rendering (PBR) light model
 	FTexture *Roughness = nullptr;						// Roughness texture for PBR
 	FTexture *AmbientOcclusion = nullptr;				// Ambient occlusion texture for PBR
+	
+	FTexture *CustomShaderTextures[MAX_CUSTOM_HW_SHADER_TEXTURES] = { nullptr }; // Custom texture maps for custom hardware shaders
 
 	FString Name;
 	ETextureType UseType;	// This texture's primary purpose


### PR DESCRIPTION
Custom hardware shaders now can use custom texture units.

To use this feature, do like this:

```
HardwareShader Texture REDTEX
{
	Shader "lol.glsl"
	Speed 1
	Texture "AAAA"
	Texture "BBBB"
}
```

You will get textures `AAAA` and `BBBB` as `sampler2D`s `texture2` and `texture3`, respectively.

_Now did it in a single commit._