### PR TITLE
Export PlayerPawn.PickNewWeapon to ZScript

### DIFF
--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -1195,6 +1195,12 @@ AWeapon *APlayerPawn::PickNewWeapon(PClassActor *ammotype)
 	return best;
 }
 
+DEFINE_ACTION_FUNCTION(APlayerPawn, PickNewWeapon)
+{
+	PARAM_SELF_PROLOGUE(APlayerPawn);
+	PARAM_CLASS(ammo, AActor);
+	ACTION_RETURN_POINTER(self->PickNewWeapon(ammo));
+}
 //===========================================================================
 //
 // APlayerPawn :: GiveDeathmatchInventory

--- a/wadsrc/static/zscript/shared/player.txt
+++ b/wadsrc/static/zscript/shared/player.txt
@@ -1277,7 +1277,7 @@ class PlayerPawn : Actor native
 	native void CheckUse();
 	native void CheckWeaponButtons();
 	native Weapon BestWeapon(class<Ammo> ammotype);
-    native Weapon PickNewWeapon(class<Ammo> ammotype);
+	native Weapon PickNewWeapon(class<Ammo> ammotype);
 
 }
 

--- a/wadsrc/static/zscript/shared/player.txt
+++ b/wadsrc/static/zscript/shared/player.txt
@@ -1277,6 +1277,7 @@ class PlayerPawn : Actor native
 	native void CheckUse();
 	native void CheckWeaponButtons();
 	native Weapon BestWeapon(class<Ammo> ammotype);
+    native Weapon PickNewWeapon(class<Ammo> ammotype);
 
 }
 


### PR DESCRIPTION
This small PR exports PlayerPawn.PickNewWeapon function to ZScript.

One concrete use case for this function would be in overrides of Weapon.CheckAmmo when implementing a custom condition to decide whether or not to switch weapons. Right now, it is possible to force the player to switch weapons by calling base implementation of CheckAmmo with an _ammouse_ value being knowingly higher than the current ammo amount. However, this feels like a hack, so it would be better if it were possible to access PickNewWeapon directly. 