### PR TITLE
Fix loading of shared libraries on OpenBSD

### DIFF
--- a/src/posix/unix/gtk_dialogs.cpp
+++ b/src/posix/unix/gtk_dialogs.cpp
@@ -39,6 +39,14 @@
 #pragma GCC diagnostic ignored "-Waddress"
 #endif
 
+#ifdef __OpenBSD__
+#define GTKLIB "libgtk-3.so"
+#define GTKX11LIB "libgtk-x11-2.0.so"
+#else
+#define GTKLIB "libgtk-3.so.0"
+#define GTKX11LIB "libgtk-x11-2.0.so.0"
+#endif
+
 #include <gtk/gtk.h>
 #if GTK_MAJOR_VERSION >= 3
 #include <gdk/gdk.h>
@@ -427,7 +435,7 @@ bool I_GtkAvailable()
 
 	if(GtkAvailable < 0)
 	{
-		if (!GtkModule.Load({"libgtk-3.so.0", "libgtk-x11-2.0.so.0"}))
+		if (!GtkModule.Load({GTKLIB, GTKX11LIB}))
 		{
 			GtkAvailable = 0;
 			return false;

--- a/src/sound/mididevices/music_fluidsynth_mididevice.cpp
+++ b/src/sound/mididevices/music_fluidsynth_mididevice.cpp
@@ -61,7 +61,9 @@ extern "C" unsigned __stdcall GetSystemDirectoryA(char *lpBuffer, unsigned uSize
 
 #ifdef __APPLE__
 #define FLUIDSYNTHLIB1	"libfluidsynth.1.dylib"
-#else // !__APPLE__
+#elif defined(__OpenBSD__)
+#define FLUIDSYNTHLIB1	"libfluidsynth.so"
+#else // !__APPLE__ && !__OpenBSD__
 #define FLUIDSYNTHLIB1	"libfluidsynth.so.1"
 #endif // __APPLE__
 #endif

--- a/src/sound/mpg123_decoder.cpp
+++ b/src/sound/mpg123_decoder.cpp
@@ -46,6 +46,8 @@ FModule MPG123Module{"MPG123"};
 #define MPG123LIB "libmpg123-0.dll"
 #elif defined(__APPLE__)
 #define MPG123LIB "libmpg123.0.dylib"
+#elif defined(__OpenBSD__)
+#define MPG123LIB "libmpg123.so"
 #else
 #define MPG123LIB "libmpg123.so.0"
 #endif

--- a/src/sound/sndfile_decoder.cpp
+++ b/src/sound/sndfile_decoder.cpp
@@ -46,6 +46,8 @@ FModule SndFileModule{"SndFile"};
 #define SNDFILELIB "libsndfile-1.dll"
 #elif defined(__APPLE__)
 #define SNDFILELIB "libsndfile.1.dylib"
+#elif defined(__OpenBSD__)
+#define SNDFILELIB "libsndfile.so"
 #else
 #define SNDFILELIB "libsndfile.so.1"
 #endif


### PR DESCRIPTION
OpenBSD doesn't follow same major.minor naming in shared libraries as
others. This fixes the gtk, fluidsynth, libmpg123 and libsndfile library names on
OpenBSD so the linker can load the correct library. If the shared library uses
".so" as the suffix and linker will automatically find the "latest" version and
loads it. This is usually the correct thing to do.