### PR TITLE
Fix model rendering only using interpolated yaw

### DIFF
--- a/src/r_data/models/models.cpp
+++ b/src/r_data/models/models.cpp
@@ -69,7 +69,12 @@ void FModelRenderer::RenderModel(float x, float y, float z, FSpriteModelFrame *s
 	float pitch = 0;
 	float roll = 0;
 	double rotateOffset = 0;
-	float angle = actor->Angles.Yaw.Degrees;
+	DRotator angles;
+	if (actor->renderflags & RF_INTERPOLATEANGLES) // [Nash] use interpolated angles
+		angles = actor->InterpolatedAngles(ticFrac);
+	else
+		angles = actor->Angles;
+	float angle = angles.Yaw.Degrees;
 
 	// [BB] Workaround for the missing pitch information.
 	if ((smf->flags & MDL_PITCHFROMMOMENTUM))
@@ -110,11 +115,11 @@ void FModelRenderer::RenderModel(float x, float y, float z, FSpriteModelFrame *s
 	// If both flags MDL_USEACTORPITCH and MDL_PITCHFROMMOMENTUM are set, the pitch sums up the actor pitch and the velocity vector pitch.
 	if (smf->flags & MDL_USEACTORPITCH)
 	{
-		double d = actor->Angles.Pitch.Degrees;
+		double d = angles.Pitch.Degrees;
 		if (smf->flags & MDL_BADROTATION) pitch += d;
 		else pitch -= d;
 	}
-	if (smf->flags & MDL_USEACTORROLL) roll += actor->Angles.Roll.Degrees;
+	if (smf->flags & MDL_USEACTORROLL) roll += angles.Roll.Degrees;
 
 	VSMatrix objectToWorldMatrix;
 	objectToWorldMatrix.loadIdentity();
@@ -124,13 +129,6 @@ void FModelRenderer::RenderModel(float x, float y, float z, FSpriteModelFrame *s
 
 	// [Nash] take SpriteRotation into account
 	angle += actor->SpriteRotation.Degrees;
-
-	if (actor->renderflags & RF_INTERPOLATEANGLES)
-	{
-		// [Nash] use interpolated angles
-		DRotator Angles = actor->InterpolatedAngles(ticFrac);
-		angle = Angles.Yaw.Degrees;
-	}
 
 	// Applying model transformations:
 	// 1) Applying actor angle, pitch and roll to the model


### PR DESCRIPTION
On actors with the INTERPOLATEANGLES flag, only the yaw seems to be interpolated when rendering models. This is easily noticeable with Doom Tournament's Pulsegun alt-fire, where aiming up and down would make the beam jittery. This PR fixes that. Here are "before" and "after" gifs with this change.
![pulse1](https://user-images.githubusercontent.com/2286785/43685569-cdfbd1b8-98b5-11e8-801b-0e6e382065a1.gif)
![pulse2](https://user-images.githubusercontent.com/2286785/43685570-d1c5c61e-98b5-11e8-8508-ae0a679ddaf6.gif)
