### PR TITLE
VelIntercept

### DIFF
--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -683,6 +683,7 @@ class Actor : Thinker native
 	native clearscope vector2 Vec2Angle(double length, double angle, bool absolute = false) const;
 	native clearscope vector2 Vec2Offset(double x, double y, bool absolute = false) const;
 	native clearscope vector3 Vec2OffsetZ(double x, double y, double atz, bool absolute = false) const;
+	native void VelIntercept(Actor targ, double speed = -1, bool aimpitch = true, bool oldvel = false);
 	native void VelFromAngle(double speed = 0, double angle = 0);
 	native void Vel3DFromAngle(double speed, double angle, double pitch);
 	native void Thrust(double speed = 0, double angle = 0);


### PR DESCRIPTION
- Uses the same code as Thing_ProjectileIntercept to aim and move the projectile.
  - targ: The actor the caller will aim at.
  - speed: Used for calculating the new angle/pitch and adjusts the speed accordingly. Default is -1 (current speed).
  - aimpitch: If true, aims the pitch in the travelling direction. Default is true.
  - oldvel: If true, does not replace the velocity with the specified speed. Default is false.

- Split the code from Thing_ProjectileIntercept and have that function call VelIntercept.