### PR TITLE
Fixed FastProjectile not calling sector damage callback in XY movement

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -2553,21 +2553,6 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 			AActor *BlockingMobj = mo->BlockingMobj;
 			line_t *BlockingLine = mo->BlockingLine;
 
-			// [ZZ] 
-			if (!BlockingLine && !BlockingMobj) // hit floor or ceiling while XY movement - sector actions
-			{
-				int hitpart = -1;
-				sector_t* hitsector = nullptr;
-				secplane_t* hitplane = nullptr;
-				if (tm.ceilingsector && mo->Z() + mo->Height > tm.ceilingsector->ceilingplane.ZatPoint(tm.pos.XY()))
-					mo->BlockingCeiling = tm.ceilingsector;
-				if (tm.floorsector && mo->Z() < tm.floorsector->floorplane.ZatPoint(tm.pos.XY()))
-					mo->BlockingFloor = tm.floorsector;
-				// the following two only set the appropriate field - to avoid issues caused by running actions right in the middle of XY movement
-				P_CheckFor3DFloorHit(mo, mo->floorz, false);
-				P_CheckFor3DCeilingHit(mo, mo->ceilingz, false);
-			}
-
 			if (!(mo->flags & MF_MISSILE) && (mo->BounceFlags & BOUNCE_MBF) 
 				&& (BlockingMobj != NULL ? P_BounceActor(mo, BlockingMobj, false) : P_BounceWall(mo)))
 			{

--- a/wadsrc/static/zscript/shared/fastprojectile.txt
+++ b/wadsrc/static/zscript/shared/fastprojectile.txt
@@ -128,6 +128,12 @@ class FastProjectile : Actor
 							}
 						}
 
+						if (!BlockingLine && !BlockingMobj)
+						{
+							if (BlockingFloor) Destructible.ProjectileHitPlane(self, SECPART_Floor);
+							if (BlockingCeiling) Destructible.ProjectileHitPlane(self, SECPART_Ceiling);
+						}
+
 						ExplodeMissile (BlockingLine, BlockingMobj);
 						return;
 					}
@@ -148,7 +154,7 @@ class FastProjectile : Actor
 
 					SetZ(floorz);
 					HitFloor ();
-                    Destructible.ProjectileHitPlane(self, SECPART_Floor);
+					Destructible.ProjectileHitPlane(self, SECPART_Floor);
 					ExplodeMissile (NULL, NULL);
 					return;
 				}
@@ -162,7 +168,7 @@ class FastProjectile : Actor
 					}
 
 					SetZ(ceilingz - Height);
-                    Destructible.ProjectileHitPlane(self, SECPART_Ceiling);
+					Destructible.ProjectileHitPlane(self, SECPART_Ceiling);
 					ExplodeMissile (NULL, NULL);
 					return;
 				}


### PR DESCRIPTION
This weird actor is broken again... special thanks to Lewisk3 for having all his projectiles as fast :p
Also moved BlockingCeiling/BlockingFloor to P_CheckPosition so that it's more reliable on ZScript side.