### PR TITLE
Fixed textures on the two rising switches in TNT MAP31

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -179,6 +179,11 @@ class LevelCompatibility play
 			{
 				// The famous missing yellow key...
 				SetThingFlags(470, 2016);
+				// Fix textures on the two switches that rise from the floor in the eastern area
+				for (int i = 0; i < 8; i++)
+				{
+					SetLineFlags(1676 + i, 0, Line.ML_DONTPEGBOTTOM);
+				}
 				break;
 			}
 


### PR DESCRIPTION
This small PR fixes textures on the two switches that rise from the floor in the eastern area of TNT MAP31 (approx. coordinates: X = 3520, Y = -448). These switches (sector 258, linedefs 1676 to 1679, and sector 259, linedefs 1680 to 1683) have the "lower unpegged" flag set on all of their linedefs, which is probably a mapping error. Compare how they look [originally (with the flag)](https://imgur.com/a/Voo1Rb7) and [without the flag](https://imgur.com/a/Of7STKj). The fixed version is much less likely to confuse new players.
