### PR TITLE
DamageMobj Refactor

### DIFF
--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -663,6 +663,7 @@ class Actor : Thinker native
 
 	native void SetIdle(bool nofunction = false);
 	native bool CheckMeleeRange();
+	native bool TriggerPainChance(Name mod, bool forcedPain = false);
 	native virtual int DamageMobj(Actor inflictor, Actor source, int damage, Name mod, int flags = 0, double angle = 0);
 	native void PoisonMobj (Actor inflictor, Actor source, int damage, int duration, int period, Name type);
 	native double AimLineAttack(double angle, double distance, out FTranslatedLineTarget pLineTarget = null, double vrange = 0., int flags = 0, Actor target = null, Actor friender = null);


### PR DESCRIPTION
Splits off all state modifications into its own function, ReactToDamage. Pain states themselves are exclusively in their own function, **TriggerPainState(Name mod, bool forcePain = false).**

Further modifies DamageMobj to return -1 if all effects are cancelled. All functions that aren't dealing with the virtual have their values clamped to 0.

_I will not squash the commits unless I'm given the green light and all changes are finalized. This will allow people to read my changes more easily. Thank you for understanding._