### PR TITLE
Fix SDL window "sticking" to the center of the screen after using vid_setsize

### DIFF
--- a/src/posix/sdl/gl_sysfb.h
+++ b/src/posix/sdl/gl_sysfb.h
@@ -31,6 +31,8 @@ public:
 	SDL_Window *GetSDLWindow() { return Screen; }
 	void GetWindowBordersSize(int &top, int &left);
 
+	bool m_fsswitch;
+
 protected:
 	void SetGammaTable(uint16_t *tbl);
 	void ResetGammaTable();

--- a/src/posix/sdl/sdlglvideo.cpp
+++ b/src/posix/sdl/sdlglvideo.cpp
@@ -175,6 +175,8 @@ IVideo *gl_CreateVideo()
 SystemGLFrameBuffer::SystemGLFrameBuffer (void *, bool fullscreen)
 	: DFrameBuffer (vid_defwidth, vid_defheight)
 {
+	m_fsswitch = false;
+
 	// SDL_GetWindowBorderSize() is only available since 2.0.5, but because
 	// GZDoom supports platforms with older SDL2 versions, this function
 	// has to be dynamically loaded
@@ -334,8 +336,16 @@ void SystemGLFrameBuffer::ToggleFullscreen(bool yes)
 	SDL_SetWindowFullscreen(Screen, yes ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
 	if ( !yes )
 	{
-		fullscreen = false;
-		SetWindowSize(win_w, win_h);
+		if ( !m_fsswitch )
+		{
+			m_fsswitch = true;
+			fullscreen = false;
+		}
+		else
+		{
+			m_fsswitch = false;
+			SetWindowSize(win_w, win_h);
+		}
 	}
 }
 
@@ -414,7 +424,7 @@ void ProcessSDLWindowEvent(const SDL_WindowEvent &event)
 		break;
 
 	case SDL_WINDOWEVENT_RESIZED:
-		if (!fullscreen)
+		if (!fullscreen && !(static_cast<SystemGLFrameBuffer *>(screen)->m_fsswitch))
 		{
 			win_w = event.data1;
 			win_h = event.data2;


### PR DESCRIPTION
This is an issue in my implementation that I didn't notice until it was too late. SetWindowSize gets endlessly called on a loop after using vid_setsize while fullscreen, when it was meant to be called only once.

And yes, I say again, this is still the same hack as in Windows and it's necessary.