### PR TITLE
Fix: Changing DecalGenerator value for weapons now actually changes the decal.

### DIFF
--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -7063,7 +7063,7 @@ void SpawnShootDecal(AActor *t1, const FTraceResults &trace)
 
 	if (t1->player != NULL && t1->player->ReadyWeapon != NULL)
 	{
-		decalbase = t1->player->ReadyWeapon->GetDefault()->DecalGenerator;
+		decalbase = t1->player->ReadyWeapon->DecalGenerator;
 	}
 	else
 	{


### PR DESCRIPTION
For some reason, the `SpawnShootDecal` function in p_map.cpp uses the weapon's default decal generator when spawning the decal. I don't see any reason for this restriction to exist, since it nullifies any effect from changing the decal generator dynamically. Removing this limitation doesn't seem to break anything, and changing DecalGenerator now works properly.
