### PR TITLE
Improve SDL_GetWindowBordersSize() pointer loading

### DIFF
--- a/src/posix/sdl/gl_sysfb.h
+++ b/src/posix/sdl/gl_sysfb.h
@@ -52,11 +52,7 @@ protected:
 
 	static const int MIN_WIDTH = 320;
 	static const int MIN_HEIGHT = 200;
-
-	typedef DECLSPEC int SDLCALL (*SDL_GetWindowBordersSizePtr)(SDL_Window *, int *, int *, int *, int *);
-
-	SDL_GetWindowBordersSizePtr SDL_GetWindowBordersSize_;
-	void *sdl_lib;
 };
 
 #endif // __POSIX_SDL_GL_SYSFB_H__
+


### PR DESCRIPTION
Proposed fix for https://forum.zdoom.org/viewtopic.php?t=61913

I have a limited ability to test it on different distros.
@OrdinaryMagician, could you please check if it works for you?