### PR TITLE
Make various getter and pure-math methods clearscope, and where applicable, const

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -869,7 +869,7 @@ public:
 		return (Pos().XY() - otherpos).LengthSquared();
 	}
 
-	double Distance2D(AActor *other, bool absolute = false)
+	double Distance2D(AActor *other, bool absolute = false) const
 	{
 		DVector2 otherpos = absolute ? other->Pos() : other->PosRelative(this);
 		return (Pos().XY() - otherpos).Length();
@@ -880,7 +880,7 @@ public:
 		return DVector2(X() - x, Y() - y).Length();
 	}
 
-	double Distance2D(AActor *other, double xadd, double yadd, bool absolute = false)
+	double Distance2D(AActor *other, double xadd, double yadd, bool absolute = false) const
 	{
 		DVector3 otherpos = absolute ? other->Pos() : other->PosRelative(this);
 		return DVector2(X() - otherpos.X + xadd, Y() - otherpos.Y + yadd).Length();
@@ -991,7 +991,7 @@ public:
 		}
 	}
 
-	double AccuracyFactor()
+	double AccuracyFactor() const
 	{
 		return 1. / (1 << (accuracy * 5 / 100));
 	}
@@ -1505,7 +1505,7 @@ public:
 
 	// This is used by many vertical velocity calculations.
 	// Better have it in one place, if something needs to be changed about the formula.
-	double DistanceBySpeed(AActor *dest, double speed)
+	double DistanceBySpeed(AActor *dest, double speed) const
 	{
 		return MAX(1., Distance2D(dest) / speed);
 	}

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -407,11 +407,11 @@ class Actor : Thinker native
 	// Functions
 
 	// 'parked' global functions.
-	native static double deltaangle(double ang1, double ang2);
-	native static double absangle(double ang1, double ang2);
-	native static Vector2 AngleToVector(double angle, double length = 1);
-	native static Vector2 RotateVector(Vector2 vec, double angle);
-	native static double Normalize180(double ang);
+	native clearscope static double deltaangle(double ang1, double ang2);
+	native clearscope static double absangle(double ang1, double ang2);
+	native clearscope static Vector2 AngleToVector(double angle, double length = 1);
+	native clearscope static Vector2 RotateVector(Vector2 vec, double angle);
+	native clearscope static double Normalize180(double ang);
 	
 
 	bool IsPointerEqual(int ptr_select1, int ptr_select2)
@@ -419,7 +419,7 @@ class Actor : Thinker native
 		return GetPointer(ptr_select1) == GetPointer(ptr_select2);
 	}
 	
-	static double BobSin(double fb)
+	clearscope static double BobSin(double fb)
 	{
 		return sin(fb * (180./32)) * 8;
 	}
@@ -547,7 +547,7 @@ class Actor : Thinker native
 	native static class<Actor> GetReplacement(class<Actor> cls);
 	native static class<Actor> GetReplacee(class<Actor> cls);
 	native static int GetSpriteIndex(name sprt);
-	native static double GetDefaultSpeed(class<Actor> type);
+	native clearscope static double GetDefaultSpeed(class<Actor> type);
 	native static class<Actor> GetSpawnableType(int spawnnum);
 	native static int ApplyDamageFactors(class<Inventory> itemcls, Name damagetype, int damage, int defdamage);
 	native void RemoveFromHash();
@@ -561,7 +561,7 @@ class Actor : Thinker native
 		
 	native clearscope string GetTag(string defstr = "") const;
 	native void SetTag(string defstr = "");
-	native double GetBobOffset(double frac = 0);
+	native clearscope double GetBobOffset(double frac = 0) const;
 	native void ClearCounters();
 	native bool GiveBody (int num, int max=0);
 	native bool HitFloor();
@@ -649,7 +649,7 @@ class Actor : Thinker native
 	native void FindFloorCeiling(int flags = 0);
 	native double, double GetFriction();
 	native bool, Actor TestMobjZ(bool quick = false);
-	native bool InStateSequence(State newstate, State basestate);
+	clearscope native bool InStateSequence(State newstate, State basestate) const;
 	
 	bool TryWalk ()
 	{
@@ -667,7 +667,7 @@ class Actor : Thinker native
 	native void RandomChaseDir();
 	native bool CheckMissileRange();
 	native bool SetState(state st, bool nofunction = false);
-	native state FindState(statelabel st, bool exact = false);
+	clearscope native state FindState(statelabel st, bool exact = false) const;
 	bool SetStateLabel(statelabel st, bool nofunction = false) { return SetState(FindState(st), nofunction); }
 	native action state ResolveState(statelabel st);	// this one, unlike FindState, is context aware.
 	native void LinkToWorld(LinkContext ctx = null);
@@ -689,14 +689,14 @@ class Actor : Thinker native
 	native clearscope bool isFriend(Actor other) const;
 	native clearscope bool isHostile(Actor other) const;
 	native void AdjustFloorClip();
-	native DropItem GetDropItems();
+	native clearscope DropItem GetDropItems() const;
 	native void CopyFriendliness (Actor other, bool changeTarget, bool resetHealth = true);
 	native bool LookForMonsters();
 	native bool LookForTid(bool allaround, LookExParams params = null);
 	native bool LookForEnemies(bool allaround, LookExParams params = null);
 	native bool LookForPlayers(bool allaround, LookExParams params = null);
 	native bool TeleportMove(Vector3 pos, bool telefrag, bool modifyactor = true);
-	native double DistanceBySpeed(Actor other, double speed);
+	native clearscope double DistanceBySpeed(Actor other, double speed) const;
 	native name GetSpecies();
 	native void PlayActiveSound();
 	native void Howl();
@@ -719,7 +719,7 @@ class Actor : Thinker native
 	native void ObtainInventory(Actor other);
 	native bool GiveAmmo (Class<Ammo> type, int amount);
 	native bool UsePuzzleItem(int PuzzleItemType);
-	native float AccuracyFactor();
+	native clearscope float AccuracyFactor() const;
 	native bool MorphMonster (Class<Actor> spawntype, int duration, int style, Class<Actor> enter_flash, Class<Actor> exit_flash);
 	action native void SetCamera(Actor cam, bool revert = false);
 	native bool Warp(Actor dest, double xofs = 0, double yofs = 0, double zofs = 0, double angle = 0, int flags = 0, double heightoffset = 0, double radiusoffset = 0, double pitch = 0);

--- a/wadsrc/static/zscript/shared/player.txt
+++ b/wadsrc/static/zscript/shared/player.txt
@@ -1472,22 +1472,22 @@ struct PlayerInfo native play	// this is what internally is known as player_t
 	native void BringUpWeapon();
 	native bool Resurrect();
 
-	native String GetUserName() const;
-	native Color GetColor() const;
-	native Color GetDisplayColor() const;
-	native int GetColorSet() const;
-	native int GetPlayerClassNum() const;
-	native int GetSkin() const;
-	native bool GetNeverSwitch() const;
-	native int GetGender() const;
-	native int GetTeam() const;
-	native float GetAutoaim() const;
-	native bool GetNoAutostartMap() const;
+	native clearscope String GetUserName() const;
+	native clearscope Color GetColor() const;
+	native clearscope Color GetDisplayColor() const;
+	native clearscope int GetColorSet() const;
+	native clearscope int GetPlayerClassNum() const;
+	native clearscope int GetSkin() const;
+	native clearscope bool GetNeverSwitch() const;
+	native clearscope int GetGender() const;
+	native clearscope int GetTeam() const;
+	native clearscope float GetAutoaim() const;
+	native clearscope bool GetNoAutostartMap() const;
 	native void SetFOV(float fov);
-	native bool GetClassicFlight() const;
+	native clearscope bool GetClassicFlight() const;
 	native clearscope bool HasWeaponsInSlot(int slot) const;
 
-	bool IsTotallyFrozen()
+	clearscope bool IsTotallyFrozen() const
 	{
 		return
 			gamestate == GS_TITLELEVEL ||


### PR DESCRIPTION
For instance, as far as I can see, `Normalize180` and `GetBobOffset` have no side effects, and there doesn't seem to be any reason for them to be unavailable to UI scripts. Also, Gutawer's Gutamatics library contains ZScript implementations of `deltaangle` and several similar methods, precisely because they are not `clearscope`.

Methods changed are:

[`Actor`]
* `deltaangle`
* `absangle`
* `AngleToVector`
* `RotateVector`
* `Normalize180`
* `BobSin`
* `GetDefaultSpeed`
* `GetBobOffset`
* `InStateSequence`
* `FindState`
* `GetDropItems (which changes the scope of the returned struct, but the returned struct is all-readonly anyway)`
* `DistanceBySpeed`
* `AccuracyFactor`

[`PlayerInfo`]
* `GetUserName`
* `GetColor`
* `GetDisplayColor`
* `GetColorSet`
* `GetPlayerClassNum`
* `GetSkin`
* `GetNeverSwitch`
* `GetGender`
* `GetTeam`
* `GetAutoaim`
* `GetNoAutostartMap`
* `GetClassicFlight`
* `IsTotallyFrozen`

I've also given the `const` modifier to a few C++ methods, to match ZScript:

* `AActor::AccuracyFactor()` — it is a getter method
* `AActor::DistanceBySpeed(AActor *, double)` — it is a combination of getter and pure math
* `AActor::Distance2D(AActor *, bool)` — called by `DistanceBySpeed`
* `AActor::Distance2D(AActor *, double, double, bool)` — called by `DistanceBySpeed`