### PR TITLE
Fix for garbage collection of still referenced objects

### DIFF
--- a/src/scripting/types.cpp
+++ b/src/scripting/types.cpp
@@ -1750,6 +1750,23 @@ void PArray::SetPointer(void *base, unsigned offset, TArray<size_t> *special)
 
 //==========================================================================
 //
+// PArray :: SetPointerArray
+//
+//==========================================================================
+
+void PArray::SetPointerArray(void *base, unsigned offset, TArray<size_t> *special)
+{
+	if (ElementType->isStruct())
+	{
+		for (unsigned int i = 0; i < ElementCount; ++i)
+		{
+			ElementType->SetPointerArray(base, offset + ElementSize * i, special);
+		}
+	}
+}
+
+//==========================================================================
+//
 // NewArray
 //
 // Returns a PArray for the given type and size, making sure not to create

--- a/src/scripting/types.h
+++ b/src/scripting/types.h
@@ -485,6 +485,7 @@ public:
 
 	void SetDefaultValue(void *base, unsigned offset, TArray<FTypeAndOffset> *special) override;
 	void SetPointer(void *base, unsigned offset, TArray<size_t> *special) override;
+	void SetPointerArray(void *base, unsigned offset, TArray<size_t> *ptrofs = NULL) override;
 };
 
 class PStaticArray : public PArray


### PR DESCRIPTION
Objects from dynamic array stored in items of array of structures were incorrectly treated as unreachable

https://forum.zdoom.org/viewtopic.php?t=61354