### PR TITLE
CheckReplacement hotfix

### DIFF
--- a/src/info.cpp
+++ b/src/info.cpp
@@ -438,6 +438,7 @@ PClassActor *PClassActor::GetReplacement(bool lookskill)
 	}
 	// The Replacement field is temporarily NULLed to prevent
 	// potential infinite recursion.
+	PClassActor *oldrep = ActorInfo()->Replacement;
 	ActorInfo()->Replacement = nullptr;
 	PClassActor *rep = Replacement;
 	// Handle skill-based replacement here. It has precedence on DECORATE replacement
@@ -451,7 +452,7 @@ PClassActor *PClassActor::GetReplacement(bool lookskill)
 	// Skill replacements are not recursive, contrarily to DECORATE replacements
 	rep = rep->GetReplacement(false);
 	// Reset the temporarily NULLed field
-	ActorInfo()->Replacement = Replacement;
+	ActorInfo()->Replacement = oldrep;
 	return rep;
 }
 


### PR DESCRIPTION
Small fix for the issue reported in [this thread](https://forum.zdoom.org/viewtopic.php?f=2&t=62100).

CheckReplacement was permanently changing class replacements by mistake.