### PR TITLE
Preserve line locknumber in savegames

### DIFF
--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -73,6 +73,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, line_t &line, line_t *
 			("alpha", line.alpha, def->alpha)
 			.Args("args", line.args, def->args, line.special)
 			("portalindex", line.portalindex, def->portalindex)
+			("locknumber", line.locknumber, def->locknumber)
 			// Unless the map loader is changed the sidedef references will not change between map loads so there's no need to save them.
 			//.Array("sides", line.sidedef, 2)
 			.EndObject();


### PR DESCRIPTION
This is something that bugged me many months ago when I made Soundless Mound. I had to write a hackaround with a static thinker to save and restore lock numbers on doors (they're used to mark locked/jammed doors in the automap when found, since it's a clever way to give lines custom automap colors).

I don't know why I didn't just do this instead, since it's a single line change.

This allows the locknumber property on lines to be preserved after it's altered during gameplay.

I've tested it after commenting out lines 291-300 in player.zsc on SM (the part that restores lock numbers on savegame load) and it works as expected (normally this would cause all doors to have locknumber 0, giving them a cyan-ish color in the automap).