### PR TITLE
Fake crusher floors in Doom 2 MAP04

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -514,6 +514,8 @@ class LevelCompatibility play
 				ClearSectorTags(34);
 				ClearSectorTags(83);
 				ClearSectorTags(85);
+				// Visually align floors between crushers
+				SetLineSpecial(3, Transfer_Heights, 14, 6);
 				break;
 			}
 			


### PR DESCRIPTION
Graf brought up using Transfer_Heights to cover up the deliberate missing textures, so I did. The DOORTRAK textures and what not should no longer be popping out like they did even to the DOS executable.