### PR TITLE
Add NOFRICTION and NOFRICTIONBOUNCE flags

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -405,6 +405,8 @@ enum ActorFlag8
 	MF8_BLOCKASPLAYER	= 0x00000004,	// actor is blocked by player-blocking lines even if not a player
 	MF8_DONTFACETALKER	= 0x00000008,	// don't alter the angle to face the player in conversations
 	MF8_HITOWNER		= 0x00000010,	// projectile can hit the actor that fired it
+	MF8_NOFRICTION		= 0x00000020,	// friction doesn't apply to the actor at all
+	MF8_NOFRICTIONBOUNCE	= 0x00000040,	// don't bounce off walls when on icy floors
 };
 
 // --- mobj.renderflags ---

--- a/src/p_enemy.cpp
+++ b/src/p_enemy.cpp
@@ -599,7 +599,7 @@ bool P_Move (AActor *actor)
 
 	// [RH] I'm not so sure this is such a good idea
 	// [GZ] That's why it's compat-optioned.
-	if (compatflags & COMPATF_MBFMONSTERMOVE)
+	if (compatflags & COMPATF_MBFMONSTERMOVE && !(actor->flags8 & MF8_NOFRICTION))
 	{
 		// killough 10/98: make monsters get affected by ice and sludge too:
 		movefactor = P_GetMoveFactor (actor, &friction);

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -2968,6 +2968,7 @@ void FSlide::HitSlideLine(line_t* ld)
 
 	// killough 10/98: only bounce if hit hard (prevents wobbling)
 	icyfloor =
+		!(slidemo->flags8 & MF8_NOFRICTIONBOUNCE) &&
 		tmmove.LengthSquared() > 4*4 &&
 		var_friction &&  // killough 8/28/98: calc friction on demand
 		slidemo->Z() <= slidemo->floorz &&

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -2417,8 +2417,12 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 	// that large thrusts can't propel an actor through a wall, because wall
 	// running depends on the player's original movement continuing even after
 	// it gets blocked.
-	if ((mo->player != NULL && (i_compatflags & COMPATF_WALLRUN)) || (mo->waterlevel >= 1) ||
-		(mo->player != NULL && mo->player->crouchfactor < 0.75))
+	//
+	// [anon] When friction is turned off, turn off the crouching and water
+	//  speed caps as well, since it is a sort of friction, and the modders
+	//  most likely want to deal with that themselves.
+	if ((mo->player != NULL && (i_compatflags & COMPATF_WALLRUN)) || ((mo->waterlevel >= 1 ||
+		(mo->player != NULL && mo->player->crouchfactor < 0.75)) && !(mo->flags8 & MF8_NOFRICTION)))
 	{
 		// preserve the direction instead of clamping x and y independently.
 		double cx = mo->Vel.X == 0 ? 1. : clamp(mo->Vel.X, -maxmove, maxmove) / mo->Vel.X;
@@ -2810,7 +2814,7 @@ explode:
 		return Oldfloorz;
 	}
 
-	if (mo->flags & (MF_MISSILE | MF_SKULLFLY))
+	if (mo->flags & (MF_MISSILE | MF_SKULLFLY) || mo->flags8 & MF8_NOFRICTION)
 	{ // no friction for missiles
 		return Oldfloorz;
 	}

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -319,6 +319,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, BLOCKASPLAYER, AActor, flags8),
 	DEFINE_FLAG(MF8, DONTFACETALKER, AActor, flags8),
 	DEFINE_FLAG(MF8, HITOWNER, AActor, flags8),
+	DEFINE_FLAG(MF8, NOFRICTION, AActor, flags8),
+	DEFINE_FLAG(MF8, NOFRICTIONBOUNCE, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
NOFRICTION disables all friction effects on the thing it's set on (including the speed cap from water/crouching), and NOFRICTIONBOUNCE disables the "bounce off walls on an icy floor" effect on the thing it's set on.

The point of NOFRICTION is, by disabling automatic friction and a couple speed caps, to give modders more direct control over how velocity is applied and how it decays - in my case, because having regular friction interfere with my custom friction causes all sorts of acceleration issues. The point of NOFRICTIONBOUNCE is mainly because, well, maybe you *don't* want your slippery thing to bounce off walls.

The speed cap part of NOFRICTION could be separated into its own flag, but I figure that anyone using one is probably going to be using the other. Doesn't really matter to me if it's split off or not, though.