### PR TITLE
HITOWNER fixup

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -1539,7 +1539,7 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 		// MBF bouncer might have a non-0 damage value, but they must not deal damage on impact either.
 		if ((tm.thing->BounceFlags & BOUNCE_Actors) && (tm.thing->IsZeroDamage() || !(tm.thing->flags & MF_MISSILE)))
 		{
-			return (tm.thing->target == thing || !(thing->flags & MF_SOLID));
+			return ((tm.thing->target == thing && !(tm.thing->flags8 & MF8_HITOWNER)) || !(thing->flags & MF_SOLID));
 		}
 
 		switch (tm.thing->SpecialMissileHit(thing))


### PR DESCRIPTION
Forgot to add a check for HITOWNER on bouncers with 0 damage. I have no idea how I missed it, it's like 15 lines up.