### PR TITLE
Avoid overriding vr eye-specific buffer binding during 2D rendering.

### DIFF
--- a/src/gl/renderer/gl_renderer.cpp
+++ b/src/gl/renderer/gl_renderer.cpp
@@ -50,6 +50,7 @@
 #include "gl/renderer/gl_renderbuffers.h"
 #include "gl/data/gl_vertexbuffer.h"
 #include "gl/scene/gl_drawinfo.h"
+#include "hwrenderer/utility/hw_vrmodes.h"
 #include "hwrenderer/postprocessing/hw_presentshader.h"
 #include "hwrenderer/postprocessing/hw_present3dRowshader.h"
 #include "hwrenderer/postprocessing/hw_shadowmapshader.h"
@@ -422,7 +423,8 @@ void FGLRenderer::Draw2D(F2DDrawer *drawer)
 {
 	twoD.Clock();
 	FGLDebug::PushGroup("Draw2D");
-	mBuffers->BindCurrentFB();
+	if (VRMode::GetVRMode(true)->mEyeCount == 1)
+		mBuffers->BindCurrentFB();
 	const auto &mScreenViewport = screen->mScreenViewport;
 	glViewport(mScreenViewport.left, mScreenViewport.top, mScreenViewport.width, mScreenViewport.height);
 


### PR DESCRIPTION
Fixes an issue introduced in gzdoom between releases 3.3.2 and 3.4.0. Menus and other 2D graphics were not being shown in most stereo 3D modes. The problem is related to management of which frame buffer is bound at the time when 2D graphics are drawn.