### PR TITLE
Changed the way alpha works on DrawLine and DrawThickLine so they're consistent

### DIFF
--- a/src/v_2ddrawer.cpp
+++ b/src/v_2ddrawer.cpp
@@ -574,10 +574,10 @@ void F2DDrawer::AddColorOnlyQuad(int x1, int y1, int w, int h, PalEntry color, F
 //
 //==========================================================================
 
-void F2DDrawer::AddLine(int x1, int y1, int x2, int y2, int palcolor, uint32_t color)
+void F2DDrawer::AddLine(int x1, int y1, int x2, int y2, int palcolor, uint32_t color, uint8_t alpha)
 {
 	PalEntry p = color ? (PalEntry)color : GPalette.BaseColors[palcolor];
-	p.a = 255;
+	p.a = alpha;
 
 	RenderCommand dg;
 
@@ -596,9 +596,10 @@ void F2DDrawer::AddLine(int x1, int y1, int x2, int y2, int palcolor, uint32_t c
 //
 //==========================================================================
 
-void F2DDrawer::AddThickLine(int x1, int y1, int x2, int y2, double thickness, uint32_t color)
+void F2DDrawer::AddThickLine(int x1, int y1, int x2, int y2, double thickness, uint32_t color, uint8_t alpha)
 {
 	PalEntry p = (PalEntry)color;
+	p.a = alpha;
 
 	DVector2 point0(x1, y1);
 	DVector2 point1(x2, y2);

--- a/src/v_2ddrawer.h
+++ b/src/v_2ddrawer.h
@@ -149,8 +149,8 @@ public:
 	void AddClear(int left, int top, int right, int bottom, int palcolor, uint32_t color);
 	
 		
-	void AddLine(int x1, int y1, int x2, int y2, int palcolor, uint32_t color);
-	void AddThickLine(int x1, int y1, int x2, int y2, double thickness, uint32_t color);
+	void AddLine(int x1, int y1, int x2, int y2, int palcolor, uint32_t color, uint8_t alpha = 255);
+	void AddThickLine(int x1, int y1, int x2, int y2, double thickness, uint32_t color, uint8_t alpha = 255);
 	void AddPixel(int x1, int y1, int palcolor, uint32_t color);
 
 	void Clear();

--- a/src/v_draw.cpp
+++ b/src/v_draw.cpp
@@ -1075,9 +1075,9 @@ void DFrameBuffer::FillBorder (FTexture *img)
 //
 //==========================================================================
 
-void DFrameBuffer::DrawLine(int x0, int y0, int x1, int y1, int palColor, uint32_t realcolor)
+void DFrameBuffer::DrawLine(int x0, int y0, int x1, int y1, int palColor, uint32_t realcolor, uint8_t alpha)
 {
-	m2DDrawer.AddLine(x0, y0, x1, y1, palColor, realcolor);
+	m2DDrawer.AddLine(x0, y0, x1, y1, palColor, realcolor, alpha);
 }
 
 DEFINE_ACTION_FUNCTION(_Screen, DrawLine)
@@ -1088,13 +1088,14 @@ DEFINE_ACTION_FUNCTION(_Screen, DrawLine)
 	PARAM_INT(x1);
 	PARAM_INT(y1);
 	PARAM_INT(color);
+	PARAM_INT_DEF(alpha);
 	if (!screen->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
-	screen->DrawLine(x0, y0, x1, y1, -1, color);
+	screen->DrawLine(x0, y0, x1, y1, -1, color, alpha);
 	return 0;
 }
 
-void DFrameBuffer::DrawThickLine(int x0, int y0, int x1, int y1, double thickness, uint32_t realcolor) {
-	m2DDrawer.AddThickLine(x0, y0, x1, y1, thickness, realcolor);
+void DFrameBuffer::DrawThickLine(int x0, int y0, int x1, int y1, double thickness, uint32_t realcolor, uint8_t alpha) {
+	m2DDrawer.AddThickLine(x0, y0, x1, y1, thickness, realcolor, alpha);
 }
 
 DEFINE_ACTION_FUNCTION(_Screen, DrawThickLine)
@@ -1106,8 +1107,9 @@ DEFINE_ACTION_FUNCTION(_Screen, DrawThickLine)
 	PARAM_INT(y1);
 	PARAM_FLOAT(thickness);
 	PARAM_INT(color);
+	PARAM_INT_DEF(alpha);
 	if (!screen->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
-	screen->DrawThickLine(x0, y0, x1, y1, thickness, color);
+	screen->DrawThickLine(x0, y0, x1, y1, thickness, color, alpha);
 	return 0;
 }
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -509,10 +509,10 @@ public:
 	void Clear(int left, int top, int right, int bottom, int palcolor, uint32_t color);
 
 	// Draws a line
-	void DrawLine(int x0, int y0, int x1, int y1, int palColor, uint32_t realcolor);
+	void DrawLine(int x0, int y0, int x1, int y1, int palColor, uint32_t realcolor, uint8_t alpha = 255);
 
 	// Draws a line with thickness
-	void DrawThickLine(int x0, int y0, int x1, int y1, double thickness, uint32_t realcolor);
+	void DrawThickLine(int x0, int y0, int x1, int y1, double thickness, uint32_t realcolor, uint8_t alpha = 255);
 
 	// Draws a single pixel
 	void DrawPixel(int x, int y, int palcolor, uint32_t rgbcolor);

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -193,8 +193,8 @@ struct Screen native
 	native static vararg void DrawShape(TextureID tex, bool animate, Shape2D s, ...);
 	native static vararg void DrawChar(Font font, int normalcolor, double x, double y, int character, ...);
 	native static vararg void DrawText(Font font, int normalcolor, double x, double y, String text, ...);
-	native static void DrawLine(int x0, int y0, int x1, int y1, Color color);
-	native static void DrawThickLine(int x0, int y0, int x1, int y1, double thickness, Color color);
+	native static void DrawLine(int x0, int y0, int x1, int y1, Color color, int alpha = 255);
+	native static void DrawThickLine(int x0, int y0, int x1, int y1, double thickness, Color color, int alpha = 255);
 	native static void DrawFrame(int x, int y, int w, int h);
 	native static Vector2, Vector2 VirtualToRealCoords(Vector2 pos, Vector2 size, Vector2 vsize, bool vbottom=false, bool handleaspect=true);
 	native static double GetAspectRatio();


### PR DESCRIPTION
Before, DrawLine had no way to use any alpha other than 255, and DrawThickLine took the alpha from the Color, now it's supplied in an argument. Ideally they'd both take it from the Color but DrawLine is too old to be changed so I figure consistency is better for these very similar functions.