### PR TITLE
Added CheckReplacement to event handlers, for runtime actor class replacement

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -69,6 +69,9 @@ bool E_Responder(const event_t* ev); // splits events into InputProcess and UiPr
 // this executes on console/net events.
 void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manual);
 
+// called when looking up the replacement for an actor class
+void E_CheckReplacement(PClassActor* replacee, PClassActor** replacement);
+
 // send networked event. unified function.
 bool E_SendNetworkEvent(FString name, int arg1, int arg2, int arg3, bool manual);
 
@@ -166,6 +169,9 @@ public:
 	
 	// 
 	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual);
+
+	//
+	void CheckReplacement(PClassActor* replacee, PClassActor** replacement);
 };
 class DEventHandler : public DStaticEventHandler
 {
@@ -260,6 +266,12 @@ struct FConsoleEvent
 	int Args[3];
 	//
 	bool IsManual;
+};
+
+struct FReplaceEvent
+{
+	PClassActor* Replacee;
+	PClassActor* Replacement;
 };
 
 #endif

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -425,7 +425,9 @@ PClassActor *PClassActor::GetReplacement(bool lookskill)
 			lookskill = false; skillrepname = NAME_None;
 		}
 	}
-	auto Replacement = ActorInfo()->Replacement;
+	// [MK] ZScript replacement through Event Handlers, has priority over others
+	PClassActor *Replacement = ActorInfo()->Replacement;
+	E_CheckReplacement(this,&Replacement);
 	if (Replacement == nullptr && (!lookskill || skillrepname == NAME_None))
 	{
 		return this;

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -285,6 +285,12 @@ struct ConsoleEvent native version("2.4")
     native readonly bool IsManual;
 }
 
+struct ReplaceEvent native version("2.4")
+{
+	native readonly Class<Actor> Replacee;
+	native Class<Actor> Replacement;
+}
+
 class StaticEventHandler : Object native play version("2.4")
 {
     // static event handlers CAN register other static event handlers.
@@ -329,6 +335,9 @@ class StaticEventHandler : Object native play version("2.4")
     virtual native ui void ConsoleProcess(ConsoleEvent e);
     virtual native void NetworkProcess(ConsoleEvent e);
     
+    //
+    virtual native void CheckReplacement(ReplaceEvent e);
+
     // this value will be queried on Register() to decide the relative order of this handler to every other.
     // this is most useful in UI systems.
     // default is 0.


### PR DESCRIPTION
A function mostly inspired by its namesake in Unreal's Mutator class.
Works similarly as (and can override) the "replaces" keyword in actor definitions.

Since it works directly with actor classes, everything is preserved during the replacement, including map thing properties like tid and whatnot without having to copy them over like `RandomSpawner` and others do. It also has the added benefit of not screwing with actor pointers assigned through calls to `Spawn`, which methods based on `WorldThingSpawned` would do. On top of that, you can also do things like "batch replacement" (as can be seen in the example), or choosing replacements based on various external factors.

The following example turns everything with the `ISMONSTER` flag into Arch-viles, with just a couple lines of code: [rep_m.zip](https://github.com/coelckers/gzdoom/files/2290840/rep_m.zip)

Replacing one class with itself is explicitly checked for and dealt with so infinite recursion won't happen (which definitely would happen in the example if I didn't do said check).