### PR TITLE
CanResurrect virtual

### DIFF
--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -4566,6 +4566,20 @@ DEFINE_ACTION_FUNCTION(AActor, A_RaiseSelf)
 
 //===========================================================================
 //
+// A_RaiseActor
+//
+// Generalized version that allows passing pointers for ZScript's sake.
+//===========================================================================
+DEFINE_ACTION_FUNCTION(AActor, A_RaiseActor)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_OBJECT(other, AActor);
+	PARAM_INT_DEF(flags);
+	ACTION_RETURN_BOOL(P_Thing_Raise(other, self, (flags & RF_NOCHECKPOSITION)));
+}
+
+//===========================================================================
+//
 // CanRaise
 //
 //===========================================================================

--- a/src/p_actionfunctions.cpp
+++ b/src/p_actionfunctions.cpp
@@ -4566,11 +4566,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_RaiseSelf)
 
 //===========================================================================
 //
-// A_RaiseActor
+// RaiseActor
 //
 // Generalized version that allows passing pointers for ZScript's sake.
 //===========================================================================
-DEFINE_ACTION_FUNCTION(AActor, A_RaiseActor)
+DEFINE_ACTION_FUNCTION(AActor, RaiseActor)
 {
 	PARAM_SELF_PROLOGUE(AActor);
 	PARAM_OBJECT(other, AActor);

--- a/src/p_local.h
+++ b/src/p_local.h
@@ -162,6 +162,7 @@ void	P_Thing_SetVelocity(AActor *actor, const DVector3 &vec, bool add, bool setb
 void P_RemoveThing(AActor * actor);
 bool P_Thing_Raise(AActor *thing, AActor *raiser, int nocheck = false);
 bool P_Thing_CanRaise(AActor *thing);
+bool P_CanResurrect(AActor *ththing, AActor *thing);
 PClassActor *P_GetSpawnableType(int spawnnum);
 void InitSpawnablesFromMapinfo();
 int P_Thing_CheckInputNum(player_t *p, int inputnum);

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -440,7 +440,7 @@ bool P_Thing_Raise(AActor *thing, AActor *raiser, int nocheck)
 	FState * RaiseState = thing->GetRaiseState();
 	if (RaiseState == NULL)
 	{
-		return true;	// monster doesn't have a raise state
+		return false;	// monster doesn't have a raise state
 	}
 	
 	AActor *info = thing->GetDefault ();

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -434,6 +434,9 @@ void P_RemoveThing(AActor * actor)
 
 bool P_Thing_Raise(AActor *thing, AActor *raiser, int nocheck)
 {
+	if (!thing)	
+		return false;
+
 	FState * RaiseState = thing->GetRaiseState();
 	if (RaiseState == NULL)
 	{

--- a/src/p_things.cpp
+++ b/src/p_things.cpp
@@ -460,6 +460,8 @@ bool P_Thing_Raise(AActor *thing, AActor *raiser, int nocheck)
 		return false;
 	}
 
+	if (!P_CanResurrect(thing, raiser))
+		return false;
 
 	S_Sound (thing, CHAN_BODY, "vile/raise", 1, ATTN_IDLE);
 

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -444,6 +444,13 @@ class Actor : Thinker native
 		return true;
 	}
 
+	// Called by revival/resurrection to check if one can resurrect the other.
+	// "other" can be null when not passive.
+	virtual bool CanResurrect(Actor other, bool passive)
+	{
+		return true;
+	}
+
 	// Called when an actor is to be reflected by a disc of repulsion.
 	// Returns true to continue normal blast processing.
 	virtual bool SpecialBlastHandling (Actor source, double strength)

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -1091,6 +1091,7 @@ class Actor : Thinker native
 	native void A_RaiseChildren(int flags = 0);
 	native void A_RaiseSiblings(int flags = 0);
 	native bool A_RaiseSelf(int flags = 0);
+	native bool A_RaiseActor(Actor other, int flags = 0);
 	native bool CanRaise();
 	native void Revive();
 	action native bool, Actor A_ThrowGrenade(class<Actor> itemtype, double zheight = 0, double xyvel = 0, double zvel = 0, bool useammo = true);

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -1091,7 +1091,7 @@ class Actor : Thinker native
 	native void A_RaiseChildren(int flags = 0);
 	native void A_RaiseSiblings(int flags = 0);
 	native bool A_RaiseSelf(int flags = 0);
-	native bool A_RaiseActor(Actor other, int flags = 0);
+	native bool RaiseActor(Actor other, int flags = 0);
 	native bool CanRaise();
 	native void Revive();
 	action native bool, Actor A_ThrowGrenade(class<Actor> itemtype, double zheight = 0, double xyvel = 0, double zvel = 0, bool useammo = true);


### PR DESCRIPTION
Added CanResurrect(Actor other, bool passive)

- Works similarly to CanCollideWith.
  - This means the function is only called after all the other checks; a raise state and -1 duration or CanRaise are still required.
- Passive means the caller is trying to be resurrected by 'other'.
- Non-passive means the caller is trying to resurrect 'other'.

Also added A_RaiseActor(Actor other, int flags), a pointer friendly edition for ZScript's sake.

Fixed an inconsistency where P_Thing_Raise returned true if no raise state was found, while P_Thing_CanRaise returned false. P_Thing_Raise now returns false.