### PR TITLE
Remove Undefined Behaviour

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -865,25 +865,25 @@ public:
 
 	double Distance2DSquared(AActor *other, bool absolute = false)
 	{
-		DVector2 otherpos = absolute ? other->Pos() : other->PosRelative(this);
+		DVector2 otherpos = absolute ? other->Pos().XY() : other->PosRelative(this).XY();
 		return (Pos().XY() - otherpos).LengthSquared();
 	}
 
 	double Distance2D(AActor *other, bool absolute = false)
 	{
-		DVector2 otherpos = absolute ? other->Pos() : other->PosRelative(this);
+		DVector2 otherpos = absolute ? other->Pos().XY() : other->PosRelative(this).XY();
 		return (Pos().XY() - otherpos).Length();
 	}
 
 	double Distance2D(double x, double y) const
 	{
-		return DVector2(X() - x, Y() - y).Length();
+		return DVector2{X() - x, Y() - y}.Length();
 	}
 
 	double Distance2D(AActor *other, double xadd, double yadd, bool absolute = false)
 	{
 		DVector3 otherpos = absolute ? other->Pos() : other->PosRelative(this);
-		return DVector2(X() - otherpos.X + xadd, Y() - otherpos.Y + yadd).Length();
+		return DVector2{X() - otherpos.X + xadd, Y() - otherpos.Y + yadd}.Length();
 	}
 
 
@@ -902,19 +902,19 @@ public:
 
 	DAngle AngleTo(AActor *other, bool absolute = false)
 	{
-		DVector2 otherpos = absolute ? other->Pos() : other->PosRelative(this);
+		DVector2 otherpos = absolute ? other->Pos().XY() : other->PosRelative(this).XY();
 		return VecToAngle(otherpos - Pos().XY());
 	}
 
 	DAngle AngleTo(AActor *other, double oxofs, double oyofs, bool absolute = false) const
 	{
-		DVector2 otherpos = absolute ? other->Pos() : other->PosRelative(this);
-		return VecToAngle(otherpos - Pos() + DVector2(oxofs, oyofs));
+		DVector2 otherpos = absolute ? other->Pos().XY() : other->PosRelative(this).XY();
+		return VecToAngle(otherpos - Pos() + DVector2{oxofs, oyofs});
 	}
 
 	DVector2 Vec2To(AActor *other) const
 	{
-		return other->PosRelative(this) - Pos();
+		return (other->PosRelative(this) - Pos()).XY();
 	}
 
 	DVector3 Vec3To(AActor *other) const
@@ -1140,7 +1140,7 @@ public:
 	uint8_t			WeaveIndexZ;
 	int				skillrespawncount;
 	int				TIDtoHate;			// TID of things to hate (0 if none)
-	FNameNoInit		Species;		// For monster families
+	FName		Species;		// For monster families
 	TObjPtr<AActor*>	alternative;	// (Un)Morphed actors stored here. Those with the MF_UNMORPHED flag are the originals.
 	TObjPtr<AActor*>	tracer;			// Thing being chased/attacked for tracers
 	TObjPtr<AActor*>	master;			// Thing which spawned this one (prevents mutual attacks)
@@ -1183,12 +1183,12 @@ public:
 	line_t			*BlockingLine;	// Line that blocked the last move
 
 	int PoisonDamage; // Damage received per tic from poison.
-	FNameNoInit PoisonDamageType; // Damage type dealt by poison.
+	FName PoisonDamageType; // Damage type dealt by poison.
 	int PoisonDuration; // Duration left for receiving poison damage.
 	int PoisonPeriod; // How often poison damage is applied. (Every X tics.)
 
 	int PoisonDamageReceived; // Damage received per tic from poison.
-	FNameNoInit PoisonDamageTypeReceived; // Damage type received by poison.
+	FName PoisonDamageTypeReceived; // Damage type received by poison.
 	int PoisonDurationReceived; // Duration left for receiving poison damage.
 	int PoisonPeriodReceived; // How often poison damage is applied. (Every X tics.)
 	TObjPtr<AActor*> Poisoner; // Last source of received poison damage.
@@ -1228,13 +1228,13 @@ public:
 	int32_t Mass;
 	int16_t PainChance;
 	int PainThreshold;
-	FNameNoInit DamageType;
-	FNameNoInit DamageTypeReceived;
+	FName DamageType;
+	FName DamageTypeReceived;
 	double DamageFactor;
 	double DamageMultiply;
 
-	FNameNoInit PainType;
-	FNameNoInit DeathType;
+	FName PainType;
+	FName DeathType;
 	PClassActor *TeleFogSourceType;
 	PClassActor *TeleFogDestType;
 	int RipperLevel;
@@ -1438,7 +1438,7 @@ public:
 
 	double VelXYToSpeed() const
 	{
-		return DVector2(Vel.X, Vel.Y).Length();
+		return DVector2{Vel.X, Vel.Y}.Length();
 	}
 
 	double VelToSpeed() const

--- a/src/actorinlines.h
+++ b/src/actorinlines.h
@@ -46,11 +46,11 @@ inline double secplane_t::ZatPoint(const AActor *ac) const
 
 inline double sector_t::HighestCeilingAt(AActor *a, sector_t **resultsec)
 {
-	return HighestCeilingAt(a->Pos(), resultsec);
+	return HighestCeilingAt(a->Pos().XY(), resultsec);
 }
 
 inline double sector_t::LowestFloorAt(AActor *a, sector_t **resultsec)
 {
-	return LowestFloorAt(a->Pos(), resultsec);
+	return LowestFloorAt(a->Pos().XY(), resultsec);
 }
 

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -1965,7 +1965,7 @@ sector_t * AM_FakeFlat(AActor *viewer, sector_t * sec, sector_t * dest)
 	int diffTex = (sec->heightsec->MoreFlags & SECMF_CLIPFAKEPLANES);
 	sector_t * s = sec->heightsec;
 
-	memcpy(dest, sec, sizeof(sector_t));
+    *dest = *sec;
 
 	// Replace floor height with control sector's heights.
 	// The automap is only interested in the floor so let's skip the ceiling.

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -976,7 +976,7 @@ void AM_StaticInit()
 
 DVector2 AM_GetPosition()
 {
-	return DVector2((m_x + m_w / 2), (m_y + m_h / 2));
+	return DVector2{(m_x + m_w / 2), (m_y + m_h / 2)};
 }
 
 //=============================================================================
@@ -1958,8 +1958,8 @@ sector_t * AM_FakeFlat(AActor *viewer, sector_t * sec, sector_t * dest)
 	}
 	else
 	{
-		in_area = pos.Z <= viewer->Sector->heightsec->floorplane.ZatPoint(pos) ? -1 :
-			(pos.Z > viewer->Sector->heightsec->ceilingplane.ZatPoint(pos) && !(viewer->Sector->heightsec->MoreFlags&SECMF_FAKEFLOORONLY)) ? 1 : 0;
+		in_area = pos.Z <= viewer->Sector->heightsec->floorplane.ZatPoint(pos.XY()) ? -1 :
+			(pos.Z > viewer->Sector->heightsec->ceilingplane.ZatPoint(pos.XY()) && !(viewer->Sector->heightsec->MoreFlags&SECMF_FAKEFLOORONLY)) ? 1 : 0;
 	}
 
 	int diffTex = (sec->heightsec->MoreFlags & SECMF_CLIPFAKEPLANES);
@@ -2828,7 +2828,7 @@ void AM_drawPlayers ()
 		int numarrowlines;
 
 		double vh = players[consoleplayer].viewheight;
-		DVector2 pos = am_portaloverlay? players[consoleplayer].camera->GetPortalTransition(vh) : players[consoleplayer].camera->Pos();
+		DVector2 pos = am_portaloverlay? players[consoleplayer].camera->GetPortalTransition(vh).XY() : players[consoleplayer].camera->Pos().XY();
 		pt.x = pos.X;
 		pt.y = pos.Y;
 		if (am_rotate == 1 || (am_rotate == 2 && viewactive))

--- a/src/b_func.cpp
+++ b/src/b_func.cpp
@@ -571,7 +571,7 @@ DAngle DBot::FireRox (AActor *enemy, ticcmd_t *cmd)
 	//Predict.
 	m = ((dist+1) / GetDefaultByName("Rocket")->Speed);
 
-	bglobal.SetBodyAt(DVector3((enemy->Pos() + enemy->Vel * (m + 2)), ONFLOORZ), 1);
+	bglobal.SetBodyAt(DVector3((enemy->Pos().XY() + enemy->Vel * (m + 2)), ONFLOORZ), 1);
 	
 	//try the predicted location
 	if (P_CheckSight (actor, bglobal.body1, SF_IGNOREVISIBILITY)) //See the predicted location, so give a test missile
@@ -603,7 +603,7 @@ bool FCajunMaster::SafeCheckPosition (AActor *actor, double x, double y, FCheckP
 {
 	ActorFlags savedFlags = actor->flags;
 	actor->flags &= ~MF_PICKUP;
-	bool res = P_CheckPosition (actor, DVector2(x, y), tm);
+	bool res = P_CheckPosition (actor, DVector2{x, y}, tm);
 	actor->flags = savedFlags;
 	return res;
 }

--- a/src/b_think.cpp
+++ b/src/b_think.cpp
@@ -339,7 +339,7 @@ void DBot::ThinkForMove (ticcmd_t *cmd)
 	if (t_fight<(AFTERTICS/2))
 		player->mo->flags |= MF_DROPOFF;
 
-	old = player->mo->Pos();
+	old = player->mo->Pos().XY();
 }
 
 int P_GetRealMaxHealth(APlayerPawn *actor, int max);

--- a/src/compatibility.cpp
+++ b/src/compatibility.cpp
@@ -423,7 +423,7 @@ DEFINE_ACTION_FUNCTION(DLevelCompatibility, SetVertex)
 
 	if (vertex < level.vertexes.Size())
 	{
-		level.vertexes[vertex].p = DVector2(x, y);
+		level.vertexes[vertex].p = DVector2{x, y};
 	}
 	ForceNodeBuild = true;
 	return 0;

--- a/src/d_player.h
+++ b/src/d_player.h
@@ -141,7 +141,7 @@ public:
 	double		SideMove1, SideMove2;
 	FTextureID	ScoreIcon;
 	int			SpawnMask;
-	FNameNoInit	MorphWeapon;
+	FName	MorphWeapon;
 	double		AttackZOffset;			// attack height, relative to player center
 	double		UseRange;				// [NS] Distance at which player can +use
 	double		AirCapacity;			// Multiplier for air supply underwater.
@@ -155,10 +155,10 @@ public:
 	double		ViewBob;
 
 	// Former class properties that were moved into the object to get rid of the meta class.
-	FNameNoInit SoundClass;		// Sound class
-	FNameNoInit Face;			// Doom status bar face (when used)
-	FNameNoInit Portrait;
-	FNameNoInit Slot[10];
+	FName SoundClass;		// Sound class
+	FName Face;			// Doom status bar face (when used)
+	FName Portrait;
+	FName Slot[10];
 	double HexenArmor[5];
 	uint8_t ColorRangeStart;	// Skin color range
 	uint8_t ColorRangeEnd;

--- a/src/doomdata.h
+++ b/src/doomdata.h
@@ -373,7 +373,7 @@ struct FMapThing
 	uint32_t		RenderStyle;
 	int			FloatbobPhase;
 	int			friendlyseeblocks;
-	FNameNoInit arg0str;
+	FName arg0str;
 };
 
 

--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -222,7 +222,7 @@ public:
 	bool operator > (FTextureID other) const { return texnum > other.texnum; }
 
 protected:
-	FTextureID(int num) { texnum = num; }
+	FTextureID(int num) : texnum(num) {}
 private:
 	int texnum;
 };

--- a/src/edata.cpp
+++ b/src/edata.cpp
@@ -120,7 +120,7 @@ struct EDSector
 
 	int damageamount;
 	int damageinterval;
-	FNameNoInit damagetype;
+	FName damagetype;
 	uint8_t leaky;
 	uint8_t leakyadd;
 	uint8_t leakyremove;

--- a/src/fragglescript/t_func.cpp
+++ b/src/fragglescript/t_func.cpp
@@ -853,7 +853,7 @@ void FParser::SF_Spawn(void)
 			// [Graf Zahl] added option of spawning with a relative z coordinate
 			if(t_argc > 5)
 			{
-				if (intvalue(t_argv[5])) pos.Z += P_PointInSector(pos)->floorplane.ZatPoint(pos);
+				if (intvalue(t_argv[5])) pos.Z += P_PointInSector(pos.XY())->floorplane.ZatPoint(pos.XY());
 			}
 		}
 		else
@@ -1375,7 +1375,7 @@ void FParser::SF_PointToAngle(void)
 		double x2 = floatvalue(t_argv[2]);
 		double y2 = floatvalue(t_argv[3]);
 		
-		t_return.setDouble(DVector2(x2 - x1, y2 - y1).Angle().Normalized360().Degrees);
+		t_return.setDouble(DVector2{x2 - x1, y2 - y1}.Angle().Normalized360().Degrees);
 	}
 }
 
@@ -2887,7 +2887,7 @@ void FParser::SF_MoveCamera(void)
 		double targetheight = floatvalue(t_argv[2]);
 		double movespeed = floatvalue(t_argv[3]);
 		DVector3 campos = cam->Pos();
-		DVector3 targpos = DVector3(target->Pos(), targetheight);
+		DVector3 targpos = DVector3(target->Pos().XY(), targetheight);
 		DVector3 movement = targpos - campos;
 		double movelen = movement.Length();
 
@@ -3078,7 +3078,7 @@ void FParser::SF_SpawnExplosion()
 		if(t_argc > 3)
 			pos.Z = floatvalue(t_argv[3]);
 		else
-			pos.Z = P_PointInSector(pos)->floorplane.ZatPoint(pos);
+			pos.Z = P_PointInSector(pos.XY())->floorplane.ZatPoint(pos.XY());
 		
 		spawn = Spawn (pclass, pos, ALLOW_REPLACE);
 		t_return.type = svt_int;

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1446,7 +1446,7 @@ bool G_CheckSpot (int playernum, FPlayerStart *mthing)
 	{
 		spot.Z = 0;
 	}
-	spot.Z += P_PointInSector (spot)->floorplane.ZatPoint (spot);
+	spot.Z += P_PointInSector (spot.XY())->floorplane.ZatPoint (spot.XY());
 
 	if (!players[playernum].mo)
 	{ // first spawn of level, before corpses
@@ -1467,7 +1467,7 @@ bool G_CheckSpot (int playernum, FPlayerStart *mthing)
 	//    return false;
 
 	players[playernum].mo->flags |=  MF_SOLID;
-	i = P_CheckPosition(players[playernum].mo, spot);
+	i = P_CheckPosition(players[playernum].mo, spot.XY());
 	players[playernum].mo->flags &= ~MF_SOLID;
 	players[playernum].mo->SetZ(oldz);	// [RH] Restore corpse's height
 	if (!i)

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -570,7 +570,7 @@ void G_ChangeLevel(const char *levelname, int position, int flags, int nextSkill
 		{
 			nextlevel = level.NextMap;	// If there is already an end sequence please leave it alone!
 		}
-		else 
+		else
 		{
 			nextlevel.Format("enDSeQ%04x", int(gameinfo.DefaultEndSequence));
 		}
@@ -613,8 +613,8 @@ void G_ChangeLevel(const char *levelname, int position, int flags, int nextSkill
 	startpos = position;
 	gameaction = ga_completed;
 	level.SetMusicVolume(1.0);
-		
-	if (nextinfo != NULL) 
+
+	if (nextinfo != NULL)
 	{
 		if (thiscluster != nextcluster || (thiscluster && !(thiscluster->flags & CLUSTER_HUB)))
 		{
@@ -713,7 +713,7 @@ void G_ExitLevel (int position, bool keepFacing)
 	G_ChangeLevel(G_GetExitMap(), position, keepFacing ? CHANGELEVEL_KEEPFACING : 0);
 }
 
-void G_SecretExitLevel (int position) 
+void G_SecretExitLevel (int position)
 {
 	level.flags3 |= LEVEL3_EXITSECRETUSED;
 	G_ChangeLevel(G_GetSecretExitMap(), position, 0);
@@ -726,7 +726,7 @@ void G_SecretExitLevel (int position)
 
 void G_DoCompleted (void)
 {
-	int i; 
+	int i;
 
 	gameaction = ga_nothing;
 
@@ -909,14 +909,14 @@ void DAutosaver::Tick ()
 
 //==========================================================================
 //
-// G_DoLoadLevel 
+// G_DoLoadLevel
 //
 //==========================================================================
 
-extern gamestate_t 	wipegamestate; 
- 
+extern gamestate_t 	wipegamestate;
+
 void G_DoLoadLevel (int position, bool autosave)
-{ 
+{
 	static int lastposition = 0;
 	gamestate_t oldgs = gamestate;
 	int i;
@@ -958,7 +958,7 @@ void G_DoLoadLevel (int position, bool autosave)
 
 	if (gamestate != GS_TITLELEVEL)
 	{
-		gamestate = GS_LEVEL; 
+		gamestate = GS_LEVEL;
 	}
 
 	// Set the sky map.
@@ -978,7 +978,7 @@ void G_DoLoadLevel (int position, bool autosave)
 	R_InitSkyMap ();
 
 	for (i = 0; i < MAXPLAYERS; i++)
-	{ 
+	{
 		if (playeringame[i] && (deathmatch || players[i].playerstate == PST_DEAD))
 			players[i].playerstate = PST_ENTER;	// [BC]
 		memset (players[i].frags,0,sizeof(players[i].frags));
@@ -1011,14 +1011,14 @@ void G_DoLoadLevel (int position, bool autosave)
 		P_StartLightning ();
 	}
 
-	gameaction = ga_nothing; 
+	gameaction = ga_nothing;
 
 	// clear cmd building stuff
 	ResetButtonStates ();
 
 	SendItemUse = NULL;
 	SendItemDrop = NULL;
-	mousex = mousey = 0; 
+	mousex = mousey = 0;
 	sendpause = sendsave = sendturn180 = SendLand = false;
 	LocalViewAngle = 0;
 	LocalViewPitch = 0;
@@ -1093,7 +1093,7 @@ void G_DoLoadLevel (int position, bool autosave)
 	//      regular world load (savegames are handled internally)
 	E_WorldLoaded();
 	P_DoDeferedScripts ();	// [RH] Do script actions that were triggered on another map.
-	
+
 	if (demoplayback || oldgs == GS_STARTUP || oldgs == GS_TITLELEVEL)
 		C_HideConsole ();
 
@@ -1113,16 +1113,16 @@ void G_DoLoadLevel (int position, bool autosave)
 
 //==========================================================================
 //
-// G_WorldDone 
+// G_WorldDone
 //
 //==========================================================================
 
-void G_WorldDone (void) 
-{ 
+void G_WorldDone (void)
+{
 	cluster_info_t *nextcluster;
 	cluster_info_t *thiscluster;
 
-	gameaction = ga_worlddone; 
+	gameaction = ga_worlddone;
 
 	if (level.flags & LEVEL_CHANGEMAPCHEAT)
 		return;
@@ -1173,7 +1173,7 @@ void G_WorldDone (void)
 	else
 	{
 		FExitText *ext = nullptr;
-		
+
 		if (level.flags3 & LEVEL3_EXITSECRETUSED) ext = level.info->ExitMapTexts.CheckKey(NAME_Secret);
 		else if (level.flags3 & LEVEL3_EXITNORMALUSED) ext = level.info->ExitMapTexts.CheckKey(NAME_Normal);
 		if (ext == nullptr) ext = level.info->ExitMapTexts.CheckKey(nextlevel);
@@ -1223,8 +1223,8 @@ void G_WorldDone (void)
 			}
 		}
 	}
-} 
- 
+}
+
 DEFINE_ACTION_FUNCTION(FLevelLocals, WorldDone)
 {
 	G_WorldDone();
@@ -1236,8 +1236,8 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, WorldDone)
 //
 //==========================================================================
 
-void G_DoWorldDone (void) 
-{		 
+void G_DoWorldDone (void)
+{
 	gamestate = GS_LEVEL;
 	if (wminfo.next[0] == 0)
 	{
@@ -1252,7 +1252,7 @@ void G_DoWorldDone (void)
 	G_DoLoadLevel (startpos, true);
 	startpos = 0;
 	gameaction = ga_nothing;
-	viewactive = true; 
+	viewactive = true;
 }
 
 //==========================================================================
@@ -1319,7 +1319,7 @@ int G_FinishTravel ()
 	int pnum;
 	int failnum = 0;
 
-	// 
+	//
 	APlayerPawn* pawns[MAXPLAYERS];
 	int pawnsnum = 0;
 
@@ -1424,7 +1424,7 @@ int G_FinishTravel ()
 	DThinker::DestroyThinkersInList(STAT_TRAVELLING);
 	return failnum;
 }
- 
+
 //==========================================================================
 //
 //
@@ -1501,7 +1501,7 @@ void G_InitLevelLocals ()
 	level.F1Pic = info->F1Pic;
 	level.hazardcolor = info->hazardcolor;
 	level.hazardflash = info->hazardflash;
-	
+
 	// GL fog stuff modifiable by SetGlobalFogParameter.
 	level.fogdensity = info->fogdensity;
 	level.outsidefogdensity = info->outsidefogdensity;
@@ -1909,7 +1909,7 @@ void P_WriteACSDefereds (FSerializer &arc)
 void P_ReadACSDefereds (FSerializer &arc)
 {
 	FString MapName;
-	
+
 	P_RemoveDefereds ();
 
 	if (arc.BeginObject("deferred"))
@@ -2028,7 +2028,7 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, Vec2Diff)
 	PARAM_FLOAT(y1);
 	PARAM_FLOAT(x2);
 	PARAM_FLOAT(y2);
-	ACTION_RETURN_VEC2(VecDiff(DVector2(x1, y1), DVector2(x2, y2)));
+	ACTION_RETURN_VEC2(VecDiff(DVector2{x1, y1}, DVector2{x2, y2}));
 }
 
 DEFINE_ACTION_FUNCTION(FLevelLocals, Vec3Diff)
@@ -2053,7 +2053,8 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, Vec2Offset)
 	PARAM_BOOL_DEF(absolute);
 	if (absolute)
 	{
-		ACTION_RETURN_VEC2(DVector2(x + dx, y + dy));
+        auto dv = DVector2{x + dx, y + dy};
+		ACTION_RETURN_VEC2(dv);
 	}
 	else
 	{

--- a/src/g_shared/a_decals.cpp
+++ b/src/g_shared/a_decals.cpp
@@ -377,7 +377,7 @@ static void GetWallStuff (side_t *wall, vertex_t *&v1, double &ldx, double &ldy)
 
 static double Length (double dx, double dy)
 {
-	return DVector2(dx, dy).Length();
+	return DVector2{dx, dy}.Length();
 }
 
 static side_t *NextWall (const side_t *wall)

--- a/src/g_shared/a_dynlight.cpp
+++ b/src/g_shared/a_dynlight.cpp
@@ -185,7 +185,7 @@ void ADynamicLight::PostBeginPlay()
 		Activate (NULL);
 	}
 
-	subsector = R_PointInSubsector(Pos());
+	subsector = R_PointInSubsector(Pos().XY());
 }
 
 
@@ -364,7 +364,7 @@ void ADynamicLight::UpdateLocation()
 			DVector3 pos = target->Vec3Offset(m_off.X * c + m_off.Y * s, m_off.X * s - m_off.Y * c, m_off.Z + target->GetBobOffset());
 			SetXYZ(pos); // attached lights do not need to go into the regular blockmap
 			Prev = target->Pos();
-			subsector = R_PointInSubsector(Prev);
+			subsector = R_PointInSubsector(Prev.XY());
 			Sector = subsector->sector;
 
 			// Some z-coordinate fudging to prevent the light from getting too close to the floor or ceiling planes. With proper attenuation this would render them invisible.
@@ -699,7 +699,7 @@ void ADynamicLight::LinkLight()
 	if (radius>0)
 	{
 		// passing in radius*radius allows us to do a distance check without any calls to sqrt
-		subsector_t * subSec = R_PointInSubsector(Pos());
+		subsector_t * subSec = R_PointInSubsector(Pos().XY());
 		::validcount++;
 		CollectWithinRadius(Pos(), subSec, float(radius*radius));
 

--- a/src/gl/scene/gl_scene.cpp
+++ b/src/gl/scene/gl_scene.cpp
@@ -412,7 +412,7 @@ void FDrawInfo::ProcessScene(bool toscreen)
 	iter_dlightf = iter_dlight = draw_dlight = draw_dlightf = 0;
 	GLRenderer->mPortalState.BeginScene();
 
-	int mapsection = R_PointInSubsector(Viewpoint.Pos)->mapsection;
+	int mapsection = R_PointInSubsector(Viewpoint.Pos.XY())->mapsection;
 	CurrentMapSections.Set(mapsection);
 	DrawScene(toscreen ? DM_MAINVIEW : DM_OFFSCREEN);
 

--- a/src/hwrenderer/dynlights/hw_aabbtree.cpp
+++ b/src/hwrenderer/dynlights/hw_aabbtree.cpp
@@ -72,10 +72,10 @@ LevelAABBTree::LevelAABBTree()
 double LevelAABBTree::RayTest(const DVector3 &ray_start, const DVector3 &ray_end)
 {
 	// Precalculate some of the variables used by the ray/line intersection test
-	DVector2 raydelta = ray_end - ray_start;
+	DVector2 raydelta = (ray_end - ray_start).XY();
 	double raydist2 = raydelta | raydelta;
-	DVector2 raynormal = DVector2(raydelta.Y, -raydelta.X);
-	double rayd = raynormal | ray_start;
+	DVector2 raynormal = DVector2{raydelta.Y, -raydelta.X};
+	double rayd = raynormal | ray_start.XY();
 	if (raydist2 < 1.0)
 		return 1.0f;
 
@@ -89,7 +89,7 @@ double LevelAABBTree::RayTest(const DVector3 &ray_start, const DVector3 &ray_end
 	{
 		int node_index = stack[stack_pos - 1];
 
-		if (!OverlapRayAABB(ray_start, ray_end, nodes[node_index]))
+		if (!OverlapRayAABB(ray_start.XY(), ray_end.XY(), nodes[node_index]))
 		{
 			// If the ray doesn't overlap this node's AABB we're done for this subtree
 			stack_pos--;
@@ -97,7 +97,7 @@ double LevelAABBTree::RayTest(const DVector3 &ray_start, const DVector3 &ray_end
 		else if (nodes[node_index].line_index != -1) // isLeaf(node_index)
 		{
 			// We reached a leaf node. Do a ray/line intersection test to see if we hit the line.
-			hit_fraction = MIN(IntersectRayLine(ray_start, ray_end, nodes[node_index].line_index, raydelta, rayd, raydist2), hit_fraction);
+			hit_fraction = MIN(IntersectRayLine(ray_start.XY(), ray_end.XY(), nodes[node_index].line_index, raydelta, rayd, raydist2), hit_fraction);
 			stack_pos--;
 		}
 		else if (stack_pos == 16)
@@ -158,10 +158,10 @@ double LevelAABBTree::IntersectRayLine(const DVector2 &ray_start, const DVector2
 	const double epsilon = 0.0000001;
 	const AABBTreeLine &line = lines[line_index];
 
-	DVector2 raynormal = DVector2(raydelta.Y, -raydelta.X);
+	DVector2 raynormal = DVector2{raydelta.Y, -raydelta.X};
 
-	DVector2 line_pos(line.x, line.y);
-	DVector2 line_delta(line.dx, line.dy);
+	DVector2 line_pos{line.x, line.y};
+	DVector2 line_delta{line.dx, line.dy};
 
 	double den = raynormal | line_delta;
 	if (fabs(den) > epsilon)
@@ -184,7 +184,7 @@ int LevelAABBTree::GenerateTreeNode(int *lines, int num_lines, const FVector2 *c
 		return -1;
 
 	// Find bounding box and median of the lines
-	FVector2 median = FVector2(0.0f, 0.0f);
+	FVector2 median = FVector2{0.0f, 0.0f};
 	FVector2 aabb_min, aabb_max;
 	aabb_min.X = (float)level.lines[lines[0]].v1->fX();
 	aabb_min.Y = (float)level.lines[lines[0]].v1->fY();
@@ -222,7 +222,7 @@ int LevelAABBTree::GenerateTreeNode(int *lines, int num_lines, const FVector2 *c
 		aabb_max.Y - aabb_min.Y
 	};
 	int axis_order[2] = { 0, 1 };
-	FVector2 axis_plane[2] = { FVector2(1.0f, 0.0f), FVector2(0.0f, 1.0f) };
+	FVector2 axis_plane[2] = { FVector2{1.0f, 0.0f}, FVector2{0.0f, 1.0f} };
 	std::sort(axis_order, axis_order + 2, [&](int a, int b) { return axis_lengths[a] > axis_lengths[b]; });
 
 	// Try sort at longest axis, then if that fails then the other one.

--- a/src/hwrenderer/scene/hw_bsp.cpp
+++ b/src/hwrenderer/scene/hw_bsp.cpp
@@ -471,7 +471,7 @@ void HWDrawInfo::DoSubsector(subsector_t * sub)
 		{
 			if (mClipPortal)
 			{
-				int clipres = mClipPortal->ClipPoint(Particles[i].Pos);
+				int clipres = mClipPortal->ClipPoint(Particles[i].Pos.XY());
 				if (clipres == PClip_InFront) continue;
 			}
 

--- a/src/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/hwrenderer/scene/hw_drawinfo.cpp
@@ -107,7 +107,7 @@ void HWDrawInfo::ClearBuffers()
 
 void HWDrawInfo::UpdateCurrentMapSection()
 {
-	const int mapsection = R_PointInSubsector(Viewpoint.Pos)->mapsection;
+	const int mapsection = R_PointInSubsector(Viewpoint.Pos.XY())->mapsection;
 	CurrentMapSections.Set(mapsection);
 }
 
@@ -122,13 +122,13 @@ void HWDrawInfo::SetViewArea()
 {
     auto &vp = Viewpoint;
 	// The render_sector is better suited to represent the current position in GL
-	vp.sector = R_PointInSubsector(vp.Pos)->render_sector;
+	vp.sector = R_PointInSubsector(vp.Pos.XY())->render_sector;
 
 	// Get the heightsec state from the render sector, not the current one!
 	if (vp.sector->GetHeightSec())
 	{
-		in_area = vp.Pos.Z <= vp.sector->heightsec->floorplane.ZatPoint(vp.Pos) ? area_below :
-			(vp.Pos.Z > vp.sector->heightsec->ceilingplane.ZatPoint(vp.Pos) &&
+		in_area = vp.Pos.Z <= vp.sector->heightsec->floorplane.ZatPoint(vp.Pos.XY()) ? area_below :
+			(vp.Pos.Z > vp.sector->heightsec->ceilingplane.ZatPoint(vp.Pos.XY()) &&
 				!(vp.sector->heightsec->MoreFlags&SECMF_FAKEFLOORONLY)) ? area_above : area_normal;
 	}
 	else

--- a/src/hwrenderer/scene/hw_drawstructs.h
+++ b/src/hwrenderer/scene/hw_drawstructs.h
@@ -262,18 +262,11 @@ public:
 	int CountVertices();
 
 public:
-	GLWall() {}
+	GLWall() = default;
 
-	GLWall(const GLWall &other)
-	{
-		memcpy(this, &other, sizeof(GLWall));
-	}
+	GLWall(const GLWall &other) = default;
 
-	GLWall & operator=(const GLWall &other)
-	{
-		memcpy(this, &other, sizeof(GLWall));
-		return *this;
-	}
+	GLWall & operator=(const GLWall &other) = default;
 
 	void Process(HWDrawInfo *di, seg_t *seg, sector_t *frontsector, sector_t *backsector);
 	void ProcessLowerMiniseg(HWDrawInfo *di, seg_t *seg, sector_t *frontsector, sector_t *backsector);
@@ -324,18 +317,11 @@ public:
 	void SetFrom3DFloor(F3DFloor *rover, bool top, bool underside);
 	void ProcessSector(HWDrawInfo *di, sector_t * frontsector);
 	
-	GLFlat() {}
+	GLFlat() = default;
 
-	GLFlat(const GLFlat &other)
-	{
-		memcpy(this, &other, sizeof(GLFlat));
-	}
+	GLFlat(const GLFlat &other) = default;
 
-	GLFlat & operator=(const GLFlat &other)
-	{
-		memcpy(this, &other, sizeof(GLFlat));
-		return *this;
-	}
+	GLFlat & operator=(const GLFlat &other) = default;
 
 };
 
@@ -388,21 +374,14 @@ public:
 
 public:
 
-	GLSprite() {}
+	GLSprite() = default;
 	void PutSprite(HWDrawInfo *di, bool translucent);
 	void Process(HWDrawInfo *di, AActor* thing,sector_t * sector, area_t in_area, int thruportal = false);
 	void ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *sector);//, int shade, int fakeside)
 
-	GLSprite(const GLSprite &other)
-	{
-		memcpy(this, &other, sizeof(GLSprite));
-	}
+	GLSprite(const GLSprite &other) = default;
 
-	GLSprite & operator=(const GLSprite &other)
-	{
-		memcpy(this, &other, sizeof(GLSprite));
-		return *this;
-	}
+	GLSprite & operator=(const GLSprite &other) = default;
 
 };
 

--- a/src/hwrenderer/scene/hw_fakeflat.cpp
+++ b/src/hwrenderer/scene/hw_fakeflat.cpp
@@ -223,11 +223,7 @@ sector_t * hw_FakeFlat(sector_t * sec, sector_t * dest, area_t in_area, bool bac
 	int diffTex = (sec->heightsec->MoreFlags & SECMF_CLIPFAKEPLANES);
 	sector_t * s = sec->heightsec;
 	
-#if 0
-	*dest=*sec;	// This will invoke the copy operator which isn't really needed here. Memcpy is faster.
-#else
-	memcpy(dest, sec, sizeof(sector_t));
-#endif
+	*dest=*sec;	//Call copy operator, since memcpy a non-trivial type is UB
 
 	// Replace floor and ceiling height with control sector's heights.
 	if (diffTex)

--- a/src/hwrenderer/scene/hw_flats.cpp
+++ b/src/hwrenderer/scene/hw_flats.cpp
@@ -315,7 +315,7 @@ void GLFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector)
 	//
 	//
 	//
-	if (frontsector->floorplane.ZatPoint(vp.Pos) <= vp.Pos.Z)
+	if (frontsector->floorplane.ZatPoint(vp.Pos.XY()) <= vp.Pos.Z)
 	{
 		// process the original floor first.
 
@@ -375,7 +375,7 @@ void GLFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector)
 	//
 	//
 	//
-	if (frontsector->ceilingplane.ZatPoint(vp.Pos) >= vp.Pos.Z)
+	if (frontsector->ceilingplane.ZatPoint(vp.Pos.XY()) >= vp.Pos.Z)
 	{
 		// process the original ceiling first.
 
@@ -466,7 +466,7 @@ void GLFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector)
 					double ff_top = rover->top.plane->ZatPoint(sector->centerspot);
 					if (ff_top < lastceilingheight)
 					{
-						if (vp.Pos.Z <= rover->top.plane->ZatPoint(vp.Pos))
+						if (vp.Pos.Z <= rover->top.plane->ZatPoint(vp.Pos.XY()))
 						{
 							SetFrom3DFloor(rover, true, !!(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;
@@ -480,7 +480,7 @@ void GLFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector)
 					double ff_bottom = rover->bottom.plane->ZatPoint(sector->centerspot);
 					if (ff_bottom < lastceilingheight)
 					{
-						if (vp.Pos.Z <= rover->bottom.plane->ZatPoint(vp.Pos))
+						if (vp.Pos.Z <= rover->bottom.plane->ZatPoint(vp.Pos.XY()))
 						{
 							SetFrom3DFloor(rover, false, !(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;
@@ -506,7 +506,7 @@ void GLFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector)
 					double ff_bottom = rover->bottom.plane->ZatPoint(sector->centerspot);
 					if (ff_bottom > lastfloorheight || (rover->flags&FF_FIX))
 					{
-						if (vp.Pos.Z >= rover->bottom.plane->ZatPoint(vp.Pos))
+						if (vp.Pos.Z >= rover->bottom.plane->ZatPoint(vp.Pos.XY()))
 						{
 							SetFrom3DFloor(rover, false, !(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;
@@ -527,7 +527,7 @@ void GLFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector)
 					double ff_top = rover->top.plane->ZatPoint(sector->centerspot);
 					if (ff_top > lastfloorheight)
 					{
-						if (vp.Pos.Z >= rover->top.plane->ZatPoint(vp.Pos))
+						if (vp.Pos.Z >= rover->top.plane->ZatPoint(vp.Pos.XY()))
 						{
 							SetFrom3DFloor(rover, true, !!(rover->flags&FF_FOG));
 							Colormap.FadeColor = frontsector->Colormap.FadeColor;

--- a/src/hwrenderer/scene/hw_portal.cpp
+++ b/src/hwrenderer/scene/hw_portal.cpp
@@ -171,8 +171,8 @@ void HWScenePortalBase::ClearClipper(HWDrawInfo *di, Clipper *clipper)
 	clipper->SafeAddClipRange(0, 0xffffffff);
 	for (unsigned int i = 0; i < lines.Size(); i++)
 	{
-		DAngle startAngle = (DVector2(lines[i].glseg.x2, lines[i].glseg.y2) - outer_di->Viewpoint.Pos).Angle() + angleOffset;
-		DAngle endAngle = (DVector2(lines[i].glseg.x1, lines[i].glseg.y1) - outer_di->Viewpoint.Pos).Angle() + angleOffset;
+		DAngle startAngle = (DVector2{lines[i].glseg.x2, lines[i].glseg.y2} - outer_di->Viewpoint.Pos).Angle() + angleOffset;
+		DAngle endAngle = (DVector2{lines[i].glseg.x1, lines[i].glseg.y1} - outer_di->Viewpoint.Pos).Angle() + angleOffset;
 
 		if (deltaangle(endAngle, startAngle) < 0)
 		{
@@ -206,7 +206,7 @@ int HWLinePortal::ClipSeg(seg_t *seg, const DVector3 &viewpos)
 	{
 		return PClip_Inside;	// should be handled properly.
 	}
-	return P_ClipLineToPortal(linedef, line(), viewpos) ? PClip_InFront : PClip_Inside;
+	return P_ClipLineToPortal(linedef, line(), viewpos.XY()) ? PClip_InFront : PClip_Inside;
 }
 
 int HWLinePortal::ClipSubsector(subsector_t *sub)
@@ -303,7 +303,7 @@ bool HWMirrorPortal::Setup(HWDrawInfo *di, Clipper *clipper)
 		vp.Pos.Y = (y1 + r * dy) * 2 - y;
 
 		// Compensation for reendering inaccuracies
-		FVector2 v(-dx, dy);
+		FVector2 v{-dx, dy};
 		v.MakeUnit();
 
 		vp.Pos.X += v[1] * state->renderdepth / 2;
@@ -366,7 +366,7 @@ bool HWLineToLinePortal::Setup(HWDrawInfo *di, Clipper *clipper)
 	P_TranslatePortalZ(origin, vp.Pos.Z);
 	P_TranslatePortalXY(origin, vp.Path[0].X, vp.Path[0].Y);
 	P_TranslatePortalXY(origin, vp.Path[1].X, vp.Path[1].Y);
-	if (!vp.showviewer && vp.camera != nullptr && P_PointOnLineSidePrecise(vp.Path[0], glport->lines[0]->mDestination) != P_PointOnLineSidePrecise(vp.Path[1], glport->lines[0]->mDestination))
+	if (!vp.showviewer && vp.camera != nullptr && P_PointOnLineSidePrecise(vp.Path[0].XY(), glport->lines[0]->mDestination) != P_PointOnLineSidePrecise(vp.Path[1].XY(), glport->lines[0]->mDestination))
 	{
 		double distp = (vp.Path[0] - vp.Path[1]).Length();
 		if (distp > EQUAL_EPSILON)
@@ -451,8 +451,8 @@ bool HWSkyboxPortal::Setup(HWDrawInfo *di, Clipper *clipper)
 	vp.Angles.Yaw += (origin->PrevAngles.Yaw + deltaangle(origin->PrevAngles.Yaw, origin->Angles.Yaw) * vp.TicFrac);
 
 	// Don't let the viewpoint be too close to a floor or ceiling
-	double floorh = origin->Sector->floorplane.ZatPoint(origin->Pos());
-	double ceilh = origin->Sector->ceilingplane.ZatPoint(origin->Pos());
+	double floorh = origin->Sector->floorplane.ZatPoint(origin->Pos().XY());
+	double ceilh = origin->Sector->ceilingplane.ZatPoint(origin->Pos().XY());
 	if (vp.Pos.Z < floorh + 4) vp.Pos.Z = floorh + 4;
 	if (vp.Pos.Z > ceilh - 4) vp.Pos.Z = ceilh - 4;
 
@@ -554,7 +554,7 @@ bool HWSectorStackPortal::Setup(HWDrawInfo *di, Clipper *clipper)
 
 	// If the viewpoint is not within the portal, we need to invalidate the entire clip area.
 	// The portal will re-validate the necessary parts when its subsectors get traversed.
-	subsector_t *sub = R_PointInSubsector(vp.Pos);
+	subsector_t *sub = R_PointInSubsector(vp.Pos.XY());
 	if (!(di->ss_renderflags[sub->Index()] & SSRF_SEEN))
 	{
 		clipper->SafeAddClipRange(0, ANGLE_MAX);
@@ -603,7 +603,7 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, Clipper *clipper)
 	// the player is always visible in a mirror.
 	vp.showviewer = true;
 
-	double planez = origin->ZatPoint(vp.Pos);
+	double planez = origin->ZatPoint(vp.Pos.XY());
 	vp.Pos.Z = 2 * planez - vp.Pos.Z;
 	vp.ViewActor = nullptr;
 	state->PlaneMirrorMode = origin->fC() < 0 ? -1 : 1;

--- a/src/hwrenderer/scene/hw_renderhacks.cpp
+++ b/src/hwrenderer/scene/hw_renderhacks.cpp
@@ -859,7 +859,7 @@ void HWDrawInfo::ProcessLowerMinisegs(TArray<seg_t *> &lowersegs)
 
 void HWDrawInfo::HandleHackedSubsectors()
 {
-	viewsubsector = R_PointInSubsector(Viewpoint.Pos);
+	viewsubsector = R_PointInSubsector(Viewpoint.Pos.XY());
 
 	// Each subsector may only be processed once in this loop!
 	validcount++;

--- a/src/hwrenderer/scene/hw_sky.cpp
+++ b/src/hwrenderer/scene/hw_sky.cpp
@@ -341,7 +341,7 @@ void GLWall::SkyBottom(HWDrawInfo *di, seg_t * seg,sector_t * fs,sector_t * bs,v
 			else
 			{
 				// Special hack for Vrack2b
-				if (bs->floorplane.ZatPoint(di->Viewpoint.Pos) > di->Viewpoint.Pos.Z) return;
+				if (bs->floorplane.ZatPoint(di->Viewpoint.Pos.XY()) > di->Viewpoint.Pos.Z) return;
 			}
 		}
 		zbottom[0]=zbottom[1]=-32768.0f;

--- a/src/hwrenderer/scene/hw_sprites.cpp
+++ b/src/hwrenderer/scene/hw_sprites.cpp
@@ -476,7 +476,7 @@ void GLSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 
 	if (thruportal != 2 && di->mClipPortal != nullptr)
 	{
-		int clipres = di->mClipPortal->ClipPoint(thingpos);
+		int clipres = di->mClipPortal->ClipPoint(thingpos.XY());
 		if (clipres == PClip_InFront) return;
 	}
 	// disabled because almost none of the actual game code is even remotely prepared for this. If desired, use the INTERPOLATE flag.
@@ -590,7 +590,7 @@ void GLSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 		// Tests show that this doesn't look good for many decorations and corpses
 		if (spriteheight > 0 && gl_spriteclip > 0 && (thing->renderflags & RF_SPRITETYPEMASK) == RF_FACESPRITE)
 		{
-			PerformSpriteClipAdjustment(thing, thingpos, spriteheight);
+			PerformSpriteClipAdjustment(thing, thingpos.XY(), spriteheight);
 		}
 
 		float viewvecX;
@@ -863,8 +863,8 @@ void GLSprite::ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *
 		Colormap = sector->Colormap;
 		for(unsigned int i=0;i<lightlist.Size();i++)
 		{
-			if (i<lightlist.Size()-1) lightbottom = lightlist[i+1].plane.ZatPoint(particle->Pos);
-			else lightbottom = sector->floorplane.ZatPoint(particle->Pos);
+			if (i<lightlist.Size()-1) lightbottom = lightlist[i+1].plane.ZatPoint(particle->Pos.XY());
+			else lightbottom = sector->floorplane.ZatPoint(particle->Pos.XY());
 
 			if (lightbottom < particle->Pos.Z)
 			{

--- a/src/hwrenderer/scene/hw_weapon.cpp
+++ b/src/hwrenderer/scene/hw_weapon.cpp
@@ -169,11 +169,11 @@ static WeaponLighting GetWeaponLighting(sector_t *viewsector, const DVector3 &po
 
 				if (i<lightlist.Size() - 1)
 				{
-					lightbottom = lightlist[i + 1].plane.ZatPoint(pos);
+					lightbottom = lightlist[i + 1].plane.ZatPoint(pos.XY());
 				}
 				else
 				{
-					lightbottom = viewsector->floorplane.ZatPoint(pos);
+					lightbottom = viewsector->floorplane.ZatPoint(pos.XY());
 				}
 
 				if (lightbottom < pos.Z)

--- a/src/menu/menu.h
+++ b/src/menu/menu.h
@@ -287,7 +287,7 @@ class DMenuItemBase : public DObject
 	DECLARE_CLASS(DMenuItemBase, DObject)
 public:
 	double mXpos, mYpos;
-	FNameNoInit mAction;
+	FName mAction;
 	bool mEnabled;
 
 	bool Activate();

--- a/src/name.h
+++ b/src/name.h
@@ -122,15 +122,4 @@ protected:
 	static NameManager NameData;
 };
 
-class FNameNoInit : public FName
-{
-public:
-	FNameNoInit() : FName() {}
-
-	FName &operator = (const char *text) { Index = NameData.FindName (text, false); return *this; }
-	FName &operator = (const FString &text);
-	FName &operator = (const FName &other) { Index = int(other); return *this; }
-	FName &operator = (ENamedName index) { Index = index; return *this; }
-};
-
 #endif

--- a/src/name.h
+++ b/src/name.h
@@ -46,7 +46,7 @@ class FString;
 class FName
 {
 public:
-	FName () : Index(0) {}
+	FName () = default;
 	FName (const char *text) { Index = NameData.FindName (text, false); }
 	FName (const char *text, bool noCreate) { Index = NameData.FindName (text, noCreate); }
 	FName (const char *text, size_t textlen, bool noCreate) { Index = NameData.FindName (text, textlen, noCreate); }
@@ -87,7 +87,7 @@ public:
 	bool operator >= (ENamedName index) const { return Index >= index; }
 
 protected:
-	int Index;
+	int Index = 0;
 
 	struct NameEntry
 	{
@@ -120,15 +120,12 @@ protected:
 	};
 
 	static NameManager NameData;
-
-	enum EDummy { NoInit };
-	FName (EDummy) {}
 };
 
 class FNameNoInit : public FName
 {
 public:
-	FNameNoInit() : FName(NoInit) {}
+	FNameNoInit() : FName() {}
 
 	FName &operator = (const char *text) { Index = NameData.FindName (text, false); return *this; }
 	FName &operator = (const FString &text);

--- a/src/p_3dfloors.cpp
+++ b/src/p_3dfloors.cpp
@@ -904,7 +904,7 @@ secplane_t P_FindFloorPlane(sector_t * sector, const DVector3 &pos)
 		{
 			if(!(rover->flags & FF_SOLID) || !(rover->flags & FF_EXISTS)) continue;
 
-			if (rover->top.plane->ZatPoint(pos) == pos.Z)
+			if (rover->top.plane->ZatPoint(pos.XY()) == pos.Z)
 			{
 				retplane = *rover->top.plane;
 				if (retplane.fC() < 0) retplane.FlipVert();
@@ -929,12 +929,12 @@ int	P_Find3DFloor(sector_t * sec, const DVector3 &pos, bool above, bool floor, d
 		sec = P_PointInSector(pos);
 
 	// Above normal ceiling
-	cmpz = sec->ceilingplane.ZatPoint(pos);
+	cmpz = sec->ceilingplane.ZatPoint(pos.XY());
 	if (pos.Z >= cmpz)
 		return -1;
 
 	// Below normal floor
-	cmpz = sec->floorplane.ZatPoint(pos);
+	cmpz = sec->floorplane.ZatPoint(pos.XY());
 	if (pos.Z <= cmpz)
 		return -1;
 
@@ -949,19 +949,19 @@ int	P_Find3DFloor(sector_t * sec, const DVector3 &pos, bool above, bool floor, d
 		if (above)
 		{
 			// z is above that floor
-			if (floor && (pos.Z >= (cmpz = rover->top.plane->ZatPoint(pos))))
+			if (floor && (pos.Z >= (cmpz = rover->top.plane->ZatPoint(pos.XY()))))
 				return i - 1;
 			// z is above that ceiling
-			if (pos.Z >= (cmpz = rover->bottom.plane->ZatPoint(pos)))
+			if (pos.Z >= (cmpz = rover->bottom.plane->ZatPoint(pos.XY())))
 				return i - 1;
 		}
 		else // below
 		{
 			// z is below that ceiling
-			if (!floor && (pos.Z <= (cmpz = rover->bottom.plane->ZatPoint(pos))))
+			if (!floor && (pos.Z <= (cmpz = rover->bottom.plane->ZatPoint(pos.XY()))))
 				return i;
 			// z is below that floor
-			if (pos.Z <= (cmpz = rover->top.plane->ZatPoint(pos)))
+			if (pos.Z <= (cmpz = rover->top.plane->ZatPoint(pos.XY())))
 				return i;
 		}
 	}

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -5964,7 +5964,7 @@ int DLevelScript::CallFunction(int argCount, int funcIndex, int32_t *args)
 			return DoubleToACS(g_sqrt(ACSToDouble(args[0])));
 
 		case ACSF_VectorLength:
-			return DoubleToACS(DVector2(ACSToDouble(args[0]), ACSToDouble(args[1])).Length());
+			return DoubleToACS(DVector2{ACSToDouble(args[0]), ACSToDouble(args[1])}.Length());
 
 		case ACSF_SetHUDClipRect:
 			ClipRectLeft = argCount > 0 ? args[0] : 0;
@@ -6851,7 +6851,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 			double result = delta[funcIndex - ACSF_GetLineX] * ACSToDouble(args[1]);
 			if (args[2])
 			{
-				DVector2 normal = DVector2(delta.Y, -delta.X).Unit();
+				DVector2 normal = DVector2{delta.Y, -delta.X}.Unit();
 				result += normal[funcIndex - ACSF_GetLineX] * ACSToDouble(args[2]);
 			}
 			return DoubleToACS(result);

--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -3729,7 +3729,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Respawn)
 	}
 	else
 	{
-		oktorespawn = P_CheckPosition(self, self->Pos(), true);
+		oktorespawn = P_CheckPosition(self, self->Pos().XY(), true);
 	}
 
 	if (oktorespawn)
@@ -6491,7 +6491,7 @@ DEFINE_ACTION_FUNCTION(AActor, CheckBlock)
 		if (flags & CBF_NOACTORS)	fpass |= PCM_NOACTORS;
 		if (flags & CBF_NOLINES)	fpass |= PCM_NOLINES;
 		mobj->SetZ(pos.Z);
-		checker = P_CheckMove(mobj, pos, fpass);
+		checker = P_CheckMove(mobj, pos.XY(), fpass);
 		mobj->SetZ(oldpos.Z);
 	}
 	else

--- a/src/p_effect.cpp
+++ b/src/p_effect.cpp
@@ -201,7 +201,7 @@ void P_FindParticleSubsectors ()
 	for (uint16_t i = ActiveParticles; i != NO_PARTICLE; i = Particles[i].tnext)
 	{
 		 // Try to reuse the subsector from the last portal check, if still valid.
-		if (Particles[i].subsector == NULL) Particles[i].subsector = R_PointInSubsector(Particles[i].Pos);
+		if (Particles[i].subsector == NULL) Particles[i].subsector = R_PointInSubsector(Particles[i].Pos.XY());
 		int ssnum = Particles[i].subsector->Index();
 		Particles[i].snext = ParticlesInSubsec[ssnum];
 		ParticlesInSubsec[ssnum] = i;
@@ -284,7 +284,7 @@ void P_ThinkParticles ()
 		particle->Pos.Y = newxy.Y;
 		particle->Pos.Z += particle->Vel.Z;
 		particle->Vel += particle->Acc;
-		particle->subsector = R_PointInSubsector(particle->Pos);
+		particle->subsector = R_PointInSubsector(particle->Pos.XY());
 		sector_t *s = particle->subsector->sector;
 		// Handle crossing a sector portal.
 		if (!s->PortalBlocksMovement(sector_t::ceiling))
@@ -690,7 +690,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 
 		double r = ((seg.start.Y - mo->Y()) * (-seg.dir.Y) - (seg.start.X - mo->X()) * (seg.dir.X)) / (seg.length * seg.length);
 		r = clamp<double>(r, 0., 1.);
-		seg.soundpos = seg.start + r * seg.dir;
+		seg.soundpos = (seg.start + r * seg.dir).XY();
 		seg.sounddist = (seg.soundpos - mo->Pos()).LengthSquared();
 		trail.Push(seg);
 	}

--- a/src/p_effect.cpp
+++ b/src/p_effect.cpp
@@ -79,11 +79,11 @@ static const struct ColorList {
 	{&grey3,	50,  50,  50 },
 	{&grey4,	210, 210, 210},
 	{&grey5,	128, 128, 128},
-	{&red,		255, 0,   0  },  
-	{&green,	0,   200, 0  },  
+	{&red,		255, 0,   0  },
+	{&green,	0,   200, 0  },
 	{&blue,		0,   0,   255},
-	{&yellow,	255, 255, 0  },  
-	{&black,	0,   0,   0  },  
+	{&yellow,	255, 255, 0  },
+	{&black,	0,   0,   0  },
 	{&red1,		255, 127, 127},
 	{&green1,	127, 255, 127},
 	{&blue1,	127, 127, 255},
@@ -173,7 +173,23 @@ void P_ClearParticles ()
 {
 	int i;
 
-	memset (Particles, 0, NumParticles * sizeof(particle_t));
+	for (auto j = 0; j < NumParticles; j++) {
+        Particles[j].Pos = {0,0,0};
+        Particles[j].Vel = {0,0,0};
+        Particles[j].Acc = {0,0,0};
+        Particles[j].size = 0;
+        Particles[j].sizestep = 0;
+        Particles[j].subsector = nullptr;
+        Particles[j].ttl = 0;
+        Particles[j].bright = 0;
+        Particles[j].notimefreeze = false;
+        Particles[j].fadestep = 0;
+        Particles[j].alpha = 0;
+        Particles[j].color = 0;
+        Particles[j].tnext = 0;
+        Particles[j].snext = 0;
+    }
+
 	ActiveParticles = NO_PARTICLE;
 	InactiveParticles = 0;
 	for (i = 0; i < NumParticles-1; i++)
@@ -262,13 +278,27 @@ void P_ThinkParticles ()
 			prev = particle;
 			continue;
 		}
-		
+
 		auto oldtrans = particle->alpha;
 		particle->alpha -= particle->fadestep;
 		particle->size += particle->sizestep;
 		if (particle->alpha <= 0 || oldtrans < particle->alpha || --particle->ttl <= 0 || (particle->size <= 0))
 		{ // The particle has expired, so free it
-			memset (particle, 0, sizeof(particle_t));
+            particle->Pos = {0,0,0};
+            particle->Vel = {0,0,0};
+            particle->Acc = {0,0,0};
+            particle->size = 0;
+            particle->sizestep = 0;
+            particle->subsector = nullptr;
+            particle->ttl = 0;
+            particle->bright = 0;
+            particle->notimefreeze = false;
+            particle->fadestep = 0;
+            particle->alpha = 0;
+            particle->color = 0;
+            particle->tnext = 0;
+            particle->snext = 0;
+
 			if (prev)
 				prev->tnext = i;
 			else
@@ -313,7 +343,7 @@ enum PSFlag
 	PS_NOTIMEFREEZE =	1 << 5,
 };
 
-void P_SpawnParticle(const DVector3 &pos, const DVector3 &vel, const DVector3 &accel, PalEntry color, double startalpha, int lifetime, double size, 
+void P_SpawnParticle(const DVector3 &pos, const DVector3 &vel, const DVector3 &accel, PalEntry color, double startalpha, int lifetime, double size,
 	double fadestep, double sizestep, int flags)
 {
 	particle_t *particle = NewParticle();
@@ -491,7 +521,7 @@ void P_RunEffect (AActor *actor, int effects)
 	{
 		// Particle fountain
 
-		static const int *fountainColors[16] = 
+		static const int *fountainColors[16] =
 			{ &black,	&black,
 			  &red,		&red1,
 			  &green,	&green1,
@@ -621,7 +651,7 @@ void P_DrawSplash2 (int count, const DVector3 &pos, DAngle angle, int updown, in
 		p->color = M_Random() & 0x80 ? color1 : color2;
 		p->Vel.Z = M_Random() * zvel;
 		p->Acc.Z = -1 / 22.;
-		if (kind) 
+		if (kind)
 		{
 			an = angle + ((M_Random() - 128) * (180 / 256.));
 			p->Vel.X = M_Random() * an.Cos() / 2048.;
@@ -703,7 +733,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 		if (!(flags & RAF_SILENT))
 		{
 			FSoundID sound;
-			
+
 			// Allow other sounds than 'weapons/railgf'!
 			if (!source->player) sound = source->AttackSound;
 			else if (source->player->ReadyWeapon) sound = source->player->ReadyWeapon->AttackSound;
@@ -742,7 +772,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 		int spiral_steps = (int)(steps * r_rail_spiralsparsity / sparsity);
 		segment = 0;
 		lencount = trail[0].length;
-		
+
 		color1 = color1 == 0 ? -1 : ParticleColor(color1);
 		pos = trail[0].start;
 		deg = (double)SpiralOffset;
@@ -781,7 +811,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 				else
 					p->color = rblue4;
 			}
-			else 
+			else
 			{
 				p->color = color1;
 			}
@@ -856,7 +886,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 				else
 					p->color = grey1;
 			}
-			else 
+			else
 			{
 				p->color = color2;
 			}
@@ -902,7 +932,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 					diff.Y = clamp<double>(diff.Y + ((rnd & 16) ? 1 : -1), -maxdiff, maxdiff);
 				if (rnd & 4)
 					diff.Z = clamp<double>(diff.Z + ((rnd & 32) ? 1 : -1), -maxdiff, maxdiff);
-			}			
+			}
 			AActor *thing = Spawn (spawnclass, pos + diff, ALLOW_REPLACE);
 			if (thing)
 			{

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -668,7 +668,7 @@ bool P_Move (AActor *actor)
 				move = move.Rotated(anglediff);
 				oldangle = actor->Angles.Yaw;
 			}
-			start = actor->Pos() - move * i / steps;
+			start = (actor->Pos() - move * i / steps).XY();
 		}
 	}
 
@@ -707,7 +707,7 @@ bool P_Move (AActor *actor)
 			else
 			{ // The monster just hit the floor, so trigger any actions.
 				if (actor->floorsector->SecActTarget != NULL &&
-					actor->floorz == actor->floorsector->floorplane.ZatPoint(actor->PosRelative(actor->floorsector)))
+					actor->floorz == actor->floorsector->floorplane.ZatPoint(actor->PosRelative(actor->floorsector).XY()))
 				{
 					actor->floorsector->TriggerSectorActions(actor, SECSPAC_HitFloor);
 				}
@@ -1019,8 +1019,8 @@ void P_NewChaseDir(AActor * actor)
 				box.inRange(line) &&
 				box.BoxOnLineSide(line) == -1)
 		    {
-				double front = line->frontsector->floorplane.ZatPoint(actor->PosRelative(line));
-				double back  = line->backsector->floorplane.ZatPoint(actor->PosRelative(line));
+				double front = line->frontsector->floorplane.ZatPoint(actor->PosRelative(line).XY());
+				double back  = line->backsector->floorplane.ZatPoint(actor->PosRelative(line).XY());
 				DAngle angle;
 		
 				// The monster must contact one of the two floors,
@@ -2720,7 +2720,7 @@ void A_DoChase (AActor *actor, bool fastchase, FState *meleestate, FState *missi
 	if ((!fastchase || !actor->FastChaseStrafeCount) && !dontmove)
 	{
 		// CANTLEAVEFLOORPIC handling was completely missing in the non-serpent functions.
-		DVector2 old = actor->Pos();
+		DVector2 old = actor->Pos().XY();
 		int oldgroup = actor->PrevPortalGroup;
 		FTextureID oldFloor = actor->floorpic;
 
@@ -2830,7 +2830,7 @@ static bool P_CheckForResurrection(AActor *self, bool usevilestates)
 
 				corpsehit->flags |= MF_SOLID;
 				corpsehit->Height = corpsehit->GetDefault()->Height;
-				bool check = P_CheckPosition(corpsehit, corpsehit->Pos());
+				bool check = P_CheckPosition(corpsehit, corpsehit->Pos().XY());
 				corpsehit->flags = oldflags;
 				corpsehit->radius = oldradius;
 				corpsehit->Height = oldheight;

--- a/src/p_floor.cpp
+++ b/src/p_floor.cpp
@@ -743,7 +743,7 @@ bool EV_BuildStairs (int tag, DFloor::EStair type, line_t *line,
 				floor = Create<DFloor> (sec);
 				floor->StartFloorSound ();
 				floor->m_Direction = (type == DFloor::buildUp) ? 1 : -1;
-				floor->m_FloorDestDist = sec->floorplane.PointToDist (DVector2(0, 0), height);
+				floor->m_FloorDestDist = sec->floorplane.PointToDist (DVector2{0, 0}, height);
 				// [RH] Set up delay values
 				floor->m_Delay = delay;
 				floor->m_PauseTime = 0;
@@ -1249,7 +1249,7 @@ void DWaggleBase::DoWaggle (bool ceiling)
 	m_Accumulator += m_AccDelta;
 
 	dist = plane->fD();
-	plane->setD(m_OriginalDist + plane->PointToDist (DVector2(0, 0), BobSin(m_Accumulator) *m_Scale));
+	plane->setD(m_OriginalDist + plane->PointToDist (DVector2{0, 0}, BobSin(m_Accumulator) *m_Scale));
 	m_Sector->ChangePlaneTexZ(pos, plane->HeightDiff (dist));
 	dist = plane->HeightDiff (dist);
 

--- a/src/p_glnodes.cpp
+++ b/src/p_glnodes.cpp
@@ -134,7 +134,7 @@ static int CheckForMissingSegs()
 		if (seg.sidedef != nullptr)
 		{
 			// check all the segs and calculate the length they occupy on their sidedef
-			DVector2 vec1(seg.v2->fX() - seg.v1->fX(), seg.v2->fY() - seg.v1->fY());
+			DVector2 vec1{seg.v2->fX() - seg.v1->fX(), seg.v2->fY() - seg.v1->fY()};
 			added_seglen[seg.sidedef->Index()] += vec1.Length();
 		}
 	}

--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -164,7 +164,7 @@ FUNC(LS_Polyobj_MoveTimes8)
 FUNC(LS_Polyobj_MoveTo)
 // Polyobj_MoveTo (po, speed, x, y)
 {
-	return EV_MovePolyTo (ln, arg0, SPEED(arg1), DVector2(arg2, arg3), false);
+	return EV_MovePolyTo (ln, arg0, SPEED(arg1), DVector2{arg2, arg3}, false);
 }
 
 FUNC(LS_Polyobj_MoveToSpot)
@@ -173,7 +173,7 @@ FUNC(LS_Polyobj_MoveToSpot)
 	FActorIterator iterator (arg2);
 	AActor *spot = iterator.Next();
 	if (spot == NULL) return false;
-	return EV_MovePolyTo (ln, arg0, SPEED(arg1), spot->Pos(), false);
+	return EV_MovePolyTo (ln, arg0, SPEED(arg1), spot->Pos().XY(), false);
 }
 
 FUNC(LS_Polyobj_DoorSwing)
@@ -215,7 +215,7 @@ FUNC(LS_Polyobj_OR_MoveTimes8)
 FUNC(LS_Polyobj_OR_MoveTo)
 // Polyobj_OR_MoveTo (po, speed, x, y)
 {
-	return EV_MovePolyTo (ln, arg0, SPEED(arg1), DVector2(arg2, arg3), true);
+	return EV_MovePolyTo (ln, arg0, SPEED(arg1), DVector2{arg2, arg3}, true);
 }
 
 FUNC(LS_Polyobj_OR_MoveToSpot)
@@ -224,7 +224,7 @@ FUNC(LS_Polyobj_OR_MoveToSpot)
 	FActorIterator iterator (arg2);
 	AActor *spot = iterator.Next();
 	if (spot == NULL) return false;
-	return EV_MovePolyTo (ln, arg0, SPEED(arg1), spot->Pos(), true);
+	return EV_MovePolyTo (ln, arg0, SPEED(arg1), spot->Pos().XY(), true);
 }
 
 FUNC(LS_Polyobj_Stop)
@@ -3267,10 +3267,10 @@ FUNC(LS_GlassBreak)
 		if (!arg0)
 		{ // Break some glass
 
-			DVector2 linemid((ln->v1->fX() + ln->v2->fX()) / 2, (ln->v1->fY() + ln->v2->fY()) / 2);
+			DVector2 linemid{(ln->v1->fX() + ln->v2->fX()) / 2, (ln->v1->fY() + ln->v2->fY()) / 2};
 
 			// remove dependence on sector size and always spawn 2 map units in front of the line.
-			DVector2 normal(ln->Delta().Y, -ln->Delta().X);
+			DVector2 normal{ln->Delta().Y, -ln->Delta().X};
 			linemid += normal.Unit() * 2;
 			/* old code:
 			x += (ln->frontsector->centerspot.x - x) / 5;

--- a/src/p_maputl.cpp
+++ b/src/p_maputl.cpp
@@ -469,7 +469,7 @@ void AActor::LinkToWorld(FLinkContext *ctx, bool spawningmapthing, sector_t *sec
 	}
 
 	Sector = sector;
-	subsector = R_PointInSubsector(Pos());	// this is from the rendering nodes, not the gameplay nodes!
+	subsector = R_PointInSubsector(Pos().XY());	// this is from the rendering nodes, not the gameplay nodes!
 
 	if (!(flags & MF_NOSECTOR))
 	{

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1970,7 +1970,7 @@ void P_ExplodeMissile (AActor *mo, line_t *line, AActor *target, bool onsky)
 	if (line != NULL && cl_missiledecals)
 	{
 		DVector3 pos = mo->PosRelative(line);
-		int side = P_PointOnLineSidePrecise (pos, line);
+		int side = P_PointOnLineSidePrecise (pos.XY(), line);
 		if (line->sidedef[side] == NULL)
 			side ^= 1;
 		if (line->sidedef[side] != NULL)
@@ -2001,7 +2001,7 @@ void P_ExplodeMissile (AActor *mo, line_t *line, AActor *target, bool onsky)
 
 							if ((rover->flags&(FF_EXISTS|FF_SOLID|FF_RENDERSIDES))==(FF_EXISTS|FF_SOLID|FF_RENDERSIDES))
 							{
-								if (pos.Z <= rover->top.plane->ZatPoint(linepos) && pos.Z >= rover->bottom.plane->ZatPoint(linepos))
+								if (pos.Z <= rover->top.plane->ZatPoint(linepos.XY()) && pos.Z >= rover->bottom.plane->ZatPoint(linepos.XY()))
 								{
 									ffloor = rover;
 									break;
@@ -2328,7 +2328,7 @@ bool P_SeekerMissile (AActor *actor, double thresh, double turnMax, bool precise
 			{
 				aimheight = static_cast<APlayerPawn *>(target)->ViewHeight;
 			}
-			pitch = DVector2(dist, target->Z() + aimheight - actor->Center()).Angle();
+			pitch = DVector2{dist, target->Z() + aimheight - actor->Center()}.Angle();
 		}
 		actor->Vel3DFromAngle(-pitch, speed);
 	}
@@ -2403,7 +2403,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 	{
 		mo->Vel.MakeResize(VELOCITY_THRESHOLD);
 	}
-	move = mo->Vel;
+	move = mo->Vel.XY();
 	// [RH] Carrying sectors didn't work with low speeds in BOOM. This is
 	// because BOOM relied on the speed being fast enough to accumulate
 	// despite friction. If the speed is too low, then its movement will get
@@ -2489,7 +2489,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 	// because it also calls P_CheckSlopeWalk on its clipped steps.
 	DVector2 onestep = startmove / steps;
 
-	start = mo->Pos();
+	start = mo->Pos().XY();
 	step = 1;
 	totalsteps = steps;
 
@@ -2514,7 +2514,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 
 		ptry = start + move * step / steps;
 
-		DVector2 startvel = mo->Vel;
+		DVector2 startvel = mo->Vel.XY();
 
 		// killough 3/15/98: Allow objects to drop off
 		// [RH] If walking on a slope, stay on the slope
@@ -2551,7 +2551,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 						// If the move is done a second time (because it was too fast for one move), it
 						// is still clipped against the wall at its full speed, so you effectively
 						// execute two moves in one tic.
-							P_SlideMove (mo, mo->Vel, 1);
+							P_SlideMove (mo, mo->Vel.XY(), 1);
 						}
 						else
 						{
@@ -2565,7 +2565,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 						{
 							if (!player || !(i_compatflags & COMPATF_WALLRUN))
 							{
-								move = mo->Vel;
+								move = mo->Vel.XY();
 								onestep = move / steps;
 								P_CheckSlopeWalk (mo, move);
 							}
@@ -2582,7 +2582,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 					DVector2 t;
 					t.X = 0, t.Y = onestep.Y;
 					walkplane = P_CheckSlopeWalk (mo, t);
-					if (P_TryMove (mo, mo->Pos() + t, true, walkplane, tm))
+					if (P_TryMove (mo, mo->Pos().XY() + t, true, walkplane, tm))
 					{
 						mo->Vel.X = 0;
 					}
@@ -2590,7 +2590,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 					{
 						t.X = onestep.X, t.Y = 0;
 						walkplane = P_CheckSlopeWalk (mo, t);
-						if (P_TryMove (mo, mo->Pos() + t, true, walkplane, tm))
+						if (P_TryMove (mo, mo->Pos().XY() + t, true, walkplane, tm))
 						{
 							mo->Vel.Y = 0;
 						}
@@ -2689,7 +2689,7 @@ explode:
 					if (tm.ceilingline &&
 						tm.ceilingline->backsector &&
 						tm.ceilingline->backsector->GetTexture(sector_t::ceiling) == skyflatnum &&
-						mo->Z() >= tm.ceilingline->backsector->ceilingplane.ZatPoint(mo->PosRelative(tm.ceilingline)))
+						mo->Z() >= tm.ceilingline->backsector->ceilingplane.ZatPoint(mo->PosRelative(tm.ceilingline).XY()))
 					{
 						if (!(mo->flags3 & MF3_SKYEXPLODE))
 						{
@@ -2742,7 +2742,7 @@ explode:
 						move = move.Rotated(anglediff);
 						oldangle = mo->Angles.Yaw;
 					}
-					start = mo->Pos() - move * step / steps;
+					start = mo->Pos().XY() - move * step / steps;
 				}
 			}
 		}
@@ -3392,7 +3392,7 @@ void P_NightmareRespawn (AActor *mobj)
 	}
 
 	// something is occupying its position?
-	if (!P_CheckPosition(mo, mo->Pos(), true))
+	if (!P_CheckPosition(mo, mo->Pos().XY(), true))
 	{
 		//[GrafZahl] MF_COUNTKILL still needs to be checked here.
 		mo->ClearCounters();
@@ -3421,7 +3421,7 @@ void P_NightmareRespawn (AActor *mobj)
 	P_SpawnTeleportFog(mobj, mobj->Pos(), true, true);
 
 	// spawn a teleport fog at the new spot
-	P_SpawnTeleportFog(mobj, DVector3(mobj->SpawnPoint, z), false, true);
+	P_SpawnTeleportFog(mobj, DVector3(mobj->SpawnPoint.XY(), z), false, true);
 
 	// remove the old monster
 	mobj->Destroy ();
@@ -4263,7 +4263,7 @@ void AActor::Tick ()
 		}
 
 		// [RH] Consider carrying sectors here
-		DVector2 cumm(0, 0);
+		DVector2 cumm{0, 0};
 
 		if ((((flags8 & MF8_INSCROLLSEC) && level.Scrolls.Size() > 0) || player != NULL) && !(flags & MF_NOCLIP) && !(flags & MF_NOSECTOR))
 		{
@@ -4364,7 +4364,7 @@ void AActor::Tick ()
 					continue;
 				}
 				DVector3 pos = PosRelative(sec);
-				height = sec->floorplane.ZatPoint (pos);
+				height = sec->floorplane.ZatPoint (pos.XY());
 				double height2 = sec->floorplane.ZatPoint(this);
 				if (isAbove(height))
 				{
@@ -4373,7 +4373,7 @@ void AActor::Tick ()
 						continue;
 					}
 
-					waterheight = heightsec->floorplane.ZatPoint (pos);
+					waterheight = heightsec->floorplane.ZatPoint (pos.XY());
 					if (waterheight > height && Z() >= waterheight)
 					{
 						continue;
@@ -4413,7 +4413,7 @@ void AActor::Tick ()
 			floorplane = P_FindFloorPlane(floorsector, PosAtZ(floorz));
 
 			if (floorplane.fC() < STEEPSLOPE &&
-				floorplane.ZatPoint (PosRelative(floorsector)) <= floorz)
+				floorplane.ZatPoint (PosRelative(floorsector).XY()) <= floorz)
 			{
 				const msecnode_t *node;
 				bool dopush = true;
@@ -4425,7 +4425,7 @@ void AActor::Tick ()
 						const sector_t *sec = node->m_sector;
 						if (sec->floorplane.fC() >= STEEPSLOPE)
 						{
-							if (floorplane.ZatPoint(PosRelative(node->m_sector)) >= Z() - MaxStepHeight)
+							if (floorplane.ZatPoint(PosRelative(node->m_sector).XY()) >= Z() - MaxStepHeight)
 							{
 								dopush = false;
 								break;
@@ -4985,8 +4985,8 @@ AActor *AActor::StaticSpawn (PClassActor *type, const DVector3 &pos, replace_t a
 	actor->LinkToWorld (nullptr, SpawningMapThing);
 	actor->ClearInterpolation();
 
-	actor->dropoffz = actor->floorz = actor->Sector->floorplane.ZatPoint(pos);
-	actor->ceilingz = actor->Sector->ceilingplane.ZatPoint(pos);
+	actor->dropoffz = actor->floorz = actor->Sector->floorplane.ZatPoint(pos.XY());
+	actor->ceilingz = actor->Sector->ceilingplane.ZatPoint(pos.XY());
 
 	// The z-coordinate needs to be set once before calling P_FindFloorCeiling
 	// For FLOATRANDZ just use the floor here.
@@ -5420,7 +5420,7 @@ void AActor::AdjustFloorClip ()
 	{
 		DVector3 pos = PosRelative(m->m_sector);
 		sector_t *hsec = m->m_sector->GetHeightSec();
-		if (hsec == NULL && m->m_sector->floorplane.ZatPoint (pos) == Z())
+		if (hsec == NULL && m->m_sector->floorplane.ZatPoint (pos.XY()) == Z())
 		{
 			double clip = Terrains[m->m_sector->GetTerrain(sector_t::floor)].FootClip;
 			if (clip < shallowestclip)
@@ -5785,7 +5785,7 @@ AActor *P_SpawnMapThing (FMapThing *mthing, int position)
 	{
 		polyspawns_t *polyspawn = new polyspawns_t;
 		polyspawn->next = polyspawns;
-		polyspawn->pos = mthing->pos;
+		polyspawn->pos = mthing->pos.XY();
 		polyspawn->angle = mthing->angle;
 		polyspawn->type = mentry->Special;
 		polyspawns = polyspawn;
@@ -6003,7 +6003,7 @@ AActor *P_SpawnMapThing (FMapThing *mthing, int position)
 	else
 		sz = ONFLOORZ;
 
-	mobj = AActor::StaticSpawn (i, DVector3(mthing->pos, sz), NO_REPLACE, true);
+	mobj = AActor::StaticSpawn (i, DVector3(mthing->pos.XY(), sz), NO_REPLACE, true);
 
 	if (sz == ONFLOORZ)
 	{
@@ -6545,7 +6545,7 @@ bool P_HitWater (AActor * thing, sector_t * sec, const DVector3 &pos, bool check
 		{
 			F3DFloor * rover = sec->e->XFloor.ffloors[i];
 			if (!(rover->flags & FF_EXISTS)) continue;
-			double planez = rover->top.plane->ZatPoint(pos);
+			double planez = rover->top.plane->ZatPoint(pos.XY());
 				if (pos.Z > planez - 0.5 && pos.Z < planez + 0.5)	// allow minor imprecisions
 			{
 				if ((rover->flags & (FF_SOLID | FF_SWIMMABLE)) || rover->alpha > 0)
@@ -6554,7 +6554,7 @@ bool P_HitWater (AActor * thing, sector_t * sec, const DVector3 &pos, bool check
 					goto foundone;
 				}
 			}
-			planez = rover->bottom.plane->ZatPoint(pos);
+			planez = rover->bottom.plane->ZatPoint(pos.XY());
 			if (planez < pos.Z && !(planez < thing->floorz)) return false;
 		}
 	}
@@ -6681,7 +6681,7 @@ bool P_HitFloor (AActor *thing)
 	for (m = thing->touching_sectorlist; m; m = m->m_tnext)
 	{
 		pos = thing->PosRelative(m->m_sector);
-		if (thing->Z() == m->m_sector->floorplane.ZatPoint(pos))
+		if (thing->Z() == m->m_sector->floorplane.ZatPoint(pos.XY()))
 		{
 			break;
 		}
@@ -6693,7 +6693,7 @@ bool P_HitFloor (AActor *thing)
 			if (!(rover->flags & FF_EXISTS)) continue;
 			if (rover->flags & (FF_SOLID|FF_SWIMMABLE))
 			{
-				if (rover->top.plane->ZatPoint(pos) == thing->Z())
+				if (rover->top.plane->ZatPoint(pos.XY()) == thing->Z())
 				{
 					return P_HitWater (thing, m->m_sector, pos);
 				}
@@ -6801,7 +6801,7 @@ bool P_CheckMissileSpawn (AActor* th, double maxdist)
 	// killough 3/15/98: no dropoff (really = don't care for missiles)
 	auto oldf2 = th->flags2;
 	th->flags2 &= ~(MF2_MCROSS|MF2_PCROSS);	// The following check is not supposed to activate missile triggers.
-	if (!(P_TryMove (th, newpos, false, NULL, tm, true)))
+	if (!(P_TryMove (th, newpos.XY(), false, NULL, tm, true)))
 	{
 		// [RH] Don't explode ripping missiles that spawn inside something
 		if (th->BlockingMobj == NULL || !(th->flags2 & MF2_RIP) || (th->BlockingMobj->flags5 & MF5_DONTRIP))
@@ -7988,7 +7988,7 @@ static FRandom pr_restore("RestorePos");
 void AActor::RestoreSpecialPosition()
 {
 	// Move item back to its original location
-	DVector2 sp = SpawnPoint;
+	DVector2 sp = SpawnPoint.XY();
 
 	FLinkContext ctx;
 	UnlinkFromWorld(&ctx);
@@ -8252,7 +8252,8 @@ DEFINE_ACTION_FUNCTION(AActor, RotateVector)
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
 	PARAM_ANGLE(angle);
-	ACTION_RETURN_VEC2(DVector2(x, y).Rotated(angle));
+    auto dv = DVector2{x, y};
+	ACTION_RETURN_VEC2(dv.Rotated(angle));
 }
 
 DEFINE_ACTION_FUNCTION(AActor, Normalize180)

--- a/src/p_pusher.cpp
+++ b/src/p_pusher.cpp
@@ -293,7 +293,7 @@ void DPusher::Tick ()
 			}
 			else // special water sector
 			{
-				ht = hsec->floorplane.ZatPoint(pos);
+				ht = hsec->floorplane.ZatPoint(pos.XY());
 				if (thing->Z() > ht) // above ground
 				{
 					pushvel = m_PushVec; // full force
@@ -320,7 +320,7 @@ void DPusher::Tick ()
 			{ // special water sector
 				floor = &hsec->floorplane;
 			}
-			if (thing->Z() > floor->ZatPoint(pos))
+			if (thing->Z() > floor->ZatPoint(pos.XY()))
 			{ // above ground
 				pushvel.Zero(); // no force
 			}

--- a/src/p_secnodes.cpp
+++ b/src/p_secnodes.cpp
@@ -414,7 +414,7 @@ void AActor::UpdateRenderSectorList()
 			if (planeh <= lasth) break;	// broken setup.
 			if (Top() + SPRITE_SPACE < planeh) break;
 			lasth = planeh;
-			DVector2 newpos = Pos() + sec->GetPortalDisplacement(sector_t::ceiling);
+			DVector2 newpos = Pos().XY() + sec->GetPortalDisplacement(sector_t::ceiling);
 			sec = P_PointInSector(newpos);
 			touching_sectorportallist = P_AddSecnode(sec, this, touching_sectorportallist, sec->sectorportal_thinglist);
 		}
@@ -426,7 +426,7 @@ void AActor::UpdateRenderSectorList()
 			if (planeh >= lasth) break;	// broken setup.
 			if (Z() - SPRITE_SPACE > planeh) break;
 			lasth = planeh;
-			DVector2 newpos = Pos() + sec->GetPortalDisplacement(sector_t::floor);
+			DVector2 newpos = Pos().XY() + sec->GetPortalDisplacement(sector_t::floor);
 			sec = P_PointInSector(newpos);
 			touching_sectorportallist = P_AddSecnode(sec, this, touching_sectorportallist, sec->sectorportal_thinglist);
 		}

--- a/src/p_sectors.cpp
+++ b/src/p_sectors.cpp
@@ -1214,7 +1214,7 @@ DEFINE_ACTION_FUNCTION(_Sector, HighestCeilingAt)
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
 	sector_t *s;
-	double h = self->HighestCeilingAt(DVector2(x, y), &s);
+	double h = self->HighestCeilingAt(DVector2{x, y}, &s);
 	if (numret > 0) ret[0].SetFloat(h);
 	if (numret > 1) ret[1].SetPointer(s);
 	return numret;
@@ -1249,7 +1249,7 @@ DEFINE_ACTION_FUNCTION(_Sector, LowestFloorAt)
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
 	sector_t *s;
-	double h = self->LowestFloorAt(DVector2(x, y), &s);
+	double h = self->LowestFloorAt(DVector2{x, y}, &s);
 	if (numret > 0) ret[0].SetFloat(h);
 	if (numret > 1) ret[1].SetPointer(s);
 	return numret;
@@ -1536,7 +1536,7 @@ DEFINE_ACTION_FUNCTION(_Sector, NextLowestFloorAt)
 
 	 if (bottomglowcolor[3]> 0)
 	 {
-		 double floordiff = pos.Z - floorplane.ZatPoint(pos);
+		 double floordiff = pos.Z - floorplane.ZatPoint(pos.XY());
 		 if (floordiff < bottomglowcolor[3])
 		 {
 			 int maxlight = (255 + lightlevel) >> 1;
@@ -2611,7 +2611,7 @@ DEFINE_ACTION_FUNCTION(_Secplane, PointToDist)
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
 	PARAM_FLOAT(z);
-	ACTION_RETURN_FLOAT(self->PointToDist(DVector2(x, y), z));
+	ACTION_RETURN_FLOAT(self->PointToDist(DVector2{x, y}, z));
 }
 
 

--- a/src/p_sight.cpp
+++ b/src/p_sight.cpp
@@ -121,7 +121,7 @@ public:
 	void init(AActor * t1, AActor * t2, sector_t *startsector, SightTask *task, int flags)
 	{
 		sightstart = t1->PosRelative(task->portalgroup);
-		sightend = t2->PosRelative(task->portalgroup);
+		sightend = t2->PosRelative(task->portalgroup).XY();
 		sightstart.Z += t1->Height * 0.75;
 
 		portalgroup = task->portalgroup;
@@ -257,7 +257,7 @@ bool SightCheck::PTR_SightTraverse (intercept_t *in)
 	if (open.portalflags)
 	{
 		sector_t *frontsec, *backsec;
-		frontflag = P_PointOnLineSidePrecise(sightstart, li);
+		frontflag = P_PointOnLineSidePrecise(sightstart.XY(), li);
 		if (!frontflag)
 		{
 			frontsec = li->frontsector;
@@ -292,7 +292,7 @@ bool SightCheck::PTR_SightTraverse (intercept_t *in)
 	// now handle 3D-floors
 	if(li->frontsector->e->XFloor.ffloors.Size() || li->backsector->e->XFloor.ffloors.Size())
 	{
-		if (frontflag == -1) frontflag = P_PointOnLineSidePrecise(sightstart, li);
+		if (frontflag == -1) frontflag = P_PointOnLineSidePrecise(sightstart.XY(), li);
 		
 		//Check 3D FLOORS!
 		for(int i=1;i<=2;i++)
@@ -638,8 +638,8 @@ bool SightCheck::P_SightPathTraverse ()
 	{
 		if(!(rover->flags & FF_EXISTS)) continue;
 		
-		double ff_bottom=rover->bottom.plane->ZatPoint(sightstart);
-		double ff_top=rover->top.plane->ZatPoint(sightstart);
+		double ff_bottom=rover->bottom.plane->ZatPoint(sightstart.XY());
+		double ff_top=rover->top.plane->ZatPoint(sightstart.XY());
 
 		if (sightstart.Z < ff_top) checkceiling = false;
 		if (sightstart.Z >= ff_bottom) checkfloor = false;

--- a/src/p_slopes.cpp
+++ b/src/p_slopes.cpp
@@ -58,7 +58,7 @@ static void P_SlopeLineToPoint (int lineid, const DVector3 &pos, bool slopeCeil)
 		sector_t *sec;
 		secplane_t *plane;
 		
-		if (P_PointOnLineSidePrecise (pos, line) == 0)
+		if (P_PointOnLineSidePrecise (pos.XY(), line) == 0)
 		{
 			sec = line->frontsector;
 		}
@@ -398,7 +398,7 @@ void P_SpawnSlopeMakers (FMapThing *firstmt, FMapThing *lastmt, const int *oldve
 				refplane = &sec->floorplane;
 				ceiling = false;
 			}
-			pos.Z = refplane->ZatPoint (mt->pos) + mt->pos.Z;
+			pos.Z = refplane->ZatPoint (mt->pos.XY()) + mt->pos.Z;
 
 			if (mt->info->Special <= SMT_SlopeCeilingPointLine)
 			{ // SlopeFloorPointLine and SlopCeilingPointLine
@@ -421,7 +421,7 @@ void P_SpawnSlopeMakers (FMapThing *firstmt, FMapThing *lastmt, const int *oldve
 		if (mt->info != NULL && mt->info->Type == NULL &&
 			(mt->info->Special == SMT_CopyFloorPlane || mt->info->Special == SMT_CopyCeilingPlane))
 		{
-			P_CopyPlane (mt->args[0], mt->pos, mt->info->Special == SMT_CopyCeilingPlane);
+			P_CopyPlane (mt->args[0], mt->pos.XY(), mt->info->Special == SMT_CopyCeilingPlane);
 			mt->EdNum = 0;
 		}
 	}

--- a/src/p_spec.cpp
+++ b/src/p_spec.cpp
@@ -988,7 +988,7 @@ void P_SetupPortals()
 	{
 		if (s.mType == PORTS_STACKEDSECTORTHING && s.mSkybox)
 		{
-			s.mDisplacement = s.mSkybox->Pos() - s.mSkybox->target->Pos();
+			s.mDisplacement = (s.mSkybox->Pos() - s.mSkybox->target->Pos()).XY();
 			s.mSkybox = NULL;
 		}
 	}

--- a/src/p_states.cpp
+++ b/src/p_states.cpp
@@ -78,7 +78,7 @@ DEFINE_ACTION_FUNCTION(FState, GetSpriteTexture)
 	}
 	if (numret > 0) ret[0].SetInt(sprframe->Texture[rotation].GetIndex());
 	if (numret > 1) ret[1].SetInt(!!(sprframe->Flip & (1 << rotation)));
-	if (numret > 2) ret[2].SetVector2(DVector2(scalex, scaley));
+	if (numret > 2) ret[2].SetVector2(DVector2{scalex, scaley});
 	return MIN(3, numret);
 }
 

--- a/src/p_teleport.cpp
+++ b/src/p_teleport.cpp
@@ -72,7 +72,7 @@ void P_SpawnTeleportFog(AActor *mobj, const DVector3 &pos, bool beforeTele, bool
 	else
 	{
 		double fogDelta = mobj->flags & MF_MISSILE ? 0 : TELEFOGHEIGHT;
-		mo = Spawn((beforeTele ? mobj->TeleFogSourceType : mobj->TeleFogDestType), DVector3(pos, pos.Z + fogDelta), ALLOW_REPLACE);
+		mo = Spawn((beforeTele ? mobj->TeleFogSourceType : mobj->TeleFogDestType), DVector3(pos.XY(), pos.Z + fogDelta), ALLOW_REPLACE);
 	}
 
 	if (mo != NULL && setTarget)
@@ -114,8 +114,8 @@ bool P_Teleport (AActor *thing, DVector3 pos, DAngle angle, int flags)
 	player = thing->player;
 	if (player && player->mo != thing)
 		player = NULL;
-	floorheight = destsect->floorplane.ZatPoint (pos);
-	ceilingheight = destsect->ceilingplane.ZatPoint (pos);
+	floorheight = destsect->floorplane.ZatPoint (pos.XY());
+	ceilingheight = destsect->ceilingplane.ZatPoint (pos.XY());
 	if (thing->flags & MF_MISSILE)
 	{ // We don't measure z velocity, because it doesn't change.
 		missilespeed = thing->VelXYToSpeed();
@@ -386,7 +386,7 @@ bool EV_Teleport (int tid, int tag, line_t *line, int side, AActor *thing, int f
 	{
 		badangle = 0.01;
 	}
-	if (P_Teleport (thing, DVector3(searcher->Pos(), z), searcher->Angles.Yaw + badangle, flags))
+	if (P_Teleport (thing, DVector3(searcher->Pos().XY(), z), searcher->Angles.Yaw + badangle, flags))
 	{
 		// [RH] Lee Killough's changes for silent teleporters from BOOM
 		if (line)
@@ -612,7 +612,7 @@ bool EV_TeleportOther (int other_tid, int dest_tid, bool fog)
 static bool DoGroupForOne (AActor *victim, AActor *source, AActor *dest, bool floorz, bool fog)
 {
 	DAngle an = dest->Angles.Yaw - source->Angles.Yaw;
-	DVector2 off = victim->Pos() - source->Pos();
+	DVector2 off = (victim->Pos() - source->Pos()).XY();
 	DAngle offAngle = victim->Angles.Yaw - source->Angles.Yaw;
 	DVector2 newp = { off.X * an.Cos() - off.Y * an.Sin(), off.X * an.Sin() + off.Y * an.Cos() };
 	double z = floorz ? ONFLOORZ : dest->Z() + victim->Z() - source->Z();

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -420,7 +420,7 @@ bool P_Thing_Raise(AActor *thing, AActor *raiser, int nocheck)
 	thing->flags |= MF_SOLID;
 	thing->Height = info->Height;	// [RH] Use real height
 	thing->radius = info->radius;	// [RH] Use real radius
-	if (!nocheck && !P_CheckPosition (thing, thing->Pos()))
+	if (!nocheck && !P_CheckPosition (thing, thing->Pos().XY()))
 	{
 		thing->flags = oldflags;
 		thing->radius = oldradius;
@@ -462,7 +462,7 @@ bool P_Thing_CanRaise(AActor *thing)
 	thing->Height = info->Height;
 	thing->radius = info->radius;
 
-	bool check = P_CheckPosition (thing, thing->Pos());
+	bool check = P_CheckPosition (thing, thing->Pos().XY());
 
 	// Restore checked properties
 	thing->flags = oldflags;
@@ -939,7 +939,7 @@ int P_Thing_Warp(AActor *caller, AActor *reference, double xofs, double yofs, do
 			{
 				caller->AddZ(reference->GetBobOffset());
 			}
-			P_TryMove(caller, caller->Pos(), false);
+			P_TryMove(caller, caller->Pos().XY(), false);
 		}
 		return true;
 	}

--- a/src/p_trace.cpp
+++ b/src/p_trace.cpp
@@ -68,10 +68,10 @@ struct FTraceInfo
 	int ptflags;
 
 	// These are required for 3D-floor checking
-	// to create a fake sector with a floor 
+	// to create a fake sector with a floor
 	// or ceiling plane coming from a 3D-floor
-	sector_t DummySector[2];	
-	int sectorsel;		
+	sector_t DummySector[2];
+	int sectorsel;
 
 	void Setup3DFloors();
 	bool LineCheck(intercept_t *in, double dist, DVector3 hit, bool special3dpass);
@@ -196,7 +196,7 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 	}
 
 	if (reslt)
-	{ 
+	{
 		return flags ? EditTraceResult(flags, res) : true;
 	}
 	else
@@ -291,7 +291,7 @@ void FTraceInfo::Setup3DFloors()
 
 	if (ff.Size())
 	{
-		memcpy(&DummySector[0], CurSector, sizeof(sector_t));
+        DummySector[0] = *CurSector;
 		CurSector = &DummySector[0];
 		sectorsel = 1;
 
@@ -490,7 +490,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		// check for 3D floors first
 		if (entersector->e->XFloor.ffloors.Size())
 		{
-			memcpy(&DummySector[sectorsel], entersector, sizeof(sector_t));
+            DummySector[sectorsel] = *entersector;
 			entersector = &DummySector[sectorsel];
 			sectorsel ^= 1;
 
@@ -516,7 +516,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 								bf = ff_top - EQUAL_EPSILON;
 							}
 						}
-						
+
 						// above
 						if (bf < ff_top)
 						{
@@ -658,7 +658,7 @@ cont:
 	}
 }
 
-	
+
 //==========================================================================
 //
 //
@@ -808,7 +808,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 		double dist = MaxDist * in->frac;
 		DVector3 hit = Start + Vec * dist;
 
-		// Crossed a floor portal? 
+		// Crossed a floor portal?
 		if (Vec.Z < 0 && !CurSector->PortalBlocksMovement(sector_t::floor))
 		{
 			// calculate position where the portal is crossed

--- a/src/p_trace.cpp
+++ b/src/p_trace.cpp
@@ -299,8 +299,8 @@ void FTraceInfo::Setup3DFloors()
 		DVector3 pos = Start + Vec * sdist;
 
 
-		double bf = CurSector->floorplane.ZatPoint(pos);
-		double bc = CurSector->ceilingplane.ZatPoint(pos);
+		double bf = CurSector->floorplane.ZatPoint(pos.XY());
+		double bc = CurSector->ceilingplane.ZatPoint(pos.XY());
 
 		for (auto rover : ff)
 		{
@@ -312,7 +312,7 @@ void FTraceInfo::Setup3DFloors()
 				if (Check3DFloorPlane(rover, false) && isLiquid(rover))
 				{
 					// only consider if the plane is above the actual floor.
-					if (rover->top.plane->ZatPoint(Results->HitPos) > bf)
+					if (rover->top.plane->ZatPoint(Results->HitPos.XY()) > bf)
 					{
 						Results->Crossed3DWater = rover;
 						Results->Crossed3DWaterPos = Results->HitPos;
@@ -323,8 +323,8 @@ void FTraceInfo::Setup3DFloors()
 
 			if (!(rover->flags&FF_SHOOTTHROUGH))
 			{
-				double ff_bottom = rover->bottom.plane->ZatPoint(pos);
-				double ff_top = rover->top.plane->ZatPoint(pos);
+				double ff_bottom = rover->bottom.plane->ZatPoint(pos.XY());
+				double ff_top = rover->top.plane->ZatPoint(pos.XY());
 				// clip to the part of the sector we are in
 				if (pos.Z > ff_top)
 				{
@@ -404,7 +404,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		}
 		else
 		{
-			lineside = P_PointOnLineSide(Start, in->d.line);
+			lineside = P_PointOnLineSide(Start.XY(), in->d.line);
 			CurSector = lineside ? in->d.line->backsector : in->d.line->frontsector;
 		}
 	}
@@ -434,20 +434,20 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		}
 	}
 
-	ff = CurSector->floorplane.ZatPoint(hit);
-	fc = CurSector->ceilingplane.ZatPoint(hit);
+	ff = CurSector->floorplane.ZatPoint(hit.XY());
+	fc = CurSector->ceilingplane.ZatPoint(hit.XY());
 
 	if (entersector != NULL)
 	{
-		bf = entersector->floorplane.ZatPoint(hit);
-		bc = entersector->ceilingplane.ZatPoint(hit);
+		bf = entersector->floorplane.ZatPoint(hit.XY());
+		bc = entersector->ceilingplane.ZatPoint(hit.XY());
 	}
 
 	sector_t *hsec = CurSector->GetHeightSec();
 	if (Results->CrossedWater == NULL &&
 		hsec != NULL &&
-		Start.Z > hsec->floorplane.ZatPoint(Start) &&
-		hit.Z <= hsec->floorplane.ZatPoint(hit))
+		Start.Z > hsec->floorplane.ZatPoint(Start.XY()) &&
+		hit.Z <= hsec->floorplane.ZatPoint(hit.XY()))
 	{
 		// hit crossed a water plane
 		if (CheckSectorPlane(hsec, true))
@@ -500,8 +500,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 
 				if (entershootthrough != inshootthrough && rover->flags&FF_EXISTS)
 				{
-					double ff_bottom = rover->bottom.plane->ZatPoint(hit);
-					double ff_top = rover->top.plane->ZatPoint(hit);
+					double ff_bottom = rover->bottom.plane->ZatPoint(hit.XY());
+					double ff_top = rover->top.plane->ZatPoint(hit.XY());
 
 					// clip to the part of the sector we are in
 					if (hit.Z > ff_top)
@@ -703,8 +703,8 @@ bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 	if (CurSector->e->XFloor.ffloors.Size())
 	{
 		// check for 3D floor hits first.
-		double ff_floor = CurSector->floorplane.ZatPoint(hit);
-		double ff_ceiling = CurSector->ceilingplane.ZatPoint(hit);
+		double ff_floor = CurSector->floorplane.ZatPoint(hit.XY());
+		double ff_ceiling = CurSector->ceilingplane.ZatPoint(hit.XY());
 
 		if (hit.Z > ff_ceiling && CurSector->PortalBlocksMovement(sector_t::ceiling))	// actor is hit above the current ceiling
 		{
@@ -793,7 +793,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 					if (Check3DFloorPlane(rover, false))
 					{
 						// only consider if the plane is above the actual floor.
-						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+						if (rover->top.plane->ZatPoint(Results->HitPos.XY()) > CurSector->floorplane.ZatPoint(Results->HitPos.XY()))
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = Results->HitPos;
@@ -835,10 +835,10 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 
 		if (in->isaline)
 		{
-			if (in->d.line->isLinePortal() && P_PointOnLineSidePrecise(Start, in->d.line) == 0)
+			if (in->d.line->isLinePortal() && P_PointOnLineSidePrecise(Start.XY(), in->d.line) == 0)
 			{
 				sector_t *entersector = in->d.line->backsector;
-				if (entersector == NULL || (hit.Z >= entersector->floorplane.ZatPoint(hit) && hit.Z <= entersector->ceilingplane.ZatPoint(hit)))
+				if (entersector == NULL || (hit.Z >= entersector->floorplane.ZatPoint(hit.XY()) && hit.Z <= entersector->ceilingplane.ZatPoint(hit.XY())))
 				{
 					FLinePortal *port = in->d.line->getPortal();
 					// The caller cannot handle portals without global offset.
@@ -876,8 +876,8 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 
 	if (Results->CrossedWater == NULL &&
 		CurSector->heightsec != NULL &&
-		CurSector->heightsec->floorplane.ZatPoint(Start) < Start.Z &&
-		CurSector->heightsec->floorplane.ZatPoint(Results->HitPos) >= Results->HitPos.Z)
+		CurSector->heightsec->floorplane.ZatPoint(Start.XY()) < Start.Z &&
+		CurSector->heightsec->floorplane.ZatPoint(Results->HitPos.XY()) >= Results->HitPos.Z)
 	{
 		// Save the result so that the water check doesn't destroy it.
 		FTraceResults *res = Results;

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -313,7 +313,7 @@ player_t::player_t()
   viewheight(0),
   deltaviewheight(0),
   bob(0),
-  Vel(0, 0),
+  Vel({0, 0}),
   centering(0),
   turnticks(0),
   attackdown(0),

--- a/src/po_man.cpp
+++ b/src/po_man.cpp
@@ -1176,7 +1176,7 @@ bool FPolyObj::CheckMobjBlocking (side_t *sd)
 							performBlockingThrust = true;
 						}
 
-						DVector2 pos = mobj->PosRelative(ld);
+						DVector2 pos = mobj->PosRelative(ld).XY();
 						FBoundingBox box(pos.X, pos.Y, mobj->radius);
 
 						if (!box.inRange(ld) || box.BoxOnLineSide(ld) != -1)
@@ -1187,7 +1187,7 @@ bool FPolyObj::CheckMobjBlocking (side_t *sd)
 						if (ld->isLinePortal())
 						{
 							// Fixme: this still needs to figure out if the polyobject move made the player cross the portal line.
-							if (P_TryMove(mobj, mobj->Pos(), false))
+                            if (P_TryMove(mobj, mobj->Pos().XY(), false))
 							{
 								continue;
 							}
@@ -1197,7 +1197,7 @@ bool FPolyObj::CheckMobjBlocking (side_t *sd)
 						// Best use the one facing the player and ignore the back side.
 						if (ld->sidedef[1] != NULL)
 						{
-							int side = P_PointOnLineSidePrecise(mobj->Pos(), ld);
+							int side = P_PointOnLineSidePrecise(mobj->Pos().XY(), ld);
 							if (ld->sidedef[side] != sd)
 							{
 								continue;

--- a/src/polyrenderer/scene/poly_cull.cpp
+++ b/src/polyrenderer/scene/poly_cull.cpp
@@ -91,7 +91,7 @@ void PolyCull::CullNode(void *node)
 		node_t *bsp = (node_t *)node;
 
 		// Decide which side the view point is on.
-		int side = PointOnSide(PolyRenderer::Instance()->Viewpoint.Pos, bsp);
+		int side = PointOnSide(PolyRenderer::Instance()->Viewpoint.Pos.XY(), bsp);
 
 		// Recursively divide front space (toward the viewer).
 		CullNode(bsp->children[side]);

--- a/src/polyrenderer/scene/poly_decal.cpp
+++ b/src/polyrenderer/scene/poly_decal.cpp
@@ -67,7 +67,7 @@ void RenderPolyDecal::Render(PolyRenderThread *thread, DBaseDecal *decal, const 
 
 	double dcx, dcy;
 	decal->GetXY(line->sidedef, dcx, dcy);
-	DVector2 decal_pos = DVector2(dcx, dcy) + normal;
+	DVector2 decal_pos = DVector2{dcx, dcy} + normal;
 	DVector2 decal_left = decal_pos - edge_left * angvec;
 	DVector2 decal_right = decal_pos + edge_right * angvec;
 

--- a/src/polyrenderer/scene/poly_portal.cpp
+++ b/src/polyrenderer/scene/poly_portal.cpp
@@ -234,7 +234,7 @@ void PolyDrawLinePortal::SaveGlobals()
 	}
 
 	viewpoint.camera = nullptr;
-	viewpoint.sector = R_PointInSubsector(viewpoint.Pos)->sector;
+	viewpoint.sector = R_PointInSubsector(viewpoint.Pos.XY())->sector;
 
 	viewpoint.SetViewAngle(viewwindow);
 }

--- a/src/polyrenderer/scene/poly_scene.cpp
+++ b/src/polyrenderer/scene/poly_scene.cpp
@@ -81,7 +81,7 @@ void RenderPolyScene::Render(PolyPortalViewpoint *viewpoint)
 				double distanceSquared = (thing->Pos() - rviewpoint.Pos).LengthSquared();
 				if (r_modelscene && modelframe && distanceSquared < model_distance_cull)
 				{
-					AddModel(thread, thing, distanceSquared, thing->Pos());
+					AddModel(thread, thing, distanceSquared, thing->Pos().XY());
 				}
 				else
 				{
@@ -201,7 +201,7 @@ void RenderPolyScene::RenderPolyNode(PolyRenderThread *thread, void *node, uint3
 		node_t *bsp = (node_t *)node;
 
 		// Decide which side the view point is on.
-		int side = PointOnSide(PolyRenderer::Instance()->Viewpoint.Pos, bsp);
+		int side = PointOnSide(PolyRenderer::Instance()->Viewpoint.Pos.XY(), bsp);
 
 		// Recursively divide front space (toward the viewer).
 		RenderPolyNode(thread, bsp->children[side], subsectorDepth, frontsector);
@@ -272,8 +272,8 @@ void RenderPolyScene::AddSprite(PolyRenderThread *thread, AActor *thing, double 
 	{
 		node_t *bsp = (node_t *)node;
 		
-		DVector2 planePos(FIXED2DBL(bsp->x), FIXED2DBL(bsp->y));
-		DVector2 planeNormal = DVector2(FIXED2DBL(-bsp->dy), FIXED2DBL(bsp->dx));
+		DVector2 planePos{FIXED2DBL(bsp->x), FIXED2DBL(bsp->y)};
+		DVector2 planeNormal{FIXED2DBL(-bsp->dy), FIXED2DBL(bsp->dx)};
 		double planeD = planeNormal | planePos;
 		
 		int sideLeft = (left | planeNormal) > planeD;
@@ -317,8 +317,8 @@ void RenderPolyScene::AddModel(PolyRenderThread *thread, AActor *thing, double s
 		{
 			node_t *bsp = (node_t *)node;
 
-			DVector2 planePos(FIXED2DBL(bsp->x), FIXED2DBL(bsp->y));
-			DVector2 planeNormal = DVector2(FIXED2DBL(-bsp->dy), FIXED2DBL(bsp->dx));
+			DVector2 planePos{FIXED2DBL(bsp->x), FIXED2DBL(bsp->y)};
+			DVector2 planeNormal{FIXED2DBL(-bsp->dy), FIXED2DBL(bsp->dx)};
 			double planeD = planeNormal | planePos;
 
 			int side = (pos | planeNormal) > planeD;
@@ -513,8 +513,8 @@ PolyTransferHeights::PolyTransferHeights(subsector_t *sub) : Subsector(sub)
 			}
 		}
 
-		double refceilz = s->ceilingplane.ZatPoint(PolyRenderer::Instance()->Viewpoint.Pos);
-		double orgceilz = sec->ceilingplane.ZatPoint(PolyRenderer::Instance()->Viewpoint.Pos);
+		double refceilz = s->ceilingplane.ZatPoint(PolyRenderer::Instance()->Viewpoint.Pos.XY());
+		double orgceilz = sec->ceilingplane.ZatPoint(PolyRenderer::Instance()->Viewpoint.Pos.XY());
 
 		if (underwater || doorunderwater)
 		{

--- a/src/polyrenderer/scene/poly_sprite.cpp
+++ b/src/polyrenderer/scene/poly_sprite.cpp
@@ -66,8 +66,8 @@ bool RenderPolySprite::GetLine(AActor *thing, DVector2 &left, DVector2 &right)
 	else
 		offsetX = tex->GetLeftOffsetPo() * thingxscalemul;
 
-	left = DVector2(pos.X - viewpoint.Sin * offsetX, pos.Y + viewpoint.Cos * offsetX);
-	right = DVector2(left.X + viewpoint.Sin * spriteWidth, left.Y - viewpoint.Cos * spriteWidth);
+	left = DVector2{pos.X - viewpoint.Sin * offsetX, pos.Y + viewpoint.Cos * offsetX};
+	right = DVector2{left.X + viewpoint.Sin * spriteWidth, left.Y - viewpoint.Cos * spriteWidth};
 	return true;
 }
 
@@ -113,7 +113,7 @@ void RenderPolySprite::Render(PolyRenderThread *thread, AActor *thing, subsector
 	double spriteHeight = thingyscalemul * tex->GetHeight();
 
 	posZ -= (tex->GetHeight() - tex->GetTopOffsetPo()) * thingyscalemul;
-	posZ = PerformSpriteClipAdjustment(thing, thingpos, spriteHeight, posZ);
+	posZ = PerformSpriteClipAdjustment(thing, thingpos.XY(), spriteHeight, posZ);
 
 	//double depth = 1.0;
 	//visstyle_t visstyle = GetSpriteVisStyle(thing, depth);

--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -718,7 +718,9 @@ DEFINE_ACTION_FUNCTION(FSectorPortal, GetSkyboxPortal)
 unsigned P_GetPortal(int type, int plane, sector_t *from, sector_t *to, const DVector2 &displacement)
 {
 	unsigned i = level.sectorPortals.Reserve(1);
-	memset(&level.sectorPortals[i], 0, sizeof(level.sectorPortals[i]));
+	level.sectorPortals[i].mFlags = 0;
+	level.sectorPortals[i].mPartner = 0;
+	level.sectorPortals[i].mSkybox = nullptr;
 	level.sectorPortals[i].mType = type;
 	level.sectorPortals[i].mPlane = plane;
 	level.sectorPortals[i].mOrigin = from;
@@ -739,7 +741,8 @@ unsigned P_GetPortal(int type, int plane, sector_t *from, sector_t *to, const DV
 unsigned P_GetStackPortal(AActor *point, int plane)
 {
 	unsigned i = level.sectorPortals.Reserve(1);
-	memset(&level.sectorPortals[i], 0, sizeof(level.sectorPortals[i]));
+	level.sectorPortals[i].mFlags = 0;
+	level.sectorPortals[i].mPartner = 0;
 	level.sectorPortals[i].mType = PORTS_STACKEDSECTORTHING;
 	level.sectorPortals[i].mPlane = plane;
 	level.sectorPortals[i].mOrigin = point->target->Sector;

--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -761,7 +761,7 @@ unsigned P_GetStackPortal(AActor *point, int plane)
 
 DVector2 P_GetOffsetPosition(double x, double y, double dx, double dy)
 {
-	DVector2 dest(x + dx, y + dy);
+	DVector2 dest{x + dx, y + dy};
 	if (level.PortalBlockmap.containsLines)
 	{
 		double actx = x, acty = y;

--- a/src/portal.h
+++ b/src/portal.h
@@ -14,7 +14,7 @@ struct subsector_t;
 // that are connected by portals.
 // The idea here is basically the same as implemented in Eternity Engine:
 //
-// - each portal creates two sector groups in the map 
+// - each portal creates two sector groups in the map
 //   which are offset by the displacement of the portal anchors
 //
 // - for two or multiple groups the displacement is calculated by
@@ -34,6 +34,9 @@ struct FDisplacement
 
 };
 
+#include <type_traits>
+//static_assert(std::is_trivial<DVector2>::value, "DVector2 is not trivial");
+
 struct FDisplacementTable
 {
 	TArray<FDisplacement> data;
@@ -47,7 +50,12 @@ struct FDisplacementTable
 	void Create(int numgroups)
 	{
 		data.Resize(numgroups*numgroups);
-		memset(&data[0], 0, numgroups*numgroups*sizeof(data[0]));
+        for (auto i = 0; i < size; ++i) {
+            data[i].pos = {0,0};
+            data[i].isSet = false;
+            data[i].indirect = 0;
+        }
+		//memset(&data[0], 0, numgroups*numgroups*sizeof(data[0]));
 		size = numgroups;
 	}
 

--- a/src/portal.h
+++ b/src/portal.h
@@ -34,9 +34,6 @@ struct FDisplacement
 
 };
 
-#include <type_traits>
-//static_assert(std::is_trivial<DVector2>::value, "DVector2 is not trivial");
-
 struct FDisplacementTable
 {
 	TArray<FDisplacement> data;

--- a/src/r_data/models/models.cpp
+++ b/src/r_data/models/models.cpp
@@ -506,7 +506,6 @@ void InitModels()
 	{
 		FVoxelModel *md = (FVoxelModel*)Models[VoxelDefs[i]->Voxel->VoxelIndex];
 		FSpriteModelFrame smf;
-		memset(&smf, 0, sizeof(smf));
 		smf.modelIDs[1] = smf.modelIDs[2] = smf.modelIDs[3] = -1;
 		smf.modelIDs[0] = VoxelDefs[i]->Voxel->VoxelIndex;
 		smf.skinIDs[0] = md->GetPaletteTexture();

--- a/src/r_data/models/models_ue1.cpp
+++ b/src/r_data/models/models_ue1.cpp
@@ -122,7 +122,7 @@ void FUE1Model::LoadGeometry()
 			Poly.V[j] = dpolys[i].vertices[j];
 		// unpack coords
 		for ( int j=0; j<3; j++ )
-			Poly.C[j] = FVector2(dpolys[i].uv[j][0]/255.f,dpolys[i].uv[j][1]/255.f);
+			Poly.C[j] = FVector2{dpolys[i].uv[j][0]/255.f,dpolys[i].uv[j][1]/255.f};
 		// compute facet normal
 		FVector3 dir[2];
 		dir[0] = verts[Poly.V[1]].Pos-verts[Poly.V[0]].Pos;

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -301,7 +301,7 @@ public:
 	{
 		return D;
 	}
-	
+
 	bool isSlope() const
 	{
 		return !normal.XY().isZero();
@@ -476,7 +476,7 @@ enum
 	SECF_NORESPAWN		= 8,	// players can not respawn in this sector
 	SECF_FRICTION		= 16,	// sector has friction enabled
 	SECF_PUSH			= 32,	// pushers enabled
-	SECF_SILENTMOVE		= 64,	// Sector movement makes mo sound (Eternity got this so this may be useful for an extended cross-port standard.) 
+	SECF_SILENTMOVE		= 64,	// Sector movement makes mo sound (Eternity got this so this may be useful for an extended cross-port standard.)
 	SECF_DMGTERRAINFX	= 128,	// spawns terrain splash when inflicting damage
 	SECF_ENDGODMODE		= 256,	// getting damaged by this sector ends god mode
 	SECF_ENDLEVEL		= 512,	// ends level when health goes below 10
@@ -571,21 +571,23 @@ struct FTransform
 
 struct secspecial_t
 {
-	FNameNoInit damagetype;		// [RH] Means-of-death for applied damage
+	FName damagetype;		// [RH] Means-of-death for applied damage
 	int damageamount = 0;			// [RH] Damage to do while standing on floor
 	short special = 0;
 	short damageinterval = 0;	// Interval for damage application
 	short leakydamage = 0;		// chance of leaking through radiation suit
 	int Flags = 0;
 
-	secspecial_t()
-	{
-		Clear();
-	}
+	secspecial_t() = default;
 
 	void Clear()
 	{
-		memset(this, 0, sizeof(*this));
+        damagetype = FName{};
+		damageamount = 0;
+		special = 0;
+        damageinterval = 0;
+        leakydamage = 0;
+        Flags = 0;
 	}
 };
 
@@ -792,7 +794,7 @@ public:
 		planes[pos].Flags |= Or;
 	}
 
-	int GetPlaneLight(int pos) const 
+	int GetPlaneLight(int pos) const
 	{
 		return planes[pos].Light;
 	}
@@ -986,7 +988,7 @@ public:
 	short		seqType;		// this sector's sound sequence
 
 	int			sky;
-	FNameNoInit	SeqName;		// Sound sequence name. Setting seqType non-negative will override this.
+	FName	SeqName;		// Sound sequence name. Setting seqType non-negative will override this.
 
 	DVector2	centerspot;		// origin for any sounds played by the sector
 	int 		validcount;		// if == validcount, already checked
@@ -1036,7 +1038,7 @@ public:
 	struct msecnode_t *touching_renderthings; // this is used to allow wide things to be rendered not only from their main sector.
 
 	double gravity;			// [RH] Sector gravity (1.0 is normal)
-	FNameNoInit damagetype;		// [RH] Means-of-death for applied damage
+	FName damagetype;		// [RH] Means-of-death for applied damage
 	int damageamount;			// [RH] Damage to do while standing on floor
 	short damageinterval;	// Interval for damage application
 	short leakydamage;		// chance of leaking through radiation suit
@@ -1175,7 +1177,7 @@ struct side_t
 	{
 		textures[which].xOffset = offset;;
 	}
-	
+
 	void SetTextureXOffset(double offset)
 	{
 		textures[top].xOffset =
@@ -1393,7 +1395,7 @@ struct seg_t
 {
 	vertex_t*	v1;
 	vertex_t*	v2;
-	
+
 	side_t* 	sidedef;
 	line_t* 	linedef;
 
@@ -1458,7 +1460,7 @@ struct subsector_t
 };
 
 
-	
+
 
 //
 // BSP node.
@@ -1513,6 +1515,11 @@ typedef uint8_t lighttable_t;	// This could be wider for >8 bit display.
 subsector_t *P_PointInSubsector(double x, double y);
 
 inline sector_t *P_PointInSector(const DVector2 &pos)
+{
+	return P_PointInSubsector(pos.X, pos.Y)->sector;
+}
+
+inline sector_t *P_PointInSector(const DVector3 &pos)
 {
 	return P_PointInSubsector(pos.X, pos.Y)->sector;
 }

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -93,7 +93,7 @@ struct vertexdata_t
 
 struct vertex_t
 {
-	DVector2 p;
+	DVector2 p{0, 0};
 
 	void set(fixed_t x, fixed_t y)
 	{
@@ -141,24 +141,15 @@ struct vertex_t
 	void RecalcVertexHeights();
 
 
-	angle_t viewangle;	// precalculated angle for clipping
-	int angletime;		// recalculation time for view angle
-	bool dirty;			// something has changed and needs to be recalculated
-	int numheights;
-	int numsectors;
-	sector_t ** sectors;
-	float * heightlist;
+	angle_t viewangle = 0;	// precalculated angle for clipping
+	int angletime = 0;		// recalculation time for view angle
+	bool dirty = true;			// something has changed and needs to be recalculated
+	int numheights = 0;
+	int numsectors = 0;
+	sector_t ** sectors = nullptr;
+	float * heightlist = nullptr;
 
-	vertex_t()
-	{
-		p = { 0,0 };
-		angletime = 0;
-		viewangle = 0;
-		dirty = true;
-		numheights = numsectors = 0;
-		sectors = NULL;
-		heightlist = NULL;
-	}
+	vertex_t() = default;
 
 	~vertex_t()
 	{
@@ -215,9 +206,7 @@ struct FUDMFKey
 	double FloatVal;
 	FString StringVal;
 
-	FUDMFKey()
-	{
-	}
+	FUDMFKey() = default;
 
 	FUDMFKey& operator =(int val)
 	{
@@ -583,11 +572,11 @@ struct FTransform
 struct secspecial_t
 {
 	FNameNoInit damagetype;		// [RH] Means-of-death for applied damage
-	int damageamount;			// [RH] Damage to do while standing on floor
-	short special;
-	short damageinterval;	// Interval for damage application
-	short leakydamage;		// chance of leaking through radiation suit
-	int Flags;
+	int damageamount = 0;			// [RH] Damage to do while standing on floor
+	short special = 0;
+	short damageinterval = 0;	// Interval for damage application
+	short leakydamage = 0;		// chance of leaking through radiation suit
+	int Flags = 0;
 
 	secspecial_t()
 	{

--- a/src/r_utility.cpp
+++ b/src/r_utility.cpp
@@ -449,8 +449,8 @@ void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Fr
 		NoInterpolateView = false;
 		iview->Old = iview->New;
 	}
-	int oldgroup = R_PointInSubsector(iview->Old.Pos)->sector->PortalGroup;
-	int newgroup = R_PointInSubsector(iview->New.Pos)->sector->PortalGroup;
+	int oldgroup = R_PointInSubsector(iview->Old.Pos.XY())->sector->PortalGroup;
+	int newgroup = R_PointInSubsector(iview->New.Pos.XY())->sector->PortalGroup;
 
 	DAngle oviewangle = iview->Old.Angles.Yaw;
 	DAngle nviewangle = iview->New.Angles.Yaw;
@@ -505,7 +505,7 @@ void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Fr
 						nviewz -= totalzdiff - zdiff;
 						oviewangle += adiff;
 						nviewangle -= totaladiff - adiff;
-						DVector2 viewpos = start.pos + (fragfrac * (end.pos - start.pos));
+						DVector2 viewpos = (start.pos + (fragfrac * (end.pos - start.pos))).XY();
 						viewpoint.Pos = { viewpos, oviewz + Frac * (nviewz - oviewz) };
 						break;
 					}
@@ -555,7 +555,7 @@ void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Fr
 	}
 	
 	// Due to interpolation this is not necessarily the same as the sector the camera is in.
-	viewpoint.sector = R_PointInSubsector(viewpoint.Pos)->sector;
+	viewpoint.sector = R_PointInSubsector(viewpoint.Pos.XY())->sector;
 	bool moved = false;
 	while (!viewpoint.sector->PortalBlocksMovement(sector_t::ceiling))
 	{
@@ -563,7 +563,7 @@ void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Fr
 		{
 			viewpoint.Pos += viewpoint.sector->GetPortalDisplacement(sector_t::ceiling);
 			viewpoint.ActorPos += viewpoint.sector->GetPortalDisplacement(sector_t::ceiling);
-			viewpoint.sector = R_PointInSubsector(viewpoint.Pos)->sector;
+			viewpoint.sector = R_PointInSubsector(viewpoint.Pos.XY())->sector;
 			moved = true;
 		}
 		else break;
@@ -576,7 +576,7 @@ void R_InterpolateView (FRenderViewpoint &viewpoint, player_t *player, double Fr
 			{
 				viewpoint.Pos += viewpoint.sector->GetPortalDisplacement(sector_t::floor);
 				viewpoint.ActorPos += viewpoint.sector->GetPortalDisplacement(sector_t::floor);
-				viewpoint.sector = R_PointInSubsector(viewpoint.Pos)->sector;
+				viewpoint.sector = R_PointInSubsector(viewpoint.Pos.XY())->sector;
 				moved = true;
 			}
 			else break;
@@ -806,7 +806,7 @@ void R_SetupFrame (FRenderViewpoint &viewpoint, FViewWindow &viewwindow, AActor 
 	if (player != NULL && gamestate != GS_TITLELEVEL &&
 		((player->cheats & CF_CHASECAM) || (r_deathcamera && viewpoint.camera->health <= 0)))
 	{
-		sector_t *oldsector = R_PointInSubsector(iview->Old.Pos)->sector;
+		sector_t *oldsector = R_PointInSubsector(iview->Old.Pos.XY())->sector;
 		// [RH] Use chasecam view
 		DVector3 campos;
 		DAngle camangle;
@@ -858,7 +858,7 @@ void R_SetupFrame (FRenderViewpoint &viewpoint, FViewWindow &viewwindow, AActor 
 	// Keep the view within the sector's floor and ceiling
 	if (viewpoint.sector->PortalBlocksMovement(sector_t::ceiling))
 	{
-		double theZ = viewpoint.sector->ceilingplane.ZatPoint(viewpoint.Pos) - 4;
+		double theZ = viewpoint.sector->ceilingplane.ZatPoint(viewpoint.Pos.XY()) - 4;
 		if (viewpoint.Pos.Z > theZ)
 		{
 			viewpoint.Pos.Z = theZ;
@@ -867,7 +867,7 @@ void R_SetupFrame (FRenderViewpoint &viewpoint, FViewWindow &viewwindow, AActor 
 
 	if (viewpoint.sector->PortalBlocksMovement(sector_t::floor))
 	{
-		double theZ = viewpoint.sector->floorplane.ZatPoint(viewpoint.Pos) + 4;
+		double theZ = viewpoint.sector->floorplane.ZatPoint(viewpoint.Pos.XY()) + 4;
 		if (viewpoint.Pos.Z < theZ)
 		{
 			viewpoint.Pos.Z = theZ;

--- a/src/s_sound.cpp
+++ b/src/s_sound.cpp
@@ -881,7 +881,7 @@ static void CalcSectorSoundOrg(const DVector3 &listenpos, const sector_t *sec, i
 			// Find the closest point on the sector's boundary lines and use
 			// that as the perceived origin of the sound.
 			DVector2 xy;
-			sec->ClosestPoint(listenpos, xy);
+			sec->ClosestPoint(listenpos.XY(), xy);
 			pos.X = (float)xy.X;
 			pos.Z = (float)xy.Y;
 		}
@@ -895,15 +895,15 @@ static void CalcSectorSoundOrg(const DVector3 &listenpos, const sector_t *sec, i
 	// Set sound vertical position based on channel.
 	if (channum == CHAN_FLOOR)
 	{
-		pos.Y = (float)MIN<double>(sec->floorplane.ZatPoint(listenpos), listenpos.Z);
+		pos.Y = (float)MIN<double>(sec->floorplane.ZatPoint(listenpos.XY()), listenpos.Z);
 	}
 	else if (channum == CHAN_CEILING)
 	{
-		pos.Y = (float)MAX<double>(sec->ceilingplane.ZatPoint(listenpos), listenpos.Z);
+		pos.Y = (float)MAX<double>(sec->ceilingplane.ZatPoint(listenpos.XY()), listenpos.Z);
 	}
 	else if (channum == CHAN_INTERIOR)
 	{
-		pos.Y = (float)clamp<double>(listenpos.Z, sec->floorplane.ZatPoint(listenpos), sec->ceilingplane.ZatPoint(listenpos));
+		pos.Y = (float)clamp<double>(listenpos.Z, sec->floorplane.ZatPoint(listenpos.XY()), sec->ceilingplane.ZatPoint(listenpos.XY()));
 	}
 }
 
@@ -924,11 +924,11 @@ static void CalcPolyobjSoundOrg(const DVector3 &listenpos, const FPolyObj *poly,
 	sector_t *sec;
 
 	DVector2 ppos;
-	poly->ClosestPoint(listenpos, ppos, &side);
+	poly->ClosestPoint(listenpos.XY(), ppos, &side);
 	pos.X = (float)ppos.X;
 	pos.Z = (float)ppos.Y;
 	sec = side->sector;
-	pos.Y = (float)clamp<double>(listenpos.Z, sec->floorplane.ZatPoint(listenpos), sec->ceilingplane.ZatPoint(listenpos));
+	pos.Y = (float)clamp<double>(listenpos.Z, sec->floorplane.ZatPoint(listenpos.XY()), sec->ceilingplane.ZatPoint(listenpos.XY()));
 }
 
 //==========================================================================

--- a/src/sound/timiditypp/reverb.cpp
+++ b/src/sound/timiditypp/reverb.cpp
@@ -30,6 +30,7 @@
 
 #include <string.h>
 #include <stdint.h>
+#include <climits>
 #include "timidity.h"
 #include "tables.h"
 #include "common.h"
@@ -3373,7 +3374,7 @@ void Reverb::do_lofi1(int32_t *buf, int32_t count, EffectList *ef)
 	const int32_t level_shift = info->level_shift;
 
 	if(count == MAGIC_INIT_EFFECT_INFO) {
-		info->bit_mask = ~0L << (info->lofi_type * 2);
+		info->bit_mask = UINT32_MAX << (info->lofi_type * 2);
 		info->level_shift = ~info->bit_mask >> 1;
 		info->dryi = TIM_FSCALE(info->dry * info->level, 24);
 		info->weti = TIM_FSCALE(info->wet * info->level, 24);
@@ -3435,7 +3436,7 @@ void Reverb::do_lofi2(int32_t *buf, int32_t count, EffectList *ef)
 			fil->freq = -1;	/* bypass */
 			calc_filter_biquad_low(fil);
 		}
-		info->bit_mask = ~0L << (info->lofi_type * 2);
+		info->bit_mask = UINT32_MAX << (info->lofi_type * 2);
 		info->level_shift = ~info->bit_mask >> 1;
 		info->dryi = TIM_FSCALE(info->dry * info->level, 24);
 		info->weti = TIM_FSCALE(info->wet * info->level, 24);

--- a/src/swrenderer/line/r_farclip_line.cpp
+++ b/src/swrenderer/line/r_farclip_line.cpp
@@ -93,7 +93,7 @@ namespace swrenderer
 
 		// reject lines that aren't seen from the portal (if any)
 		// [ZZ] 10.01.2016: lines inside a skybox shouldn't be clipped, although this imposes some limitations on portals in skyboxes.
-		if (!renderportal->CurrentPortalInSkybox && renderportal->CurrentPortal && P_ClipLineToPortal(line->linedef, renderportal->CurrentPortal->dst, Thread->Viewport->viewpoint.Pos))
+		if (!renderportal->CurrentPortalInSkybox && renderportal->CurrentPortal && P_ClipLineToPortal(line->linedef, renderportal->CurrentPortal->dst, Thread->Viewport->viewpoint.Pos.XY()))
 			return;
 
 		mFrontCeilingZ1 = mFrontSector->ceilingplane.ZatPoint(line->v1);

--- a/src/swrenderer/line/r_line.cpp
+++ b/src/swrenderer/line/r_line.cpp
@@ -108,7 +108,7 @@ namespace swrenderer
 
 		// reject lines that aren't seen from the portal (if any)
 		// [ZZ] 10.01.2016: lines inside a skybox shouldn't be clipped, although this imposes some limitations on portals in skyboxes.
-		if (!renderportal->CurrentPortalInSkybox && renderportal->CurrentPortal && P_ClipLineToPortal(line->linedef, renderportal->CurrentPortal->dst, Thread->Viewport->viewpoint.Pos))
+		if (!renderportal->CurrentPortalInSkybox && renderportal->CurrentPortal && P_ClipLineToPortal(line->linedef, renderportal->CurrentPortal->dst, Thread->Viewport->viewpoint.Pos.XY()))
 			return;
 
 		vertex_t *v1 = line->linedef->v1;

--- a/src/swrenderer/line/r_renderdrawsegment.cpp
+++ b/src/swrenderer/line/r_renderdrawsegment.cpp
@@ -106,7 +106,7 @@ namespace swrenderer
 		CameraLight *cameraLight = CameraLight::Instance();
 		if (cameraLight->FixedLightLevel() < 0)
 		{
-			double clipTop = m3DFloor.clipTop ? m3DFloor.sclipTop : sec->ceilingplane.ZatPoint(Thread->Viewport->viewpoint.Pos);
+			double clipTop = m3DFloor.clipTop ? m3DFloor.sclipTop : sec->ceilingplane.ZatPoint(Thread->Viewport->viewpoint.Pos.XY());
 			for (int i = frontsector->e->XFloor.lightlist.Size() - 1; i >= 0; i--)
 			{
 				if (clipTop <= frontsector->e->XFloor.lightlist[i].plane.Zat0())

--- a/src/swrenderer/plane/r_slopeplane.cpp
+++ b/src/swrenderer/plane/r_slopeplane.cpp
@@ -102,7 +102,7 @@ namespace swrenderer
 		lyscale = _yscale * ifloatpow2[drawerargs.TextureHeightBits()];
 		xscale = 64.f / lxscale;
 		yscale = 64.f / lyscale;
-		zeroheight = pl->height.ZatPoint(Thread->Viewport->viewpoint.Pos);
+		zeroheight = pl->height.ZatPoint(Thread->Viewport->viewpoint.Pos.XY());
 
 		pviewx = xs_ToFixed(32 - drawerargs.TextureWidthBits(), pl->xform.xOffs * pl->xform.xScale);
 		pviewy = xs_ToFixed(32 - drawerargs.TextureHeightBits(), pl->xform.yOffs * pl->xform.yScale);
@@ -173,7 +173,7 @@ namespace swrenderer
 		basecolormap = colormap;
 		bool foggy = level.fadeto || basecolormap->Fade || (level.flags & LEVEL_HASFADETABLE);;
 
-		planelightfloat = (Thread->Light->SlopePlaneGlobVis(foggy) * lxscale * lyscale) / (fabs(pl->height.ZatPoint(Thread->Viewport->viewpoint.Pos) - Thread->Viewport->viewpoint.Pos.Z)) / 65536.f;
+		planelightfloat = (Thread->Light->SlopePlaneGlobVis(foggy) * lxscale * lyscale) / (fabs(pl->height.ZatPoint(Thread->Viewport->viewpoint.Pos.XY()) - Thread->Viewport->viewpoint.Pos.Z)) / 65536.f;
 
 		if (pl->height.fC() > 0)
 			planelightfloat = -planelightfloat;

--- a/src/swrenderer/scene/r_3dfloors.cpp
+++ b/src/swrenderer/scene/r_3dfloors.cpp
@@ -94,7 +94,7 @@ namespace swrenderer
 		HeightLevel *near;
 		HeightLevel *curr;
 
-		double height = add->ZatPoint(Thread->Viewport->viewpoint.Pos);
+		double height = add->ZatPoint(Thread->Viewport->viewpoint.Pos.XY());
 		if (height >= sec->CenterCeiling()) return;
 		if (height <= sec->CenterFloor()) return;
 

--- a/src/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/swrenderer/scene/r_opaque_pass.cpp
@@ -213,8 +213,8 @@ namespace swrenderer
 				}
 			}
 
-			double refceilz = s->ceilingplane.ZatPoint(Thread->Viewport->viewpoint.Pos);
-			double orgceilz = sec->ceilingplane.ZatPoint(Thread->Viewport->viewpoint.Pos);
+			double refceilz = s->ceilingplane.ZatPoint(Thread->Viewport->viewpoint.Pos.XY());
+			double orgceilz = sec->ceilingplane.ZatPoint(Thread->Viewport->viewpoint.Pos.XY());
 
 #if 1
 			// [RH] Allow viewing underwater areas through doors/windows that
@@ -857,7 +857,7 @@ namespace swrenderer
 			node_t *bsp = (node_t *)node;
 
 			// Decide which side the view point is on.
-			int side = R_PointOnSide(Thread->Viewport->viewpoint.Pos, bsp);
+			int side = R_PointOnSide(Thread->Viewport->viewpoint.Pos.XY(), bsp);
 
 			// Recursively divide front space (toward the viewer).
 			RenderBSPNode(bsp->children[side]);
@@ -993,7 +993,7 @@ namespace swrenderer
 		// [ZZ] Or less definitely not visible (hue)
 		// [ZZ] 10.01.2016: don't try to clip stuff inside a skybox against the current portal.
 		RenderPortal *renderportal = Thread->Portal.get();
-		if (!renderportal->CurrentPortalInSkybox && renderportal->CurrentPortal && !!P_PointOnLineSidePrecise(thing->Pos(), renderportal->CurrentPortal->dst))
+		if (!renderportal->CurrentPortalInSkybox && renderportal->CurrentPortal && !!P_PointOnLineSidePrecise(thing->Pos().XY(), renderportal->CurrentPortal->dst))
 			return false;
 
 		double distanceSquared = (thing->Pos() - Thread->Viewport->viewpoint.Pos).LengthSquared();

--- a/src/swrenderer/scene/r_portal.cpp
+++ b/src/swrenderer/scene/r_portal.cpp
@@ -386,7 +386,7 @@ namespace swrenderer
 			P_TranslatePortalXY(pds->src, viewpoint.Path[0].X, viewpoint.Path[0].Y);
 			P_TranslatePortalXY(pds->src, viewpoint.Path[1].X, viewpoint.Path[1].Y);
 
-			if (!viewpoint.showviewer && viewpoint.camera && P_PointOnLineSidePrecise(viewpoint.Path[0], pds->dst) != P_PointOnLineSidePrecise(viewpoint.Path[1], pds->dst))
+			if (!viewpoint.showviewer && viewpoint.camera && P_PointOnLineSidePrecise(viewpoint.Path[0].XY(), pds->dst) != P_PointOnLineSidePrecise(viewpoint.Path[1].XY(), pds->dst))
 			{
 				double distp = (viewpoint.Path[0] - viewpoint.Path[1]).Length();
 				if (distp > EQUAL_EPSILON)

--- a/src/swrenderer/things/r_decal.cpp
+++ b/src/swrenderer/things/r_decal.cpp
@@ -153,8 +153,8 @@ namespace swrenderer
 		DVector2 angvec = (curline->v2->fPos() - curline->v1->fPos()).Unit();
 		float maskedScaleY;
 
-		decal_left = decal_pos - edge_left * angvec - thread->Viewport->viewpoint.Pos;
-		decal_right = decal_pos + edge_right * angvec - thread->Viewport->viewpoint.Pos;
+		decal_left = decal_pos - edge_left * angvec - thread->Viewport->viewpoint.Pos.XY();
+		decal_right = decal_pos + edge_right * angvec - thread->Viewport->viewpoint.Pos.XY();
 
 		CameraLight *cameraLight;
 		double texturemid;

--- a/src/swrenderer/things/r_particle.cpp
+++ b/src/swrenderer/things/r_particle.cpp
@@ -89,7 +89,7 @@ namespace swrenderer
 		RenderPortal *renderportal = thread->Portal.get();
 
 		// [ZZ] Particle not visible through the portal plane
-		if (renderportal->CurrentPortal && !!P_PointOnLineSide(particle->Pos, renderportal->CurrentPortal->dst))
+		if (renderportal->CurrentPortal && !!P_PointOnLineSide(particle->Pos.XY(), renderportal->CurrentPortal->dst))
 			return;
 
 		// transform the origin point
@@ -192,9 +192,9 @@ namespace swrenderer
 			map = GetColorTable(sector->Colormap, sector->SpecialColors[sector_t::sprites], true);
 		}
 
-		if (botpic != skyflatnum && ippz < botplane->ZatPoint(particle->Pos))
+		if (botpic != skyflatnum && ippz < botplane->ZatPoint(particle->Pos.XY()))
 			return;
-		if (toppic != skyflatnum && ippz >= topplane->ZatPoint(particle->Pos))
+		if (toppic != skyflatnum && ippz >= topplane->ZatPoint(particle->Pos.XY()))
 			return;
 
 		// store information in a vissprite

--- a/src/swrenderer/things/r_sprite.cpp
+++ b/src/swrenderer/things/r_sprite.cpp
@@ -116,19 +116,19 @@ namespace swrenderer
 		{
 			if (fakeside == WaterFakeSide::AboveCeiling)
 			{
-				if (gzt < heightsec->ceilingplane.ZatPoint(pos))
+				if (gzt < heightsec->ceilingplane.ZatPoint(pos.XY()))
 					return;
 			}
 			else if (fakeside == WaterFakeSide::BelowFloor)
 			{
-				if (gzb >= heightsec->floorplane.ZatPoint(pos))
+				if (gzb >= heightsec->floorplane.ZatPoint(pos.XY()))
 					return;
 			}
 			else
 			{
-				if (gzt < heightsec->floorplane.ZatPoint(pos))
+				if (gzt < heightsec->floorplane.ZatPoint(pos.XY()))
 					return;
-				if (!(heightsec->MoreFlags & SECMF_FAKEFLOORONLY) && gzb >= heightsec->ceilingplane.ZatPoint(pos))
+				if (!(heightsec->MoreFlags & SECMF_FAKEFLOORONLY) && gzb >= heightsec->ceilingplane.ZatPoint(pos.XY()))
 					return;
 			}
 		}

--- a/src/swrenderer/things/r_visiblesprite.cpp
+++ b/src/swrenderer/things/r_visiblesprite.cpp
@@ -120,7 +120,7 @@ namespace swrenderer
 			if (clip3DFloor.clipTop)
 				clipTop = clip3DFloor.clipTop;
 			else
-				clipTop = spr->sector->ceilingplane.ZatPoint(thread->Viewport->viewpoint.Pos);
+				clipTop = spr->sector->ceilingplane.ZatPoint(thread->Viewport->viewpoint.Pos.XY());
 
 			sector_t *sec = nullptr;
 			FDynamicColormap *mybasecolormap = nullptr;
@@ -193,7 +193,7 @@ namespace swrenderer
 		{ // only things in specially marked sectors
 			if (spr->FakeFlatStat != WaterFakeSide::AboveCeiling)
 			{
-				double hz = spr->heightsec->floorplane.ZatPoint(spr->gpos);
+				double hz = spr->heightsec->floorplane.ZatPoint(spr->gpos.XY());
 				int h = xs_RoundToInt(viewport->CenterY - (hz - viewport->viewpoint.Pos.Z) * scale);
 
 				if (spr->FakeFlatStat == WaterFakeSide::BelowFloor)
@@ -215,7 +215,7 @@ namespace swrenderer
 			}
 			if (spr->FakeFlatStat != WaterFakeSide::BelowFloor && !(spr->heightsec->MoreFlags & SECMF_FAKEFLOORONLY))
 			{
-				double hz = spr->heightsec->ceilingplane.ZatPoint(spr->gpos);
+				double hz = spr->heightsec->ceilingplane.ZatPoint(spr->gpos.XY());
 				int h = xs_RoundToInt(viewport->CenterY - (hz - viewport->viewpoint.Pos.Z) * scale);
 
 				if (spr->FakeFlatStat == WaterFakeSide::AboveCeiling)

--- a/src/swrenderer/things/r_visiblespritelist.cpp
+++ b/src/swrenderer/things/r_visiblespritelist.cpp
@@ -127,8 +127,8 @@ namespace swrenderer
 		{
 			node_t *bsp = (node_t *)node;
 
-			DVector2 planePos(FIXED2DBL(bsp->x), FIXED2DBL(bsp->y));
-			DVector2 planeNormal = DVector2(FIXED2DBL(-bsp->dy), FIXED2DBL(bsp->dx));
+			DVector2 planePos{FIXED2DBL(bsp->x), FIXED2DBL(bsp->y)};
+			DVector2 planeNormal{FIXED2DBL(-bsp->dy), FIXED2DBL(bsp->dx)};
 			double planeD = planeNormal | planePos;
 
 			int side = (worldPos | planeNormal) > planeD;

--- a/src/swrenderer/things/r_voxel.cpp
+++ b/src/swrenderer/things/r_voxel.cpp
@@ -101,19 +101,19 @@ namespace swrenderer
 		{
 			if (fakeside == WaterFakeSide::AboveCeiling)
 			{
-				if (gzt < heightsec->ceilingplane.ZatPoint(pos))
+				if (gzt < heightsec->ceilingplane.ZatPoint(pos.XY()))
 					return;
 			}
 			else if (fakeside == WaterFakeSide::BelowFloor)
 			{
-				if (gzb >= heightsec->floorplane.ZatPoint(pos))
+				if (gzb >= heightsec->floorplane.ZatPoint(pos.XY()))
 					return;
 			}
 			else
 			{
-				if (gzt < heightsec->floorplane.ZatPoint(pos))
+				if (gzt < heightsec->floorplane.ZatPoint(pos.XY()))
 					return;
-				if (!(heightsec->MoreFlags & SECMF_FAKEFLOORONLY) && gzb >= heightsec->ceilingplane.ZatPoint(pos))
+				if (!(heightsec->MoreFlags & SECMF_FAKEFLOORONLY) && gzb >= heightsec->ceilingplane.ZatPoint(pos.XY()))
 					return;
 			}
 		}

--- a/src/tarray.h
+++ b/src/tarray.h
@@ -134,8 +134,8 @@ public:
 	{
 		return &Array[Count];
 	}
-	
-	
+
+
 
 	////////
 	// This is a dummy constructor that does nothing. The purpose of this
@@ -302,7 +302,9 @@ public:
 			Array[index].~T();
 			if (index < --Count)
 			{
-				memmove (&Array[index], &Array[index+1], sizeof(T)*(Count - index));
+                for (auto i = index; i < Count; ++i) {
+                    Array[i] = Array[i+1];
+                }
 			}
 		}
 	}
@@ -322,7 +324,9 @@ public:
 			Count -= deletecount;
 			if (index < Count)
 			{
-				memmove (&Array[index], &Array[index+deletecount], sizeof(T)*(Count - index));
+                for (auto i = index; i < Count; ++i) {
+                    Array[i] = Array[i+deletecount];
+                }
 			}
 		}
 	}
@@ -344,7 +348,9 @@ public:
 			Resize (Count + 1);
 
 			// Now move items from the index and onward out of the way
-			memmove (&Array[index+1], &Array[index], sizeof(T)*(Count - index - 1));
+            for (auto i = index; i < Count - 1; ++i) {
+                Array[i + 1] = Array[i];
+            }
 
 			// And put the new element in
 			::new ((void *)&Array[index]) T(item);
@@ -498,7 +504,7 @@ public:
 	{
 		for (unsigned int i = 0; i < TArray<T,TT>::Size(); ++i)
 		{
-			if ((*this)[i] != NULL) 
+			if ((*this)[i] != NULL)
 				delete (*this)[i];
 		}
 	}
@@ -506,7 +512,7 @@ public:
 	{
 		for (unsigned int i = 0; i < TArray<T,TT>::Size(); ++i)
 		{
-			if ((*this)[i] != NULL) 
+			if ((*this)[i] != NULL)
 				delete (*this)[i];
 		}
 		this->Clear();
@@ -991,11 +997,11 @@ protected:
 	}
 
 	/*
-	** Inserts a new key into a hash table; first, check whether key's main 
-	** position is free. If not, check whether colliding node is in its main 
-	** position or not: if it is not, move colliding node to an empty place and 
-	** put new key in its main position; otherwise (colliding node is in its main 
-	** position), new key goes to an empty position. 
+	** Inserts a new key into a hash table; first, check whether key's main
+	** position is free. If not, check whether colliding node is in its main
+	** position or not: if it is not, move colliding node to an empty place and
+	** put new key in its main position; otherwise (colliding node is in its main
+	** position), new key goes to an empty position.
 	**
 	** The Value field is left unconstructed.
 	*/

--- a/src/textures/texture.cpp
+++ b/src/textures/texture.cpp
@@ -178,7 +178,7 @@ FTexture * FTexture::CreateTexture (const char *name, int lumpnum, ETextureType 
 
 FTexture::FTexture (const char *name, int lumpnum)
 	: 
-  WidthBits(0), HeightBits(0), Scale(1,1), SourceLump(lumpnum),
+  WidthBits(0), HeightBits(0), Scale({1,1}), SourceLump(lumpnum),
   UseType(ETextureType::Any), bNoDecals(false), bNoRemap0(false), bWorldPanning(false),
   bMasked(true), bAlphaTexture(false), bHasCanvas(false), bWarped(0), bComplex(false), bMultiPatch(false), bKeepAround(false), bFullNameTexture(false),
 	Rotations(0xFFFF), SkyOffset(0), Width(0), Height(0), WidthMask(0)

--- a/src/textures/texturemanager.cpp
+++ b/src/textures/texturemanager.cpp
@@ -1442,9 +1442,11 @@ DEFINE_ACTION_FUNCTION(_TexMan, GetScaledSize)
 	auto tex = TexMan.ByIndex(texid);
 	if (tex != nullptr)
 	{
-		ACTION_RETURN_VEC2(DVector2(tex->GetScaledWidthDouble(), tex->GetScaledHeightDouble()));
+        auto dv = DVector2{tex->GetScaledWidthDouble(), tex->GetScaledHeightDouble()};
+		ACTION_RETURN_VEC2(dv);
 	}
-	ACTION_RETURN_VEC2(DVector2(-1, -1));
+    auto dv = DVector2{-1, -1};
+	ACTION_RETURN_VEC2(dv);
 }
 
 //==========================================================================
@@ -1460,9 +1462,11 @@ DEFINE_ACTION_FUNCTION(_TexMan, GetScaledOffset)
 	auto tex = TexMan.ByIndex(texid);
 	if (tex != nullptr)
 	{
-		ACTION_RETURN_VEC2(DVector2(tex->GetScaledLeftOffsetDouble(0), tex->GetScaledTopOffsetDouble(0)));
+        auto dv = DVector2{tex->GetScaledLeftOffsetDouble(0), tex->GetScaledTopOffsetDouble(0)};
+		ACTION_RETURN_VEC2(dv);
 	}
-	ACTION_RETURN_VEC2(DVector2(-1, -1));
+    auto dv = DVector2{-1, -1};
+	ACTION_RETURN_VEC2(dv);
 }
 
 //==========================================================================

--- a/src/v_2ddrawer.cpp
+++ b/src/v_2ddrawer.cpp
@@ -52,7 +52,7 @@ DEFINE_ACTION_FUNCTION(DShape2D, PushVertex)
 	PARAM_SELF_PROLOGUE(DShape2D);
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
-	self->mVertices.Push(DVector2(x,y));
+	self->mVertices.Push(DVector2{x,y});
 	return 0;
 }
 
@@ -61,7 +61,7 @@ DEFINE_ACTION_FUNCTION(DShape2D, PushCoord)
 	PARAM_SELF_PROLOGUE(DShape2D);
 	PARAM_FLOAT(u);
 	PARAM_FLOAT(v);
-	self->mCoords.Push(DVector2(u,v));
+	self->mCoords.Push(DVector2{u,v});
 	return 0;
 }
 

--- a/src/v_draw.cpp
+++ b/src/v_draw.cpp
@@ -991,8 +991,8 @@ DEFINE_ACTION_FUNCTION(_Screen, VirtualToRealCoords)
 	PARAM_BOOL_DEF(vbottom);
 	PARAM_BOOL_DEF(handleaspect);
 	screen->VirtualToRealCoords(x, y, w, h, vw, vh, vbottom, handleaspect);
-	if (numret >= 1) ret[0].SetVector2(DVector2(x, y));
-	if (numret >= 2) ret[1].SetVector2(DVector2(w, h));
+	if (numret >= 1) ret[0].SetVector2(DVector2{x, y});
+	if (numret >= 2) ret[1].SetVector2(DVector2{w, h});
 	return MIN(numret, 2);
 }
 
@@ -1407,9 +1407,9 @@ void DFrameBuffer::DrawBlend(sector_t * viewsector)
 			{
 				double lightbottom;
 				if (i < lightlist.Size() - 1)
-					lightbottom = lightlist[i + 1].plane.ZatPoint(vpp);
+					lightbottom = lightlist[i + 1].plane.ZatPoint(vpp.XY());
 				else
-					lightbottom = viewsector->floorplane.ZatPoint(vpp);
+					lightbottom = viewsector->floorplane.ZatPoint(vpp.XY());
 
 				if (lightbottom < vpp.Z && (!lightlist[i].caster || !(lightlist[i].caster->flags&FF_FADEWALLS)))
 				{

--- a/src/vectors.h
+++ b/src/vectors.h
@@ -66,9 +66,7 @@ struct TVector2
 {
 	vec_t X, Y;
 
-	TVector2 ()
-	{
-	}
+	TVector2 () = default;
 
 	TVector2 (vec_t a, vec_t b)
 		: X(a), Y(b)
@@ -317,9 +315,7 @@ struct TVector3
 
 	vec_t X, Y, Z;
 
-	TVector3 ()
-	{
-	}
+	TVector3 () = default;
 
 	TVector3 (vec_t a, vec_t b, vec_t c)
 		: X(a), Y(b), Z(c)
@@ -662,9 +658,7 @@ struct TVector4
 
 	vec_t X, Y, Z, W;
 
-	TVector4()
-	{
-	}
+	TVector4() = default;
 
 	TVector4(vec_t a, vec_t b, vec_t c, vec_t d)
 		: X(a), Y(b), Z(c), W(d)
@@ -939,9 +933,7 @@ struct TMatrix3x3
 
 	vec_t Cells[3][3];
 
-	TMatrix3x3()
-	{
-	}
+	TMatrix3x3() = default;
 
 	TMatrix3x3(const TMatrix3x3 &other)
 	{
@@ -1151,9 +1143,7 @@ struct TAngle
 	TAngle &operator= (long other) = delete;
 	TAngle &operator= (unsigned long other) = delete;
 
-	TAngle ()
-	{
-	}
+	TAngle () = default;
 
 	TAngle (vec_t amt)
 		: Degrees(amt)
@@ -1491,9 +1481,7 @@ struct TRotator
 	Angle Roll;		// rotation about the forward axis.
 	Angle CamRoll;	// Roll specific to actor cameras. Used by quakes.
 
-	TRotator ()
-	{
-	}
+	TRotator () = default;
 
 	TRotator (const Angle &p, const Angle &y, const Angle &r)
 		: Pitch(p), Yaw(y), Roll(r)

--- a/src/vectors.h
+++ b/src/vectors.h
@@ -80,18 +80,7 @@ struct TVector2
 		return X == 0 && Y == 0;
 	}
 
-	TVector2 &operator= (const TVector2 &other)
-	{
-		// This might seem backwards, but this helps produce smaller code when a newly
-		// created vector is assigned, because the components can just be popped off
-		// the FPU stack in order without the need for fxch. For platforms with a
-		// more sensible registered-based FPU, of course, the order doesn't matter.
-		// (And, yes, I know fxch can improve performance in the right circumstances,
-		// but this isn't one of those times. Here, it's little more than a no-op that
-		// makes the exe 2 bytes larger whenever you assign one vector to another.)
-		Y = other.Y, X = other.X;
-		return *this;
-	}
+	TVector2 &operator= (const TVector2 &other) = default;
 
 	// Access X and Y as an array
 	vec_t &operator[] (int index)
@@ -314,10 +303,7 @@ struct TVector3
 	{
 	}
 
-	TVector3 (const TVector3 &other)
-		: X(other.X), Y(other.Y), Z(other.Z)
-	{
-	}
+	TVector3 (const TVector3 &other) = default;
 
 	TVector3 (const Vector2 &xy, vec_t z)
 		: X(xy.X), Y(xy.Y), Z(z)
@@ -336,11 +322,7 @@ struct TVector3
 		return X == 0 && Y == 0 && Z == 0;
 	}
 
-	TVector3 &operator= (const TVector3 &other)
-	{
-		Z = other.Z, Y = other.Y, X = other.X;
-		return *this;
-	}
+	TVector3 &operator= (const TVector3 &other) = default;
 
 	// Access X and Y and Z as an array
 	vec_t &operator[] (int index)

--- a/src/vectors.h
+++ b/src/vectors.h
@@ -68,20 +68,7 @@ struct TVector2
 
 	TVector2 () = default;
 
-	TVector2 (vec_t a, vec_t b)
-		: X(a), Y(b)
-	{
-	}
-
-	TVector2 (const TVector2 &other)
-		: X(other.X), Y(other.Y)
-	{
-	}
-
-	TVector2 (const TVector3<vec_t> &other)	// Copy the X and Y from the 3D vector and discard the Z
-		: X(other.X), Y(other.Y)
-	{
-	}
+	TVector2 (const TVector2 &other) = default;
 
 	void Zero()
 	{
@@ -144,7 +131,7 @@ struct TVector2
 	// Unary negation
 	TVector2 operator- () const
 	{
-		return TVector2(-X, -Y);
+		return TVector2{-X, -Y};
 	}
 
 	// Scalar addition
@@ -156,12 +143,12 @@ struct TVector2
 
 	friend TVector2 operator+ (const TVector2 &v, vec_t scalar)
 	{
-		return TVector2(v.X + scalar, v.Y + scalar);
+		return TVector2{v.X + scalar, v.Y + scalar};
 	}
 
 	friend TVector2 operator+ (vec_t scalar, const TVector2 &v)
 	{
-		return TVector2(v.X + scalar, v.Y + scalar);
+		return TVector2{v.X + scalar, v.Y + scalar};
 	}
 
 	// Scalar subtraction
@@ -173,7 +160,7 @@ struct TVector2
 
 	TVector2 operator- (vec_t scalar) const
 	{
-		return TVector2(X - scalar, Y - scalar);
+		return TVector2{X - scalar, Y - scalar};
 	}
 
 	// Scalar multiplication
@@ -185,12 +172,12 @@ struct TVector2
 
 	friend TVector2 operator* (const TVector2 &v, vec_t scalar)
 	{
-		return TVector2(v.X * scalar, v.Y * scalar);
+		return TVector2{v.X * scalar, v.Y * scalar};
 	}
 
 	friend TVector2 operator* (vec_t scalar, const TVector2 &v)
 	{
-		return TVector2(v.X * scalar, v.Y * scalar);
+		return TVector2{v.X * scalar, v.Y * scalar};
 	}
 
 	// Scalar division
@@ -203,7 +190,7 @@ struct TVector2
 	TVector2 operator/ (vec_t scalar) const
 	{
 		scalar = 1 / scalar;
-		return TVector2(X * scalar, Y * scalar);
+		return TVector2{X * scalar, Y * scalar};
 	}
 
 	// Vector addition
@@ -215,7 +202,7 @@ struct TVector2
 
 	TVector2 operator+ (const TVector2 &other) const
 	{
-		return TVector2(X + other.X, Y + other.Y);
+		return TVector2{X + other.X, Y + other.Y};
 	}
 
 	// Vector subtraction
@@ -227,7 +214,7 @@ struct TVector2
 
 	TVector2 operator- (const TVector2 &other) const
 	{
-		return TVector2(X - other.X, Y - other.Y);
+		return TVector2{X - other.X, Y - other.Y};
 	}
 
 	// Vector length
@@ -283,7 +270,7 @@ struct TVector2
 	{
 		double cosval = g_cosdeg (angle);
 		double sinval = g_sindeg (angle);
-		return TVector2(X*cosval - Y*sinval, Y*cosval + X*sinval);
+		return TVector2{X*cosval - Y*sinval, Y*cosval + X*sinval};
 	}
 
 	// Returns a rotated vector. angle is in degrees.
@@ -292,19 +279,19 @@ struct TVector2
 	{
 		double cosval = angle.Cos();
 		double sinval = angle.Sin();
-		return TVector2(X*cosval - Y*sinval, Y*cosval + X*sinval);
+		return TVector2{X*cosval - Y*sinval, Y*cosval + X*sinval};
 	}
 
 	// Returns a vector rotated 90 degrees clockwise.
 	TVector2 Rotated90CW()
 	{
-		return TVector2(Y, -X);
+		return TVector2{Y, -X};
 	}
 
 	// Returns a vector rotated 90 degrees counterclockwise.
 	TVector2 Rotated90CCW()
 	{
-		return TVector2(-Y, X);
+		return TVector2{-Y, X};
 	}
 };
 
@@ -512,14 +499,14 @@ struct TVector3
 
 	friend Vector2 operator+ (const Vector2 &v2, const TVector3 &v3)
 	{
-		return Vector2(v2.X + v3.X, v2.Y + v3.Y);
+		return Vector2{v2.X + v3.X, v2.Y + v3.Y};
 	}
 
 	// Subtract a 3D vector and a 2D vector.
 	// Discards the Z component of the 3D vector and returns a 2D vector.
 	friend Vector2 operator- (const TVector2<vec_t> &v2, const TVector3 &v3)
 	{
-		return Vector2(v2.X - v3.X, v2.Y - v3.Y);
+		return Vector2{v2.X - v3.X, v2.Y - v3.Y};
 	}
 
 	void GetRightUp(TVector3 &right, TVector3 &up)
@@ -1362,7 +1349,7 @@ struct TAngle
 
 	TVector2<vec_t> ToVector(vec_t length = 1) const
 	{
-		return TVector2<vec_t>(length * Cos(), length * Sin());
+		return TVector2<vec_t>{length * Cos(), length * Sin()};
 	}
 
 	vec_t Cos() const
@@ -1467,7 +1454,7 @@ TAngle<T> TVector3<T>::Angle() const
 template<class T>
 TAngle<T> TVector3<T>::Pitch() const
 {
-	return VecToAngle(TVector2<T>(X, Y).Length(), Z);
+	return VecToAngle(TVector2<T>{X, Y}.Length(), Z);
 }
 
 // Much of this is copied from TVector3. Is all that functionality really appropriate?
@@ -1660,7 +1647,6 @@ typedef TVector4<double>		DVector4;
 typedef TRotator<double>		DRotator;
 typedef TMatrix3x3<double>		DMatrix3x3;
 typedef TAngle<double>			DAngle;
-
 
 class Plane
 {

--- a/src/zstring.h
+++ b/src/zstring.h
@@ -454,7 +454,6 @@ namespace StringFormat
 inline FName::FName(const FString &text) { Index = NameData.FindName (text.GetChars(), text.Len(), false); }
 inline FName::FName(const FString &text, bool noCreate) { Index = NameData.FindName (text.GetChars(), text.Len(), noCreate); }
 inline FName &FName::operator = (const FString &text) { Index = NameData.FindName (text.GetChars(), text.Len(), false); return *this; }
-inline FName &FNameNoInit::operator = (const FString &text) { Index = NameData.FindName (text.GetChars(), text.Len(), false); return *this; }
 
 // Hash FStrings on their contents. (used by TMap)
 extern unsigned int SuperFastHash (const char *data, size_t len);


### PR DESCRIPTION
Many of the warnings generated during build represent Undefined Behaviour.
The key culprits are doing a memcpy/memset on a non-trivial class.
As such, this is a key point of errors, since compilers assume UB cannot occur.

I've attempted to either make classes trivial, or replace the offending calls to a standard compliant equivalent.

This is done through explicitly defaulting constructors, turning TVec2 into a trivial class, and other small tweaks.

Not all of the undefined behaviour related warning have been squashed by this PR, but a large number of them have.

Warnings were found and corrected using GCC 8.2.0.