### PR TITLE
Bump ZScript version to 3.5.0

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -55,9 +55,9 @@ const char *GetVersionString();
 #define RC_FILEVERSION 3,5,9999,0
 #define RC_PRODUCTVERSION 3,5,9999,0
 #define RC_PRODUCTVERSION2 VERSIONSTR
-// These are for content versioning. The current state is '3.3'.
+// These are for content versioning. The current state is '3.5'.
 #define VER_MAJOR 3
-#define VER_MINOR 4
+#define VER_MINOR 5
 #define VER_REVISION 0
 
 // Version identifier for network games.


### PR DESCRIPTION
When GZDoom 3.5.0 was released, the ZScript version in the release commit was set to 3.5.0, but on master it was left at 3.4.0.

In the future, I suggest setting the ZScript version *before* making a release commit. Then master will remain up to date.