### PR TITLE
Fixed crash with psprites destruction

### DIFF
--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -835,6 +835,7 @@ void CopyPlayer(player_t *dst, player_t *src, const char *name)
 
 
 	*dst = *src;		// To avoid memory leaks at this point the userinfo in src must be empty which is taken care of by the TransferFrom call above.
+	dst->psprites = src->psprites;
 
 	dst->cheats |= chasecam;
 

--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -359,7 +359,7 @@ player_t &player_t::operator=(const player_t &p)
 	extralight = p.extralight;
 	fixedcolormap = p.fixedcolormap;
 	fixedlightlevel = p.fixedlightlevel;
-	psprites = p.psprites;
+	// psprites should be copied explicitly
 	morphTics = p.morphTics;
 	MorphedPlayerClass = p.MorphedPlayerClass;
 	MorphStyle = p.MorphStyle;


### PR DESCRIPTION
psprites member of PredictionPlayerBackup object can be destructed twice when exiting multiplayer game:
* During garbage collection initiated by class system shutdown. Pointers won't be set to null there
* During destruction of PredictionPlayerBackup itself because it still points to freed memory
Copying of psprites member was disabled in operator= and now it must be copied explicitly

https://forum.zdoom.org/viewtopic.php?t=62598