### PR TITLE
ZScript monster AI exports

### DIFF
--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1422,6 +1422,35 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, LookForPlayers, P_LookForPlayers)
 	ACTION_RETURN_BOOL(P_LookForPlayers(self, allaround, params));
 }
 
+static int CheckMonsterUseSpecials(AActor *self)
+{
+	spechit_t spec;
+	int good = 0;
+
+	if (!(self->flags6 & MF6_NOTRIGGER))
+	{
+		while (spechit.Pop (spec))
+		{
+			// [RH] let monsters push lines, as well as use them
+			if (((self->flags4 & MF4_CANUSEWALLS) && P_ActivateLine (spec.line, self, 0, SPAC_Use)) ||
+				((self->flags2 & MF2_PUSHWALL) && P_ActivateLine (spec.line, self, 0, SPAC_Push)))
+			{
+				good |= spec.line == self->BlockingLine ? 1 : 2;
+			}
+		}
+	}
+	else spechit.Clear();
+
+	return good;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(AActor, CheckMonsterUseSpecials, CheckMonsterUseSpecials)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+
+	ACTION_RETURN_INT(CheckMonsterUseSpecials(self));
+}
+
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_Wander, A_Wander)
 {
 	PARAM_SELF_PROLOGUE(AActor);

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1582,6 +1582,37 @@ DEFINE_ACTION_FUNCTION_NATIVE(AKey, GetKeyType, P_GetKeyType)
 	ACTION_RETURN_POINTER(P_GetKeyType(num));
 }
 
+//=====================================================================================
+//
+// 3D Floor exports
+//
+//=====================================================================================
+int CheckFor3DFloorHit(AActor *self, double z, bool trigger)
+{
+	return P_CheckFor3DFloorHit(self, z, trigger);
+}
+DEFINE_ACTION_FUNCTION_NATIVE(AActor, CheckFor3DFloorHit, CheckFor3DFloorHit)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_FLOAT(z);
+	PARAM_BOOL(trigger);
+
+	ACTION_RETURN_BOOL(P_CheckFor3DFloorHit(self, z, trigger));
+}
+
+int CheckFor3DCeilingHit(AActor *self, double z, bool trigger)
+{
+	return P_CheckFor3DCeilingHit(self, z, trigger);
+}
+DEFINE_ACTION_FUNCTION_NATIVE(AActor, CheckFor3DCeilingHit, CheckFor3DCeilingHit)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_FLOAT(z);
+	PARAM_BOOL(trigger);
+
+	ACTION_RETURN_BOOL(P_CheckFor3DCeilingHit(self, z, trigger));
+}
+
 
 
 DEFINE_FIELD(AActor, snext)

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -625,6 +625,8 @@ class Actor : Thinker native
 	native clearscope Actor GetPointer(int aaptr);
 	native double BulletSlope(out FTranslatedLineTarget pLineTarget = null, int aimflags = 0);
 	native void CheckFakeFloorTriggers (double oldz, bool oldz_has_viewheight = false);
+	native bool CheckFor3DFloorHit(double z, bool trigger);
+	native bool CheckFor3DCeilingHit(double z, bool trigger);
 	
 	native bool CheckMissileSpawn(double maxdist);
 	native bool CheckPosition(Vector2 pos, bool actorsonly = false, FCheckPosition tm = null);

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -627,6 +627,7 @@ class Actor : Thinker native
 	native void CheckFakeFloorTriggers (double oldz, bool oldz_has_viewheight = false);
 	native bool CheckFor3DFloorHit(double z, bool trigger);
 	native bool CheckFor3DCeilingHit(double z, bool trigger);
+	native int CheckMonsterUseSpecials();
 	
 	native bool CheckMissileSpawn(double maxdist);
 	native bool CheckPosition(Vector2 pos, bool actorsonly = false, FCheckPosition tm = null);


### PR DESCRIPTION
Exports P_CheckFor3DFloorHit and P_CheckFor3DCeilingHit to ZScript, and adds a function for triggering monster use/push specials to circumvent not being able to access the spechit array when writing custom monster AI.