### PR TITLE
Export AActor::Grind method to ZScript

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -814,7 +814,8 @@ public:
 	virtual bool Massacre ();
 
 	// Transforms the actor into a finely-ground paste
-	virtual bool Grind(bool items);
+	bool Grind(bool items);
+	bool CallGrind(bool items);
 
 	// Get this actor's team
 	int GetTeam();

--- a/src/g_inventory/a_pickups.cpp
+++ b/src/g_inventory/a_pickups.cpp
@@ -175,33 +175,6 @@ void AInventory::MarkPrecacheSounds() const
 
 //===========================================================================
 //
-// AInventory :: Grind
-//
-//===========================================================================
-
-bool AInventory::Grind(bool items)
-{
-	// Does this grind request even care about items?
-	if (!items)
-	{
-		return false;
-	}
-	// Dropped items are normally destroyed by crushers. Set the DONTGIB flag,
-	// and they'll act like corpses with it set and be immune to crushers.
-	if (flags & MF_DROPPED)
-	{
-		if (!(flags3 & MF3_DONTGIB))
-		{
-			Destroy();
-		}
-		return false;
-	}
-	// Non-dropped items call the super method for compatibility.
-	return Super::Grind(items);
-}
-
-//===========================================================================
-//
 // AInventory :: BecomeItem
 //
 // Lets this actor know that it's about to be placed in an inventory.

--- a/src/g_inventory/a_pickups.h
+++ b/src/g_inventory/a_pickups.h
@@ -76,7 +76,6 @@ public:
 	virtual void OnDestroy() override;
 	virtual void Tick() override;
 	virtual bool Massacre() override;
-	virtual bool Grind(bool items) override;
 
 	bool CallTryPickup(AActor *toucher, AActor **toucher_return = NULL);	// Wrapper for script function.
 

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -6485,7 +6485,7 @@ void P_FindBelowIntersectors(AActor *actor)
 
 void P_DoCrunch(AActor *thing, FChangePosition *cpos)
 {
-	if (!(thing && thing->Grind(true) && cpos)) return;
+	if (!(thing && thing->CallGrind(true) && cpos)) return;
 	cpos->nofit = true;
 
 	if ((cpos->crushchange > 0) && !(level.maptime & 3))

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -1903,6 +1903,26 @@ bool AActor::Grind(bool items)
 	return true;
 }
 
+DEFINE_ACTION_FUNCTION(AActor, Grind)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_BOOL(items);
+	ACTION_RETURN_BOOL(self->Grind(items));
+}
+
+bool AActor::CallGrind(bool items)
+{
+	IFVIRTUAL(AActor, Grind)
+	{
+		VMValue params[] = { (DObject*)this, items };
+		int retv;
+		VMReturn ret(&retv);
+		VMCall(func, params, 2, &ret, 1);
+		return !!retv;
+	}
+	return Grind(items);
+}
+
 //============================================================================
 //
 // AActor :: Massacre

--- a/src/po_man.cpp
+++ b/src/po_man.cpp
@@ -869,7 +869,7 @@ void FPolyObj::ThrustMobj (AActor *actor, side_t *side)
 			P_TraceBleed (newdam > 0 ? newdam : crush, actor);
 		}
 	}
-	if (level.flags2 & LEVEL2_POLYGRIND) actor->Grind(false); // crush corpses that get caught in a polyobject's way
+	if (level.flags2 & LEVEL2_POLYGRIND) actor->CallGrind(false); // crush corpses that get caught in a polyobject's way
 }
 
 //==========================================================================

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -577,6 +577,7 @@ class Actor : Thinker native
 	native void ClearCounters();
 	native bool GiveBody (int num, int max=0);
 	native bool HitFloor();
+	native virtual bool Grind(bool items);
 	native clearscope bool isTeammate(Actor other) const;
 	native clearscope int PlayerNumber() const;
 	native void SetFriendPlayer(PlayerInfo player);

--- a/wadsrc/static/zscript/inventory/inventory.txt
+++ b/wadsrc/static/zscript/inventory/inventory.txt
@@ -144,7 +144,33 @@ class Inventory : Actor native
 			Spawn ("ItemFog", Pos, ALLOW_REPLACE);
 		}
 	}
-		
+
+	//===========================================================================
+	//
+	// AInventory :: Grind
+	//
+	//===========================================================================
+
+	override bool Grind(bool items)
+	{
+		// Does this grind request even care about items?
+		if (!items)
+		{
+			return false;
+		}
+		// Dropped items are normally destroyed by crushers. Set the DONTGIB flag,
+		// and they'll act like corpses with it set and be immune to crushers.
+		if (bDropped)
+		{
+			if (!bDontGib)
+			{
+				Destroy();
+			}
+			return false;
+		}
+		// Non-dropped items call the super method for compatibility.
+		return Super.Grind(items);
+	}		
 
 	//===========================================================================
 	//


### PR DESCRIPTION
This PR exports AActor::Grind method to ZScript so that it can be overridden in user code. One possible use case for this method would be to make debris objects (like weapon casings and empty clips) able to be crushed (and subsequently destroyed) by closing doors. Currently, it only works on corpses and dropped inventory items, and since such objects are neither the former nor the latter, it is not possible to implement this kind of behavior at the moment without resorting to hacks (like comparing the actor's z-position against the ceiling height each tick or setting the appropriate flags to fool the engine into thinking that the actor is a corpse).

I've left the implementation of AActor::Grind in native code due to its complexity, so that I don't accidentally introduce any errors when converting the code to ZScript. However, I've moved AInventory::Grind to ZScript, as the logic there is quite simple; besides, I don't think this method is called too often so there probably won't be any performance issues.