### PR TITLE
TNT.WAD MAP07 and MAP08 fixes

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -135,6 +135,26 @@ class LevelCompatibility play
 				}
 				break;
 			}
+			
+			case '0F898F0688AECD42F2CD102FAE06F271': // TNT: Evilution MAP07
+			{
+				// Dropping onto the outdoor lava now also raises the
+				// triangle sectors.
+				SetLineSpecial(320, Floor_RaiseToNearest, 16, 32);
+				SetLineActivation(320, SPAC_Cross);
+				SetLineSpecial(959, Floor_RaiseToNearest, 16, 32);
+				SetLineActivation(959, SPAC_Cross);
+				SetLineSpecial(960, Floor_RaiseToNearest, 16, 32);
+				SetLineActivation(960, SPAC_Cross);
+				break;
+			}
+			
+			case '1E785E841A5247B6223C042EC712EBB3': // TNT: Evilution MAP08
+			{
+				// Missing texture when lowering sector to red keycard
+				SetWallTexture(480, Line.back, Side.Bottom, "METAL2");
+				break;
+			}
 
 			case 'DFC18B92BF3E8142B8684ECD8BD2EF06': // TNT: Evilution map15
 			{


### PR DESCRIPTION
Fixes for MAP07 and MAP08 of TNT: Evilution.

MAP07 - While there are two lines to raise the triangle sectors at the outdoor area of the map, the lines where you drop onto the lava do not do anything. It is possible to get stuck in those triangle sectors if someone drops into the lava, gets back on surface, and somehow drops in any of the three triangle sectors. The lines are now tagged and can be crossed to raise the triangle sectors.

MAP08 - The missing texture is most likely unintentional, as there is no mapping trick being used here for this line.