### PR TITLE
Add "IsFinal" parameter for CheckReplacement.

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -70,7 +70,7 @@ bool E_Responder(const event_t* ev); // splits events into InputProcess and UiPr
 void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manual);
 
 // called when looking up the replacement for an actor class
-void E_CheckReplacement(PClassActor* replacee, PClassActor** replacement);
+bool E_CheckReplacement(PClassActor* replacee, PClassActor** replacement);
 
 // send networked event. unified function.
 bool E_SendNetworkEvent(FString name, int arg1, int arg2, int arg3, bool manual);
@@ -171,7 +171,7 @@ public:
 	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual);
 
 	//
-	void CheckReplacement(PClassActor* replacee, PClassActor** replacement);
+	void CheckReplacement(PClassActor* replacee, PClassActor** replacement, bool* final);
 };
 class DEventHandler : public DStaticEventHandler
 {
@@ -272,6 +272,7 @@ struct FReplaceEvent
 {
 	PClassActor* Replacee;
 	PClassActor* Replacement;
+	bool IsFinal;
 };
 
 #endif

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -427,7 +427,11 @@ PClassActor *PClassActor::GetReplacement(bool lookskill)
 	}
 	// [MK] ZScript replacement through Event Handlers, has priority over others
 	PClassActor *Replacement = ActorInfo()->Replacement;
-	E_CheckReplacement(this,&Replacement);
+	if ( E_CheckReplacement(this,&Replacement) )
+	{
+		// [MK] the replacement is final, so don't continue with the chain
+		return Replacement ? Replacement : this;
+	}
 	if (Replacement == nullptr && (!lookskill || skillrepname == NAME_None))
 	{
 		return this;

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -289,6 +289,7 @@ struct ReplaceEvent native version("2.4")
 {
 	native readonly Class<Actor> Replacee;
 	native Class<Actor> Replacement;
+	native bool IsFinal;
 }
 
 class StaticEventHandler : Object native play version("2.4")


### PR DESCRIPTION
If set to true it guarantees that the replacement is final and will not go through the rest of the replacement chain. This is something I should have added since the beginning.

Normally, when CheckReplacement performs a replacement, the newly returned replacement class will in turn also go through another replacement check. With this one can simply end the replacement chain early and make the change definitive, thus preventing potential issues like yet more infinite recursion (e.g.: A replaces B replaces A).