### PR TITLE
Expose defaultbloodcolor to ZScript

### DIFF
--- a/src/gi.cpp
+++ b/src/gi.cpp
@@ -61,7 +61,7 @@ DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, statusscreen_single)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, statusscreen_coop)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, statusscreen_dm)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, mSliderColor)
-
+DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, defaultbloodcolor)
 
 const char *GameNames[17] =
 {

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -366,6 +366,7 @@ struct GameInfoStruct native
 	native double gibfactor;
 	native bool intermissioncounter;
 	native Name mSliderColor;
+	native Color defaultbloodcolor;
 }
 
 class Object native


### PR DESCRIPTION
This variable from gameinfo would be needed by gore mods in order to obtain the default color for blood (we've been use a hardcoded color for now, which isn't exactly good practice).