### PR TITLE
EventHandlers: NewGame and OnUnregister order fixes

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -301,7 +301,7 @@ void E_InitStaticHandlers(bool map)
 void E_Shutdown(bool map)
 {
 	// delete handlers.
-	for (DStaticEventHandler* handler = E_FirstEventHandler; handler; handler = handler->next)
+	for (DStaticEventHandler* handler = E_LastEventHandler; handler; handler = handler->prev)
 	{
 		if (handler->IsStatic() == !map)
 			handler->Destroy();
@@ -515,11 +515,16 @@ bool E_CheckReplacement( PClassActor *replacee, PClassActor **replacement )
 	return final;
 }
 
-void E_NewGame()
+void E_NewGame(bool map)
 {
+	// Shut down all per-map event handlers before static NewGame events.
+	if (!map)
+		E_Shutdown(true);
+
 	for (DStaticEventHandler* handler = E_FirstEventHandler; handler; handler = handler->next)
 	{
-		handler->NewGame();
+		if (handler->IsStatic() == !map)
+			handler->NewGame();
 	}
 }
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -515,15 +515,17 @@ bool E_CheckReplacement( PClassActor *replacee, PClassActor **replacement )
 	return final;
 }
 
-void E_NewGame(bool map)
+void E_NewGame(EventHandlerType handlerType)
 {
+	bool isStatic = handlerType == EventHandlerType::Global;
+
 	// Shut down all per-map event handlers before static NewGame events.
-	if (!map)
+	if (isStatic)
 		E_Shutdown(true);
 
 	for (DStaticEventHandler* handler = E_FirstEventHandler; handler; handler = handler->next)
 	{
-		if (handler->IsStatic() == !map)
+		if (handler->IsStatic() == isStatic)
 			handler->NewGame();
 	}
 }

--- a/src/events.h
+++ b/src/events.h
@@ -9,6 +9,12 @@
 
 class DStaticEventHandler;
 
+enum class EventHandlerType
+{
+	Global,
+	PerMap
+};
+
 // register
 bool E_RegisterHandler(DStaticEventHandler* handler);
 // unregister
@@ -73,7 +79,7 @@ void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manu
 bool E_CheckReplacement(PClassActor* replacee, PClassActor** replacement);
 
 // called on new game
-void E_NewGame(bool map);
+void E_NewGame(EventHandlerType handlerType);
 
 // send networked event. unified function.
 bool E_SendNetworkEvent(FString name, int arg1, int arg2, int arg3, bool manual);

--- a/src/events.h
+++ b/src/events.h
@@ -73,7 +73,7 @@ void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manu
 bool E_CheckReplacement(PClassActor* replacee, PClassActor** replacement);
 
 // called on new game
-void E_NewGame();
+void E_NewGame(bool map);
 
 // send networked event. unified function.
 bool E_SendNetworkEvent(FString name, int arg1, int arg2, int arg3, bool manual);

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1054,7 +1054,7 @@ void G_Ticker ()
 		switch (gameaction)
 		{
 		case ga_loadlevel:
-			G_DoLoadLevel (-1, false);
+			G_DoLoadLevel (-1, false, false);
 			break;
 		case ga_recordgame:
 			G_CheckDemoStatus();

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1004,7 +1004,7 @@ void G_DoLoadLevel (int position, bool autosave, bool newGame)
 
 	if (newGame)
 	{
-		E_NewGame(false);
+		E_NewGame(EventHandlerType::Global);
 	}
 
 	P_SetupLevel (level.MapName, position, newGame);

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -526,11 +526,8 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 	{
 		gamestate = GS_LEVEL;
 	}
-	G_DoLoadLevel (0, false);
-	if(!savegamerestore)
-	{
-		E_NewGame();
-	}
+	
+	G_DoLoadLevel (0, false, !savegamerestore);
 }
 
 //
@@ -744,7 +741,7 @@ void G_DoCompleted (void)
 	if (gamestate == GS_TITLELEVEL)
 	{
 		level.MapName = nextlevel;
-		G_DoLoadLevel (startpos, false);
+		G_DoLoadLevel (startpos, false, false);
 		startpos = 0;
 		viewactive = true;
 		return;
@@ -919,7 +916,7 @@ void DAutosaver::Tick ()
 
 extern gamestate_t 	wipegamestate; 
  
-void G_DoLoadLevel (int position, bool autosave)
+void G_DoLoadLevel (int position, bool autosave, bool newGame)
 { 
 	static int lastposition = 0;
 	gamestate_t oldgs = gamestate;
@@ -1005,7 +1002,12 @@ void G_DoLoadLevel (int position, bool autosave)
 
 	level.maptime = 0;
 
-	P_SetupLevel (level.MapName, position);
+	if (newGame)
+	{
+		E_NewGame(false);
+	}
+
+	P_SetupLevel (level.MapName, position, newGame);
 
 	AM_LevelInit();
 
@@ -1253,7 +1255,7 @@ void G_DoWorldDone (void)
 		level.MapName = nextlevel;
 	}
 	G_StartTravel ();
-	G_DoLoadLevel (startpos, true);
+	G_DoLoadLevel (startpos, true, false);
 	startpos = 0;
 	gameaction = ga_nothing;
 	viewactive = true; 

--- a/src/g_level.h
+++ b/src/g_level.h
@@ -507,7 +507,7 @@ void G_ChangeLevel(const char *levelname, int position, int flags, int nextSkill
 void G_StartTravel ();
 int G_FinishTravel ();
 
-void G_DoLoadLevel (int position, bool autosave);
+void G_DoLoadLevel (int position, bool autosave, bool newGame);
 
 void G_InitLevelLocals (void);
 

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -3642,7 +3642,7 @@ void P_FreeExtraLevelData()
 //
 //===========================================================================
 
-void P_SetupLevel (const char *lumpname, int position)
+void P_SetupLevel (const char *lumpname, int position, bool newGame)
 {
 	cycle_t times[20];
 #if 0
@@ -3719,6 +3719,11 @@ void P_SetupLevel (const char *lumpname, int position)
 	// find map num
 	level.lumpnum = map->lumpnum;
 	hasglnodes = false;
+
+	if (newGame)
+	{
+		E_NewGame(true);
+	}
 
 	// [RH] Support loading Build maps (because I felt like it. :-)
 	buildmap = false;
@@ -4298,13 +4303,13 @@ void P_Init ()
 }
 
 static void P_Shutdown ()
-{
-	// [ZZ] delete global event handlers
-	DThinker::DestroyThinkersInList(STAT_STATIC);
-	E_Shutdown(false);
+{	
+	DThinker::DestroyThinkersInList(STAT_STATIC);	
 	P_DeinitKeyMessages ();
 	P_FreeLevelData ();
 	P_FreeExtraLevelData ();
+	// [ZZ] delete global event handlers
+	E_Shutdown(false);
 	ST_Clear();
 	FS_Close();
 	for (auto &p : players)

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -3722,7 +3722,7 @@ void P_SetupLevel (const char *lumpname, int position, bool newGame)
 
 	if (newGame)
 	{
-		E_NewGame(true);
+		E_NewGame(EventHandlerType::PerMap);
 	}
 
 	// [RH] Support loading Build maps (because I felt like it. :-)

--- a/src/p_setup.h
+++ b/src/p_setup.h
@@ -138,7 +138,7 @@ bool P_CheckMapData(const char * mapname);
 // [RH] The only parameter used is mapname, so I removed playermask and skill.
 //		On September 1, 1998, I added the position to indicate which set
 //		of single-player start spots should be spawned in the level.
-void P_SetupLevel (const char *mapname, int position);
+void P_SetupLevel (const char *mapname, int position, bool newGame);
 
 void P_FreeLevelData();
 void P_FreeExtraLevelData();


### PR DESCRIPTION
Currently, all EventHandlers (including StaticEventHandlers) fire their NewGame event after their WorldLoaded event. This setup seriously limits the usefulness of the NewGame event, as it cannot be used to affect the logic implemented in other events normally fired when starting a new level (like CheckReplacement). This PR rectifies this by introducing the following changes:

1. StaticEventHandlers will fire their NewGame event before a level is loaded. This ensures that global new-game initialization takes place before any per-map handlers enter the scene.

2. Normal EventHandlers will fire their NewGame event after they have been registered and before anything else. This ensures that local new-game initialization takes place before per-map handlers actually start doing something.

There is also a problem with StaticEventHandlers being unregistered before normal EventHandlers when leaving the game. The following changes are introduced to take care of this:

3. StaticEventHandlers will be unregistered _after_ unloading the current level, instead of before (current behavior). This eliminates the need to check if a StaticEventHandler still exists in case a per-map EventHandler needs to talk to it in its OnUnregister event.

4. All event handlers will be unregistered in reverse order, compared to their registration order. This ensures that at any given time, for every event handler which is currently executing, any event handlers registered before it are guaranteed to exist. 

To see what kinds of things are not possible with the current order of events, see [here](https://forum.zdoom.org/viewtopic.php?f=2&t=62398). The example outlined there depicts a settings system where some settings can only be changed for a new game. If any of these settings is supposed to affect the behavior of events defined in per-map handlers (for example, we want to make an option which replaces a weapon with another weapon, so we need to get the value of the setting in CheckReplacement), then the values of these settings are absolutely required to be initialized _before_ any other events fire, but _after_ we determine whether a new game has started. Currently, there is no suitable entry point for this.

Regarding the PR code-wise, it's probably important to note that a new argument had to be introduced in G_DoLoadLevel and P_SetupLevel to check for a new game and decide whether to fire the NewGame event. I'm not fond of global variables, so I had to add an argument instead, just to be on the safe side (I'm saying this because I see that global variables seem to be used quite extensively thoughout the code).

In case there are any mods which depend on the current behavior... well, considering that the NewGame event itself is a relatively recent development, there probably aren't too many projects that use it, and I highly doubt these changes may break anything irreparably. If this somehow turns out to be the case, then we could introduce a new event to fire on a new game but before a level is loaded, without re-purposing NewGame for that. 

There is also an issue where the WorldUnloaded event is only fired on level transitions (i.e. by exiting normally or using the "changemap" command), but not when exiting the game completely, starting a new game or loading a new level via the "map" command. Interestingly enough, per-map handlers are affected by this but static handlers are not. I'm not sure if this is a deliberate design choice or a limitation of the current setup in the engine, so I guess I'd better not touch this for now.