### PR TITLE
- use value initialization for secspecial_t

### DIFF
--- a/src/p_ceiling.cpp
+++ b/src/p_ceiling.cpp
@@ -428,7 +428,7 @@ bool P_CreateCeiling(sector_t *sec, DCeiling::ECeiling type, line_t *line, int t
 				switch (change & 3)
 				{
 					case 1:		// type is zeroed
-						ceiling->m_NewSpecial.Clear();
+						ceiling->m_NewSpecial = {};
 						ceiling->m_Type = DCeiling::genCeilingChg0;
 						break;
 					case 2:		// type is copied
@@ -447,7 +447,7 @@ bool P_CreateCeiling(sector_t *sec, DCeiling::ECeiling type, line_t *line, int t
 			switch (change & 3)
 			{
 				case 1:		// type is zeroed
-					ceiling->m_NewSpecial.Clear();
+					ceiling->m_NewSpecial = {};
 					ceiling->m_Type = DCeiling::genCeilingChg0;
 					break;
 				case 2:		// type is copied

--- a/src/p_floor.cpp
+++ b/src/p_floor.cpp
@@ -229,7 +229,7 @@ void DFloor::SetFloorChangeType (sector_t *sec, int change)
 	switch (change & 3)
 	{
 	case 1:
-		m_NewSpecial.Clear();
+		m_NewSpecial = {};
 		m_Type = DFloor::genFloorChg0;
 		break;
 	case 2:
@@ -828,7 +828,7 @@ bool EV_DoDonut (int tag, line_t *line, double pillarspeed, double slimespeed)
 			floor->m_Speed = slimespeed;
 			floor->m_Instant = false;
 			floor->m_Texture = s3->GetTexture(sector_t::floor);
-			floor->m_NewSpecial.Clear();
+			floor->m_NewSpecial = {};
 			height = s3->FindHighestFloorPoint (&spot);
 			floor->m_FloorDestDist = s2->floorplane.PointToDist (spot, height);
 			floor->StartFloorSound ();

--- a/src/p_spec.h
+++ b/src/p_spec.h
@@ -439,7 +439,7 @@ protected:
 
 	// [RH] Need these for BOOM-ish transferring ceilings
 	FTextureID	m_Texture;
-	secspecial_t m_NewSpecial;
+	secspecial_t m_NewSpecial{};
 
 	// ID
 	int 		m_Tag;
@@ -536,7 +536,7 @@ public:
 	bool		m_Hexencrush;
 	bool		m_Instant;
 	int 		m_Direction;
-	secspecial_t m_NewSpecial;
+	secspecial_t m_NewSpecial{};
 	FTextureID	m_Texture;
 	double	 	m_FloorDestDist;
 	double	 	m_Speed;

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -588,16 +588,6 @@ struct secspecial_t
 	short damageinterval;	// Interval for damage application
 	short leakydamage;		// chance of leaking through radiation suit
 	int Flags;
-
-	secspecial_t()
-	{
-		Clear();
-	}
-
-	void Clear()
-	{
-		memset(this, 0, sizeof(*this));
-	}
 };
 
 FSerializer &Serialize(FSerializer &arc, const char *key, secspecial_t &spec, secspecial_t *def);


### PR DESCRIPTION
Because secspecial_t has a constructor and destructor, it is not an aggregate/trivial type so running `memset` on it gives a warning. This PR removes the constructor/destructor and uses value initialization instead.