### PR TITLE
Comment on ZScript's definition of DTA_FillColor is incorrect

### DIFF
--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -106,7 +106,7 @@ enum DrawTextureTags
 	DTA_DestWidth,		// width of area to draw to
 	DTA_DestHeight,		// height of area to draw to
 	DTA_Alpha,			// alpha value for translucency
-	DTA_FillColor,		// color to stencil onto the destination (RGB is the color for truecolor drawers, A is the palette index for paletted drawers)
+	DTA_FillColor,		// color to stencil onto the destination (RGB is the color for truecolor drawers, paletted drawers will use the closest palette color to RGB, and A is ignored)
 	DTA_TranslationIndex, // translation table to recolor the source
 	DTA_AlphaChannel,	// bool: the source is an alpha channel; used with DTA_FillColor
 	DTA_Clean,			// bool: scale texture size and position by CleanXfac and CleanYfac


### PR DESCRIPTION
In ZScript `base.txt`, the comment for `DTA_FillColor` says the alpha component of the provided color is interpreted as a palette index. This is incorrect; per [v_draw.cpp line 663](https://github.com/coelckers/gzdoom/blob/2a0c3e63a365fda17b421b02147a3083abb0cee7/src/v_draw.cpp#L663), the alpha component is ignored.

This trivial PR changes the comment to match the code.