### PR TITLE
- fix more memcpy non-trivial errors

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -1965,7 +1965,7 @@ sector_t * AM_FakeFlat(AActor *viewer, sector_t * sec, sector_t * dest)
 	int diffTex = (sec->heightsec->MoreFlags & SECMF_CLIPFAKEPLANES);
 	sector_t * s = sec->heightsec;
 
-	memcpy(dest, sec, sizeof(sector_t));
+	*dest = *sec;
 
 	// Replace floor height with control sector's heights.
 	// The automap is only interested in the floor so let's skip the ceiling.

--- a/src/hwrenderer/scene/hw_drawstructs.h
+++ b/src/hwrenderer/scene/hw_drawstructs.h
@@ -262,11 +262,7 @@ public:
 	int CountVertices();
 
 public:
-	GLWall() {}
-
-	GLWall(const GLWall &other) = default;
-
-	GLWall & operator=(const GLWall &other) = default;
+	GLWall() = default;
 
 	void Process(HWDrawInfo *di, seg_t *seg, sector_t *frontsector, sector_t *backsector);
 	void ProcessLowerMiniseg(HWDrawInfo *di, seg_t *seg, sector_t *frontsector, sector_t *backsector);
@@ -317,11 +313,7 @@ public:
 	void SetFrom3DFloor(F3DFloor *rover, bool top, bool underside);
 	void ProcessSector(HWDrawInfo *di, sector_t * frontsector);
 	
-	GLFlat() {}
-
-	GLFlat(const GLFlat &other) = default;
-
-	GLFlat & operator=(const GLFlat &other) = default;
+	GLFlat() = default;
 
 };
 
@@ -374,14 +366,10 @@ public:
 
 public:
 
-	GLSprite() {}
+	GLSprite() = default;
 	void PutSprite(HWDrawInfo *di, bool translucent);
 	void Process(HWDrawInfo *di, AActor* thing,sector_t * sector, area_t in_area, int thruportal = false);
 	void ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *sector);//, int shade, int fakeside)
-
-	GLSprite(const GLSprite &other) = default;
-
-	GLSprite & operator=(const GLSprite &other) = default;
 
 };
 

--- a/src/hwrenderer/scene/hw_drawstructs.h
+++ b/src/hwrenderer/scene/hw_drawstructs.h
@@ -264,16 +264,9 @@ public:
 public:
 	GLWall() {}
 
-	GLWall(const GLWall &other)
-	{
-		memcpy(this, &other, sizeof(GLWall));
-	}
+	GLWall(const GLWall &other) = default;
 
-	GLWall & operator=(const GLWall &other)
-	{
-		memcpy(this, &other, sizeof(GLWall));
-		return *this;
-	}
+	GLWall & operator=(const GLWall &other) = default;
 
 	void Process(HWDrawInfo *di, seg_t *seg, sector_t *frontsector, sector_t *backsector);
 	void ProcessLowerMiniseg(HWDrawInfo *di, seg_t *seg, sector_t *frontsector, sector_t *backsector);
@@ -326,16 +319,9 @@ public:
 	
 	GLFlat() {}
 
-	GLFlat(const GLFlat &other)
-	{
-		memcpy(this, &other, sizeof(GLFlat));
-	}
+	GLFlat(const GLFlat &other) = default;
 
-	GLFlat & operator=(const GLFlat &other)
-	{
-		memcpy(this, &other, sizeof(GLFlat));
-		return *this;
-	}
+	GLFlat & operator=(const GLFlat &other) = default;
 
 };
 
@@ -393,16 +379,9 @@ public:
 	void Process(HWDrawInfo *di, AActor* thing,sector_t * sector, area_t in_area, int thruportal = false);
 	void ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *sector);//, int shade, int fakeside)
 
-	GLSprite(const GLSprite &other)
-	{
-		memcpy(this, &other, sizeof(GLSprite));
-	}
+	GLSprite(const GLSprite &other) = default;
 
-	GLSprite & operator=(const GLSprite &other)
-	{
-		memcpy(this, &other, sizeof(GLSprite));
-		return *this;
-	}
+	GLSprite & operator=(const GLSprite &other) = default;
 
 };
 

--- a/src/hwrenderer/scene/hw_fakeflat.cpp
+++ b/src/hwrenderer/scene/hw_fakeflat.cpp
@@ -223,11 +223,7 @@ sector_t * hw_FakeFlat(sector_t * sec, sector_t * dest, area_t in_area, bool bac
 	int diffTex = (sec->heightsec->MoreFlags & SECMF_CLIPFAKEPLANES);
 	sector_t * s = sec->heightsec;
 	
-#if 0
-	*dest=*sec;	// This will invoke the copy operator which isn't really needed here. Memcpy is faster.
-#else
-	memcpy(dest, sec, sizeof(sector_t));
-#endif
+	*dest = *sec;
 
 	// Replace floor and ceiling height with control sector's heights.
 	if (diffTex)

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -4274,11 +4274,11 @@ void P_SetupLevel (const char *lumpname, int position)
 	// Note that we want binary identity here, so assignment is not sufficient because it won't initialize any padding bytes.
 	// Note that none of these structures may contain non POD fields anyway.
 	level.loadsectors.Resize(level.sectors.Size());
-	memcpy(&level.loadsectors[0], &level.sectors[0], level.sectors.Size() * sizeof(level.sectors[0]));
+	std::copy(&level.sectors[0], &level.sectors[0] + level.sectors.Size(), &level.loadsectors[0]);
 	level.loadlines.Resize(level.lines.Size());
-	memcpy(&level.loadlines[0], &level.lines[0], level.lines.Size() * sizeof(level.lines[0]));
+	std::copy(&level.lines[0], &level.lines[0] + level.lines.Size(), &level.loadlines[0]);
 	level.loadsides.Resize(level.sides.Size());
-	memcpy(&level.loadsides[0], &level.sides[0], level.sides.Size() * sizeof(level.sides[0]));
+	std::copy(&level.sides[0], &level.sides[0] + level.sides.Size(), &level.loadsides[0]);
 }
 
 

--- a/src/p_trace.cpp
+++ b/src/p_trace.cpp
@@ -291,7 +291,7 @@ void FTraceInfo::Setup3DFloors()
 
 	if (ff.Size())
 	{
-		memcpy(&DummySector[0], CurSector, sizeof(sector_t));
+		DummySector[0] = *CurSector;
 		CurSector = &DummySector[0];
 		sectorsel = 1;
 
@@ -490,7 +490,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		// check for 3D floors first
 		if (entersector->e->XFloor.ffloors.Size())
 		{
-			memcpy(&DummySector[sectorsel], entersector, sizeof(sector_t));
+			DummySector[sectorsel] = *entersector;
 			entersector = &DummySector[sectorsel];
 			sectorsel ^= 1;
 

--- a/src/p_udmf.cpp
+++ b/src/p_udmf.cpp
@@ -2151,11 +2151,11 @@ public:
 
 		// Create the real vertices
 		level.vertexes.Alloc(ParsedVertices.Size());
-		memcpy(&level.vertexes[0], &ParsedVertices[0], level.vertexes.Size() * sizeof(vertex_t));
+		std::copy(&ParsedVertices[0], &ParsedVertices[0] + level.vertexes.Size(), &level.vertexes[0]);
 
 		// Create the real sectors
 		level.sectors.Alloc(ParsedSectors.Size());
-		memcpy(&level.sectors[0], &ParsedSectors[0], level.sectors.Size() * sizeof(sector_t));
+		std::copy(&ParsedSectors[0], &ParsedSectors[0] + level.sectors.Size(), &level.sectors[0]);
 		level.sectors[0].e = new extsector_t[level.sectors.Size()];
 		for(unsigned i = 0; i < level.sectors.Size(); i++)
 		{


### PR DESCRIPTION
Defaults copy constructor/assignment operator, uses copy assignment or `std::copy` in the appropriate places. Note that `memcpy` isn't necessarily faster since the compiler can optimize copying to `memcpy` or `memmove` or needed, but it's strictly more correct because it actually calls the constructors for non-trivial types.