### PR TITLE
DONTBOUNCEONSKY

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -488,6 +488,7 @@ enum ActorBounceFlag
 	BOUNCE_UseBounceState = 1<<14,	// Use Bounce[.*] states
 	BOUNCE_NotOnShootables = 1<<15,	// do not bounce off shootable actors if we are a projectile. Explode instead.
 	BOUNCE_BounceOnUnrips = 1<<16,	// projectile bounces on actors with DONTRIP
+	BOUNCE_NotOnSky = 1<<17,		// Don't bounce on sky floors / ceilings / walls
 
 	BOUNCE_TypeMask = BOUNCE_Walls | BOUNCE_Floors | BOUNCE_Ceilings | BOUNCE_Actors | BOUNCE_AutoOff | BOUNCE_HereticType | BOUNCE_MBF,
 
@@ -1376,7 +1377,7 @@ public:
 	DVector3 PosRelative(int grp) const;
 	DVector3 PosRelative(const AActor *other) const;
 	DVector3 PosRelative(sector_t *sec) const;
-	DVector3 PosRelative(line_t *line) const;
+	DVector3 PosRelative(const line_t *line) const;
 
 	FVector3 SoundPos() const
 	{

--- a/src/actorinlines.h
+++ b/src/actorinlines.h
@@ -20,7 +20,7 @@ inline DVector3 AActor::PosRelative(sector_t *sec) const
 	return Pos() + level.Displacements.getOffset(Sector->PortalGroup, sec->PortalGroup);
 }
 
-inline DVector3 AActor::PosRelative(line_t *line) const
+inline DVector3 AActor::PosRelative(const line_t *line) const
 {
 	return Pos() + level.Displacements.getOffset(Sector->PortalGroup, line->frontsector->PortalGroup);
 }

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -38,6 +38,7 @@
 #include "doomdata.h"
 #include "g_level.h"
 #include "r_defs.h"
+#include "r_sky.h"
 #include "portal.h"
 #include "p_blockmap.h"
 #include "p_local.h"
@@ -317,4 +318,11 @@ inline line_t *line_t::getPortalDestination() const
 inline int line_t::getPortalAlignment() const
 {
 	return portalindex >= level.linePortals.Size() ? 0 : level.linePortals[portalindex].mAlign;
+}
+
+inline bool line_t::hitSkyWall(AActor* mo) const
+{
+	return backsector &&
+		backsector->GetTexture(sector_t::ceiling) == skyflatnum &&
+		mo->Z() >= backsector->ceilingplane.ZatPoint(mo->PosRelative(this));
 }

--- a/src/p_map.cpp
+++ b/src/p_map.cpp
@@ -3551,9 +3551,9 @@ bool FSlide::BounceWall(AActor *mo)
 	}
 	line = bestslideline;
 
-	if (line->special == Line_Horizon)
+	if (line->special == Line_Horizon || (mo->BounceFlags & BOUNCE_NotOnSky) && line->hitSkyWall(mo))
 	{
-		mo->SeeSound = 0;	// it might make a sound otherwise
+		mo->SeeSound = mo->BounceSound = 0;	// it might make a sound otherwise
 		mo->Destroy();
 		return true;
 	}

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -2178,15 +2178,27 @@ bool AActor::FloorBounceMissile (secplane_t &plane)
 		}
 	}
 
+	bool onsky;
+
 	if (plane.fC() < 0)
 	{ // on ceiling
 		if (!(BounceFlags & BOUNCE_Ceilings))
 			return true;
+
+		onsky = ceilingpic == skyflatnum;
 	}
 	else
 	{ // on floor
 		if (!(BounceFlags & BOUNCE_Floors))
 			return true;
+
+		onsky = floorpic == skyflatnum;
+	}
+
+	if (onsky && (BounceFlags & BOUNCE_NotOnSky))
+	{
+		Destroy();
+		return true;
 	}
 
 	// The amount of bounces is limited
@@ -2751,10 +2763,7 @@ double P_XYMovement (AActor *mo, DVector2 scroll)
 explode:
 				// explode a missile
 				bool onsky = false;
-				if (tm.ceilingline &&
-					tm.ceilingline->backsector &&
-					tm.ceilingline->backsector->GetTexture(sector_t::ceiling) == skyflatnum &&
-					mo->Z() >= tm.ceilingline->backsector->ceilingplane.ZatPoint(mo->PosRelative(tm.ceilingline)))
+				if (tm.ceilingline && tm.ceilingline->hitSkyWall(mo))
 				{
 					if (!(mo->flags3 & MF3_SKYEXPLODE))
 					{

--- a/src/r_defs.h
+++ b/src/r_defs.h
@@ -1393,6 +1393,7 @@ struct line_t
 	inline bool isVisualPortal() const;
 	inline line_t *getPortalDestination() const;
 	inline int getPortalAlignment() const;
+	inline bool hitSkyWall(AActor* mo) const;
 
 	int Index() const;
 };

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -360,6 +360,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG2(BOUNCE_UseBounceState, USEBOUNCESTATE, AActor, BounceFlags),
 	DEFINE_FLAG2(BOUNCE_NotOnShootables, DONTBOUNCEONSHOOTABLES, AActor, BounceFlags),
 	DEFINE_FLAG2(BOUNCE_BounceOnUnrips, BOUNCEONUNRIPPABLES, AActor, BounceFlags),
+	DEFINE_FLAG2(BOUNCE_NotOnSky, DONTBOUNCEONSKY, AActor, BounceFlags),
 };
 
 // These won't be accessible through bitfield variables


### PR DESCRIPTION
While I agree with Graf that projectiles bouncing off skies [makes more sense in Doom than it's supposed to](https://forum.zdoom.org/viewtopic.php?p=400704#p400704), there are still some cases where it looks wierd. A prime example is weapon casings: their movement doesn't affect gameplay, and it would make a lot more sense if they disappeared when hitting sky surfaces instead of bouncing off them.

Therefore, I've implemented a new bounce flag: DONTBOUNCEONSKY. By default, it is disabled, of course, to preserve current behavior. Enabling this flag will make any bouncing object disappear when hitting a sky floor, ceiling or wall (provided it handles bouncing off surfaces of the corresponding type).

Technical details:
- When a bouncing object is destroyed after hitting a sky wall or a horizon wall, the object's BounceSound as well as its SeeSound are now cleared. Previously, BounceSound wasn't cleared when hitting a horizon line. This is probably a bug, especially considering the comment: "it might make a sound otherwise".
- There is currently no SKYEXPLODE handling for bouncers with the new flag. This is consistent with how Line_Horizon is currently handled by bouncing objects. For normal missiles, SKYEXPLODE works both for skies and horizons, and for bouncing objects it should work the same (if implemented). However, this would constitute a change in the current behavior, that's why I haven't implemented it.
- I've moved the logic that determines whether an actor has hit a sky wall to an inline method in `line_t`. I'm not sure if this is the best place for it. This can be changed if necessary; my original intention was to avoid code duplication (since `FSlide::BounceWall` doesn't necessarily use the same line that `P_TryMove` returns during execution of `P_XYMovement`, it needs to be calculated both in `P_XYMovement` and in `FSlide::BounceWall`).
- Please correct me if I've put the checks in the wrong place (especially in `AActor::FloorBounceMissile`). The movement code is very complicated. However, existing movement behavior should not be affected in any way if the new flag is not used.