### PR TITLE
Adds OnDrop virtual to inventory items.

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1158,6 +1158,14 @@ AInventory *AActor::DropInventory (AInventory *item, int amt)
 	drop->Vel += Vel;
 	drop->flags &= ~MF_NOGRAVITY;	// Don't float
 	drop->ClearCounters();	// do not count for statistics again
+	{
+		// [MK] call OnDrop so item can change its drop behaviour
+		IFVIRTUALPTR(drop, AInventory, OnDrop)
+		{
+			VMValue params[] = { drop, this };
+			VMCall(func, params, 2, nullptr, 0);
+		}
+	}
 	return drop;
 }
 

--- a/wadsrc/static/zscript/inventory/inventory.txt
+++ b/wadsrc/static/zscript/inventory/inventory.txt
@@ -906,7 +906,17 @@ class Inventory : Actor native
 		return item;
 	}
 
-	
+
+	//===========================================================================
+	//
+	// AInventory :: OnDrop
+	//
+	// Called by AActor::DropInventory. Allows items to modify how they behave
+	// after being dropped.
+	//
+	//===========================================================================
+
+	virtual void OnDrop (Actor dropper) {}
 }
 
 //===========================================================================


### PR DESCRIPTION
Gets called on the spawned drop at the end of AActor::DropInventory and allows to customize the position/velocity and other parameters. This was mainly added because the spawn position and velocity of dropped items is hardcoded and some of us wanted to change that.

[ondrop_m.zip](https://github.com/coelckers/gzdoom/files/2386629/ondrop_m.zip)
This test defines an example TestItem that gets thrown at missile height with a higher velocity, following the thrower's view angle/pitch, along with playing a sound. Many other things could be done with it but this is just a small test anyway.

PS: The IFVIRTUALPTR had to be shoved into its own scope block since otherwise the code wouldn't compile (errors about variable/function redefinitions). I guess since no one had used it twice in the same function before this issue was never noticed.