### PR TITLE
Fixes for RemoveInventory and CheckAddToSlots

### DIFF
--- a/wadsrc/static/zscript/actor_inventory.txt
+++ b/wadsrc/static/zscript/actor_inventory.txt
@@ -122,11 +122,11 @@ extend class Actor
 					if (invp.Inv == item)
 					{
 						invp.Inv = item.Inv;
-						item.DetachFromOwner();
 						break;
 					}
 				}
 			}
+			item.DetachFromOwner();
 			item.Owner = NULL;
 			item.Inv = NULL;
 		}

--- a/wadsrc/static/zscript/inventory/weapons.txt
+++ b/wadsrc/static/zscript/inventory/weapons.txt
@@ -119,7 +119,7 @@ class Weapon : StateProvider
 	
 	virtual int, int CheckAddToSlots()
 	{
-		if (GetReplacement(GetClass()) == null && !bPowered_Up)
+		if (GetReplacement(GetClass()) == GetClass() && !bPowered_Up)
 		{
 			return SlotNumber, SlotPriority*65536;
 		}


### PR DESCRIPTION
RemoveInventory wasn't calling DetachFromOwner when the removed item is the first in the actor's inventory.

CheckAddToSlots used GetReplacement incorrectly (no replacement returns the input class, not null).