### PR TITLE
add monster tags (Friendly Names) for Hexen

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -1423,6 +1423,24 @@ TXT_QUIETUS_PIECE = "SEGMENT OF QUIETUS";
 TXT_WRAITHVERGE_PIECE = "SEGMENT OF WRAITHVERGE";
 TXT_BLOODSCOURGE_PIECE = "SEGMENT OF BLOODSCOURGE";
 
+// Friendly names
+
+FN_FIREDEMON = "Afrit";
+FN_DEMON1 = "Serpent";
+FN_ETTIN = "Ettin";
+FN_CENTAUR = "Centaur";
+FN_SLAUGHTAUR = "Slaughtaur";
+FN_BISHOP = "Bishop";
+FN_ICEGUY = "Wendigo";
+FN_SERPENT = "Stalker";
+FN_WRAITH = "Reiver";
+FN_DRAGON = "Death Wyvern";
+FN_KORAX = "Korax";
+FN_FBOSS = "Zedek";
+FN_MBOSS = "Menelkir";
+FN_CBOSS = "Traductus";
+FN_HERESIARCH = "Heresiarch";
+
 // Strife locks
 
 TXT_NEEDKEY = "You don't have the key";

--- a/wadsrc/static/zscript/hexen/bishop.txt
+++ b/wadsrc/static/zscript/hexen/bishop.txt
@@ -24,6 +24,7 @@ class Bishop : Actor
 		DeathSound "BishopDeath";
 		ActiveSound "BishopActiveSounds";
 		Obituary"$OB_BISHOP";
+		Tag "$FN_BISHOP";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/centaur.txt
+++ b/wadsrc/static/zscript/hexen/centaur.txt
@@ -21,6 +21,7 @@ class Centaur : Actor
 		HowlSound "PuppyBeat";
 		Obituary "$OB_CENTAUR";
 		DamageFactor "Electric", 3;
+		Tag "$FN_CENTAUR";
 	}
 	States
 	{
@@ -107,6 +108,7 @@ class CentaurLeader : Centaur
 		Speed 10;
 		Obituary "$OB_SLAUGHTAUR";
 		HitObituary "$OB_SLAUGHTAURHIT";
+		Tag "$FN_SLAUGHTAUR";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/hexen/clericboss.txt
+++ b/wadsrc/static/zscript/hexen/clericboss.txt
@@ -15,7 +15,8 @@ class ClericBoss : Actor
 		+DONTMORPH
 		PainSound "PlayerClericPain";
 		DeathSound "PlayerClericCrazyDeath";
-		Obituary "$OBCBOSS";
+		Obituary "$OB_CBOSS";
+		Tag "$FN_CBOSS";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/demons.txt
+++ b/wadsrc/static/zscript/hexen/demons.txt
@@ -20,6 +20,7 @@ class Demon1 : Actor
 		DeathSound "DemonDeath";
 		ActiveSound "DemonActive";
 		Obituary "$OB_DEMON1";
+		Tag "$FN_DEMON1";
 	}
 	
 	const ChunkFlags = SXF_TRANSFERTRANSLATION | SXF_ABSOLUTEVELOCITY;

--- a/wadsrc/static/zscript/hexen/dragon.txt
+++ b/wadsrc/static/zscript/hexen/dragon.txt
@@ -19,6 +19,7 @@ class Dragon : Actor
 		DeathSound "DragonDeath";
 		ActiveSound "DragonActive";
 		Obituary "$OB_DRAGON";
+		Tag "$FN_DRAGON";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/ettin.txt
+++ b/wadsrc/static/zscript/hexen/ettin.txt
@@ -22,6 +22,7 @@ class Ettin : Actor
 		ActiveSound "EttinActive";
 		HowlSound "PuppyBeat";
 		Obituary "$OB_ETTIN";
+		Tag "$FN_ETTIN";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/hexen/fighterboss.txt
+++ b/wadsrc/static/zscript/hexen/fighterboss.txt
@@ -17,6 +17,7 @@ class FighterBoss : Actor
 		PainSound "PlayerFighterPain";
 		DeathSound "PlayerFighterCrazyDeath";
 		Obituary "$OB_FBOSS";
+		Tag "$FN_FBOSS";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/firedemon.txt
+++ b/wadsrc/static/zscript/hexen/firedemon.txt
@@ -24,6 +24,7 @@ class FireDemon : Actor
 		DeathSound "FireDemonDeath";
 		ActiveSound "FireDemonActive";
 		Obituary "$OB_FIREDEMON";
+		Tag "$FN_FIREDEMON";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/heresiarch.txt
+++ b/wadsrc/static/zscript/hexen/heresiarch.txt
@@ -70,6 +70,7 @@ class Heresiarch : Actor
 		DeathSound "SorcererDeathScream";
 		ActiveSound "SorcererActive";
 		Obituary "$OB_HERESIARCH";
+		Tag "$FN_HERESIARCH";
 	}
 	
 	States

--- a/wadsrc/static/zscript/hexen/iceguy.txt
+++ b/wadsrc/static/zscript/hexen/iceguy.txt
@@ -20,6 +20,7 @@ class IceGuy : Actor
 		AttackSound "IceGuyAttack";
 		ActiveSound "IceGuyActive";
 		Obituary "$OB_ICEGUY";
+		Tag "$FN_ICEGUY";
 	}
 
 

--- a/wadsrc/static/zscript/hexen/korax.txt
+++ b/wadsrc/static/zscript/hexen/korax.txt
@@ -60,6 +60,7 @@ class Korax : Actor
 		DeathSound "KoraxDeath";
 		ActiveSound "KoraxActive";
 		Obituary "$OB_KORAX";
+		Tag "$FN_KORAX";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/mageboss.txt
+++ b/wadsrc/static/zscript/hexen/mageboss.txt
@@ -16,6 +16,7 @@ class MageBoss : Actor
 		PainSound "PlayerMagePain";
 		DeathSound "PlayerMageCrazyDeath";
 		Obituary "$OB_MBOSS";
+		Tag "$FN_MBOSS";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/serpent.txt
+++ b/wadsrc/static/zscript/hexen/serpent.txt
@@ -22,6 +22,7 @@ class Serpent : Actor
 		PainSound "SerpentPain";
 		DeathSound "SerpentDeath";
 		HitObituary "$OB_SERPENTHIT";
+		Tag "$FN_SERPENT";
 	}
 
 	States

--- a/wadsrc/static/zscript/hexen/wraith.txt
+++ b/wadsrc/static/zscript/hexen/wraith.txt
@@ -21,6 +21,7 @@ class Wraith : Actor
 		ActiveSound "WraithActive";
 		HitObituary "$OB_WRAITHHIT";
 		Obituary "$OB_WRAITH";
+		Tag "$FN_WRAITH";
 	}
 
 	States


### PR DESCRIPTION
1. Added monster tags for Hexen. Monster tags are based on the corresponding obituaries.
2. Fixed ClericBoss obituary.