### PR TITLE
SpawnTime field

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -1035,6 +1035,8 @@ public:
 
 	// When was this actor spawned? (relative to the current level)
 	int GetLevelSpawnTime() const;
+	// How many ticks passed since this actor was spawned?
+	int GetAge() const;
 
 // info for drawing
 // NOTE: The first member variable *must* be snext.

--- a/src/actor.h
+++ b/src/actor.h
@@ -1033,6 +1033,8 @@ public:
 	void AttachLight(unsigned int count, const FLightDefaults *lightdef);
 	void SetDynamicLights();
 
+	// When was this actor spawned? (relative to the current level)
+	int GetLevelSpawnTime() const;
 
 // info for drawing
 // NOTE: The first member variable *must* be snext.
@@ -1261,6 +1263,9 @@ public:
 	DRotator PrevAngles;
 	int PrevPortalGroup;
 	TArray<TObjPtr<AActor*> > AttachedLights;
+
+	// When was this actor spawned?
+	int SpawnTime;
 
 	// ThingIDs
 	static void ClearTIDHashes ();

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -8085,6 +8085,24 @@ DEFINE_ACTION_FUNCTION(AActor, GetLevelSpawnTime)
 	ACTION_RETURN_INT(self->GetLevelSpawnTime());
 }
 
+//==========================================================================
+//
+// AActor :: GetAge
+//
+// Returns the number of ticks passed since this actor was spawned.
+//
+//==========================================================================
+int AActor::GetAge() const
+{
+	return level.totaltime - SpawnTime;
+}
+
+DEFINE_ACTION_FUNCTION(AActor, GetAge)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	ACTION_RETURN_INT(self->GetAge());
+}
+
 //---------------------------------------------------------------------------
 //
 // PROP A_RestoreSpecialPosition

--- a/src/version.h
+++ b/src/version.h
@@ -91,7 +91,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4552
+#define SAVEVER 4553
 
 // This is so that derivates can use the same savegame versions without worrying about engine compatibility
 #define GAMESIG "GZDOOM"

--- a/src/version.h
+++ b/src/version.h
@@ -91,7 +91,7 @@ const char *GetVersionString();
 
 // Use 4500 as the base git save version, since it's higher than the
 // SVN revision ever got.
-#define SAVEVER 4553
+#define SAVEVER 4552
 
 // This is so that derivates can use the same savegame versions without worrying about engine compatibility
 #define GAMESIG "GZDOOM"

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -234,6 +234,7 @@ class Actor : Thinker native
 	native int RenderHidden;
 	native int RenderRequired;
 	native readonly int FriendlySeeBlocks;
+	native readonly int SpawnTime;
 
 	meta String Obituary;		// Player was killed by this actor
 	meta String HitObituary;		// Player was killed by this actor in melee
@@ -708,6 +709,7 @@ class Actor : Thinker native
 	native void GiveSecret(bool printmsg = true, bool playsound = true);
 	native clearscope double GetCameraHeight() const;
 	native clearscope double GetGravity() const;
+	native clearscope int GetLevelSpawnTime() const;
 
 	native bool CheckClass(class<Actor> checkclass, int ptr_select = AAPTR_DEFAULT, bool match_superclass = false);
 	native void AddInventory(Inventory inv);

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -710,6 +710,7 @@ class Actor : Thinker native
 	native clearscope double GetCameraHeight() const;
 	native clearscope double GetGravity() const;
 	native clearscope int GetLevelSpawnTime() const;
+	native clearscope int GetAge() const;
 
 	native bool CheckClass(class<Actor> checkclass, int ptr_select = AAPTR_DEFAULT, bool match_superclass = false);
 	native void AddInventory(Inventory inv);


### PR DESCRIPTION
This PR introduces a new field to the Actor class called `SpawnTime`. This field stores the amount of ticks that had passed since the start of the game on the moment the actor was spawned. One of the possible use cases for this field is given [here](https://forum.zdoom.org/viewtopic.php?t=62460).

I've decided to store the total time and not the level time because some actors can persist across levels - notably, the items in the player's inventory have this ability. If spawn time were stored as level time, then it would lose its meaning for player's inventory items after a level transition. I could reset it to 0, of course, but since the items are not destroyed and recreated during level transitions but rather transferred as they are, it wouldn't be technically correct to do this.

To get the spawn time relative to the current level, a new fuction called `GetLevelSpawnTime` was added to the Actor class. Note that it may return a negative value, which means the actor in question was spawned on a previous level (can happen with inventory items).

The "info" console command now also prints both global and level-relative spawn times for the target actor. The new field is correctly serialized in saved games, and save version has been bumped in this PR (not sure if I need to bump the minimum version, though). Also, I may have fixed a typo in `AActor::Serialize` in p_mobj.cpp.

**edit:** Also added a function to get an actor's age (the amount of ticks passed since it was spawned).
