### PR TITLE
Add Species to all default keys

### DIFF
--- a/wadsrc/static/zscript/chex/chexkeys.txt
+++ b/wadsrc/static/zscript/chex/chexkeys.txt
@@ -5,6 +5,7 @@ class ChexBlueCard : BlueCard
 	Default
 	{
 		inventory.pickupmessage "$GOTCBLUEKEY";
+		Species "ChexBlueCard";
 	}
 }
 
@@ -13,6 +14,7 @@ class ChexYellowCard : YellowCard
 	Default
 	{
 		inventory.pickupmessage "$GOTCYELLOWKEY";
+		Species "ChexYellowCard";
 	}
 }
 
@@ -21,5 +23,6 @@ class ChexRedCard : RedCard
 	Default
 	{
 		inventory.pickupmessage "$GOTCREDKEY";
+		Species "ChexRedCard";
 	}
 }

--- a/wadsrc/static/zscript/doom/doomkeys.txt
+++ b/wadsrc/static/zscript/doom/doomkeys.txt
@@ -17,6 +17,7 @@ class BlueCard : DoomKey
 	{
 		Inventory.Pickupmessage "$GOTBLUECARD";
 		Inventory.Icon "STKEYS0";
+		Species "BlueCard";
 	}
 	States
 	{
@@ -35,6 +36,7 @@ class YellowCard : DoomKey
 	{
 		Inventory.Pickupmessage "$GOTYELWCARD";
 		Inventory.Icon "STKEYS1";
+		Species "YellowCard";
 	}
 	States
 	{
@@ -53,6 +55,7 @@ class RedCard : DoomKey
 	{
 		Inventory.Pickupmessage "$GOTREDCARD";
 		Inventory.Icon "STKEYS2";
+		Species "RedCard";
 	}
 	States
 	{
@@ -71,6 +74,7 @@ class BlueSkull : DoomKey
 	{
 		Inventory.Pickupmessage "$GOTBLUESKUL";
 		Inventory.Icon "STKEYS3";
+		Species "BlueSkull";
 	}
 	States
 	{
@@ -89,6 +93,7 @@ class YellowSkull : DoomKey
 	{
 		Inventory.Pickupmessage "$GOTYELWSKUL";
 		Inventory.Icon "STKEYS4";
+		Species "YellowSkull";
 	}
 	States
 	{
@@ -107,6 +112,7 @@ class RedSkull : DoomKey
 	{
 		Inventory.Pickupmessage "$GOTREDSKUL";
 		Inventory.Icon "STKEYS5";
+		Species "RedSkull";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/heretic/heretickeys.txt
+++ b/wadsrc/static/zscript/heretic/heretickeys.txt
@@ -17,6 +17,7 @@ Class KeyGreen : HereticKey
 	{
 		Inventory.PickupMessage "$TXT_GOTGREENKEY";
 		Inventory.Icon "GKEYICON";
+		Species "KeyGreen";
 	}
 	States
 	{
@@ -34,6 +35,7 @@ Class KeyBlue : HereticKey
 	{
 		Inventory.PickupMessage "$TXT_GOTBLUEKEY";
 		Inventory.Icon "BKEYICON";
+		Species "KeyBlue";
 	}
 	States
 	{
@@ -51,6 +53,7 @@ Class KeyYellow : HereticKey
 	{
 		Inventory.PickupMessage "$TXT_GOTYELLOWKEY";
 		Inventory.Icon "YKEYICON";
+		Species "KeyYellow";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/hexen/hexenkeys.txt
+++ b/wadsrc/static/zscript/hexen/hexenkeys.txt
@@ -14,6 +14,7 @@ class KeySteel : HexenKey
 	{
 		Inventory.Icon "KEYSLOT1";
 		Inventory.PickupMessage "$TXT_KEY_STEEL";
+		Species "KeySteel";
 	}
 	States
 	{
@@ -29,6 +30,7 @@ class KeyCave : HexenKey
 	{
 		Inventory.Icon "KEYSLOT2";
 		Inventory.PickupMessage "$TXT_KEY_CAVE";
+		Species "KeyCave";
 	}
 	States
 	{
@@ -44,6 +46,7 @@ class KeyAxe : HexenKey
 	{
 		Inventory.Icon "KEYSLOT3";
 		Inventory.PickupMessage "$TXT_KEY_AXE";
+		Species "KeyAxe";
 	}
 	States
 	{
@@ -59,6 +62,7 @@ class KeyFire : HexenKey
 	{
 		Inventory.Icon "KEYSLOT4";
 		Inventory.PickupMessage "$TXT_KEY_FIRE";
+		Species "KeyFire";
 	}
 	States
 	{
@@ -74,6 +78,7 @@ class KeyEmerald : HexenKey
 	{
 		Inventory.Icon "KEYSLOT5";
 		Inventory.PickupMessage "$TXT_KEY_EMERALD";
+		Species "KeyEmerald";
 	}
 	States
 	{
@@ -89,6 +94,7 @@ class KeyDungeon : HexenKey
 	{
 		Inventory.Icon "KEYSLOT6";
 		Inventory.PickupMessage "$TXT_KEY_DUNGEON";
+		Species "KeyDungeon";
 	}
 	States
 	{
@@ -104,6 +110,7 @@ class KeySilver : HexenKey
 	{
 		Inventory.Icon "KEYSLOT7";
 		Inventory.PickupMessage "$TXT_KEY_SILVER";
+		Species "KeySilver";
 	}
 	States
 	{
@@ -119,6 +126,7 @@ class KeyRusted : HexenKey
 	{
 		Inventory.Icon "KEYSLOT8";
 		Inventory.PickupMessage "$TXT_KEY_RUSTED";
+		Species "KeyRusted";
 	}
 	States
 	{
@@ -134,6 +142,7 @@ class KeyHorn : HexenKey
 	{
 		Inventory.Icon "KEYSLOT9";
 		Inventory.PickupMessage "$TXT_KEY_HORN";
+		Species "KeyHorn";
 	}
 	States
 	{
@@ -149,6 +158,7 @@ class KeySwamp : HexenKey
 	{
 		Inventory.Icon "KEYSLOTA";
 		Inventory.PickupMessage "$TXT_KEY_SWAMP";
+		Species "KeySwamp";
 	}
 	States
 	{
@@ -164,6 +174,7 @@ class KeyCastle : HexenKey
 	{
 		Inventory.Icon "KEYSLOTB";
 		Inventory.PickupMessage "$TXT_KEY_CASTLE";
+		Species "KeyCastle";
 	}
 	States
 	{

--- a/wadsrc/static/zscript/strife/strifekeys.txt
+++ b/wadsrc/static/zscript/strife/strifekeys.txt
@@ -18,6 +18,7 @@ class BaseKey : StrifeKey
 		Inventory.Icon "I_FUSL";
 		Tag "$TAG_BASEKEY";
 		Inventory.PickupMessage "$TXT_BASEKEY";
+		Species "BaseKey";
 	}
 	States
 	{
@@ -37,6 +38,7 @@ class GovsKey : StrifeKey
 		Inventory.Icon "I_REBL";
 		Tag "$TAG_GOVSKEY";
 		Inventory.PickupMessage "$TXT_GOVSKEY";
+		Species "GovsKey";
 	}
 	States
 	{
@@ -56,6 +58,7 @@ class Passcard : StrifeKey
 		Inventory.Icon "I_TPAS";
 		Tag "$TAG_PASSCARD";
 		Inventory.PickupMessage "$TXT_PASSCARD";
+		Species "Passcard";
 	}
 	States
 	{
@@ -75,6 +78,7 @@ class IDBadge : StrifeKey
 		Inventory.Icon "I_CRD1";
 		Tag "$TAG_IDBADGE";
 		Inventory.PickupMessage "$TXT_IDBADGE";
+		Species "IDBadge";
 	}
 	States
 	{
@@ -95,6 +99,7 @@ class PrisonKey : StrifeKey
 		Tag "$TAG_PRISONKEY";
 		Inventory.GiveQuest 11;
 		Inventory.PickupMessage "$TXT_PRISONKEY";
+		Species "PrisonKey";
 	}
 	States
 	{
@@ -115,6 +120,7 @@ class SeveredHand : StrifeKey
 		Tag "$TAG_SEVEREDHAND";
 		Inventory.GiveQuest 12;
 		Inventory.PickupMessage "$TXT_SEVEREDHAND";
+		Species "SeveredHand";
 	}
 	States
 	{
@@ -134,6 +140,7 @@ class Power1Key : StrifeKey
 		Inventory.Icon "I_PWR1";
 		Tag "$TAG_POWER1KEY";
 		Inventory.PickupMessage "$TXT_POWER1KEY";
+		Species "Power1Key";
 	}
 	States
 	{
@@ -153,6 +160,7 @@ class Power2Key : StrifeKey
 		Inventory.Icon "I_PWR2";
 		Tag "$TAG_POWER2KEY";
 		Inventory.PickupMessage "$TXT_POWER2KEY";
+		Species "Power2Key";
 	}
 	States
 	{
@@ -172,6 +180,7 @@ class Power3Key : StrifeKey
 		Inventory.Icon "I_PWR3";
 		Tag "$TAG_POWER3KEY";
 		Inventory.PickupMessage "$TXT_POWER3KEY";
+		Species "Power3Key";
 	}
 	States
 	{
@@ -191,6 +200,7 @@ class GoldKey : StrifeKey
 		Inventory.Icon "I_KY1G";
 		Tag "$TAG_GOLDKEY";
 		Inventory.PickupMessage "$TXT_GOLDKEY";
+		Species "GoldKey";
 	}
 	States
 	{
@@ -210,6 +220,7 @@ class IDCard : StrifeKey
 		Inventory.Icon "I_CRD2";
 		Tag "$TAG_IDCARD";
 		Inventory.PickupMessage "$TXT_IDCARD";
+		Species "IDCard";
 	}
 	States
 	{
@@ -229,6 +240,7 @@ class SilverKey : StrifeKey
 		Inventory.Icon "I_KY2S";
 		Tag "$TAG_SILVERKEY";
 		Inventory.PickupMessage "$TXT_SILVERKEY";
+		Species "SilverKey";
 	}
 	States
 	{
@@ -248,6 +260,7 @@ class OracleKey : StrifeKey
 		Inventory.Icon "I_ORAC";
 		Tag "$TAG_ORACLEKEY";
 		Inventory.PickupMessage "$TXT_ORACLEKEY";
+		Species "OracleKey";
 	}
 	States
 	{
@@ -267,6 +280,7 @@ class MilitaryID : StrifeKey
 		Inventory.Icon "I_GYID";
 		Tag "$TAG_MILITARYID";
 		Inventory.PickupMessage "$TXT_MILITARYID";
+		Species "MilitaryID";
 	}
 	States
 	{
@@ -286,6 +300,7 @@ class OrderKey : StrifeKey
 		Inventory.Icon "I_FUBR";
 		Tag "$TAG_ORDERKEY";
 		Inventory.PickupMessage "$TXT_ORDERKEY";
+		Species "OrderKey";
 	}
 	States
 	{
@@ -305,6 +320,7 @@ class WarehouseKey : StrifeKey
 		Inventory.Icon "I_WARE";
 		Tag "$TAG_WAREHOUSEKEY";
 		Inventory.PickupMessage "$TXT_WAREHOUSEKEY";
+		Species "WarehouseKey";
 	}
 	States
 	{
@@ -324,6 +340,7 @@ class BrassKey : StrifeKey
 		Inventory.Icon "I_KY3B";
 		Tag "$TAG_BRASSKEY";
 		Inventory.PickupMessage "$TXT_BRASSKEY";
+		Species "BrassKey";
 	}
 	States
 	{
@@ -343,6 +360,7 @@ class RedCrystalKey : StrifeKey
 		Inventory.Icon "I_RCRY";
 		Tag "$TAG_REDCRYSTALKEY";
 		Inventory.PickupMessage "$TXT_REDCRYSTAL";
+		Species "RedCrystalKey";
 	}
 	States
 	{
@@ -362,6 +380,7 @@ class BlueCrystalKey : StrifeKey
 		Inventory.Icon "I_BCRY";
 		Tag "$TAG_BLUECRYSTALKEY";
 		Inventory.PickupMessage "$TXT_BLUECRYSTAL";
+		Species "BlueCrystalKey";
 	}
 	States
 	{
@@ -381,6 +400,7 @@ class ChapelKey : StrifeKey
 		Inventory.Icon "I_CHAP";
 		Tag "$TAG_CHAPELKEY";
 		Inventory.PickupMessage "$TXT_CHAPELKEY";
+		Species "ChapelKey";
 	}
 	States
 	{
@@ -401,6 +421,7 @@ class CatacombKey : StrifeKey
 		Tag "$TAG_CATACOMBKEY";
 		Inventory.GiveQuest 28;
 		Inventory.PickupMessage "$TXT_CATACOMBKEY";
+		Species "CatacombKey";
 	}
 	States
 	{
@@ -420,6 +441,7 @@ class SecurityKey : StrifeKey
 		Inventory.Icon "I_SECK";
 		Tag "$TAG_SECURITYKEY";
 		Inventory.PickupMessage "$TXT_SECURITYKEY";
+		Species "SecurityKey";
 	}
 	States
 	{
@@ -439,6 +461,7 @@ class CoreKey : StrifeKey
 		Inventory.Icon "I_GOID";
 		Tag "$TAG_COREKEY";
 		Inventory.PickupMessage "$TXT_COREKEY";
+		Species "CoreKey";
 	}
 	States
 	{
@@ -458,6 +481,7 @@ class MaulerKey : StrifeKey
 		Inventory.Icon "I_BLTK";
 		Tag "$TAG_MAULERKEY";
 		Inventory.PickupMessage "$TXT_MAULERKEY";
+		Species "MaulerKey";
 	}
 	States
 	{
@@ -477,6 +501,7 @@ class FactoryKey : StrifeKey
 		Inventory.Icon "I_PROC";
 		Tag "$TAG_FACTORYKEY";
 		Inventory.PickupMessage "$TXT_FACTORYKEY";
+		Species "FactoryKey";
 	}
 	States
 	{
@@ -496,6 +521,7 @@ class MineKey : StrifeKey
 		Inventory.Icon "I_MINE";
 		Tag "$TAG_MINEKEY";
 		Inventory.PickupMessage "$TXT_MINEKEY";
+		Species "MineKey";
 	}
 	States
 	{
@@ -515,6 +541,7 @@ class NewKey5 : StrifeKey
 		Inventory.Icon "I_BLTK";
 		Tag "$TAG_NEWKEY5";
 		Inventory.PickupMessage "$TXT_NEWKEY5";
+		Species "NewKey5";
 	}
 	States
 	{


### PR DESCRIPTION
Adding Species to all default keys to make APROP_Species useful when using inheritance to create new keys. Very helpful when trying to make mods that work with other mods that create their own versions of default keys (KDIZD is a prime example.) Found that adding the Species descriptor to default keys allows me to make other mods like Smooth Doom and Beautiful Doom, etc. that change keys - work with the built in map scripting of mods like KDIZD, specifically like in map Z1M9 where it depends on checking for the default keys before opening certain doors.