### PR TITLE
RandomSpawner with infinite recursion hangs the game

### DIFF
--- a/wadsrc/static/zscript/shared/randomspawner.txt
+++ b/wadsrc/static/zscript/shared/randomspawner.txt
@@ -84,7 +84,7 @@ class RandomSpawner : Actor
 				}
 			}
 			// So now we can spawn the dropped item.
-			if (di == null || bouncecount >= MAX_RANDOMSPAWNERS_RECURSION)	// Prevents infinite recursions
+			if (di == null)
 			{
 				Spawn("Unknown", Pos, NO_REPLACE);		// Show that there's a problem.
 				Destroy();
@@ -130,6 +130,13 @@ class RandomSpawner : Actor
 
 		Actor newmobj = null;
 		bool boss = false;
+
+		if (bouncecount >= MAX_RANDOMSPAWNERS_RECURSION)	// Prevents infinite recursions
+		{
+			Spawn("Unknown", Pos, NO_REPLACE);		// Show that there's a problem.
+			Destroy();
+			return;
+		}
 
 		if (Species == 'None')
 		{


### PR DESCRIPTION
A `RandomSpawner` with infinite recursion currently hangs the game, because the recursion check is happening before the recursion counter (`bouncecount`) is set. This PR moves the check to `PostBeginPlay`, which fixes the problem.