### PR TITLE
Fix crash without persistent mapped buffers

### DIFF
--- a/src/gl/data/gl_viewpointbuffer.cpp
+++ b/src/gl/data/gl_viewpointbuffer.cpp
@@ -119,8 +119,12 @@ int GLViewpointBuffer::Bind(unsigned int index)
 		glBindBufferRange(GL_UNIFORM_BUFFER, VIEWPOINT_BINDINGPOINT, mBufferId, index * mBlockAlign, mBlockAlign);
 
 		// Update the viewpoint-related clip plane setting.
+		Map();
 		auto *vp = (HWViewpointUniforms*)(((char*)mBufferPointer) + mUploadIndex * mBlockAlign);
-		if (index > 0 && (vp->mClipHeightDirection != 0.f || vp->mClipLine.X > -10000000.0f))
+		const bool enableClip = index > 0 && (vp->mClipHeightDirection != 0.f || vp->mClipLine.X > -10000000.0f);
+		Unmap();
+
+		if (enableClip)
 		{
 			glEnable(GL_CLIP_DISTANCE0);
 		}


### PR DESCRIPTION
Now it works on macOS too.