### PR TITLE
Export P_GetOffsetPosition and ADynamicLight::SetOffset to ZScript

### DIFF
--- a/src/g_shared/a_dynlight.cpp
+++ b/src/g_shared/a_dynlight.cpp
@@ -426,6 +426,20 @@ void ADynamicLight::SetOffset(const DVector3 &pos)
 	UpdateLocation();
 }
 
+static void SetOffset(ADynamicLight *self, const DVector3 &pos)
+{
+	self->SetOffset(pos);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(ADynamicLight, SetOffset, SetOffset)
+{
+	PARAM_SELF_PROLOGUE(ADynamicLight)
+	PARAM_FLOAT(x)
+	PARAM_FLOAT(y)
+	PARAM_FLOAT(z)
+	self->SetOffset(DVector3(x, y, z));
+	return 0;
+}
 
 //==========================================================================
 //

--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -820,6 +820,20 @@ DVector2 P_GetOffsetPosition(double x, double y, double dx, double dy)
 	return dest;
 }
 
+static void GetOffsetPosition(double x, double y, double dx, double dy, DVector2 *result)
+{
+	*result = P_GetOffsetPosition(x, y, dx, dy);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(DObject, GetOffsetPosition, GetOffsetPosition)
+{
+	PARAM_PROLOGUE;
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	PARAM_FLOAT(dx);
+	PARAM_FLOAT(dy);
+	ACTION_RETURN_VEC2(P_GetOffsetPosition(x, y, dx, dy));
+}
 
 //============================================================================
 //

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -406,6 +406,8 @@ class Object native
 	native static uint MSTime();
 	native vararg static void ThrowAbortException(String fmt, ...);
 
+	native static Vector2 GetOffsetPosition(double x, double y, double dx, double dy);
+
 	native virtualscope void Destroy();
 
 	// This does not call into the native method of the same name to avoid problems with objects that get garbage collected late on shutdown.

--- a/wadsrc/static/zscript/shared/dynlights.txt
+++ b/wadsrc/static/zscript/shared/dynlights.txt
@@ -28,7 +28,9 @@ class DynamicLight : Actor native
 		ColorFlickerLight, 
 		RandomColorFlickerLight
 	};
-	
+
+	native void SetOffset(Vector3 offset);
+
 	Default
 	{
 		Height 0;


### PR DESCRIPTION
Exports to ZScript:
1. P_GetOffsetPosition: Useful for people writing their own functions utilizing LineTrace to spawn objects.
2. ADynamicLight::SetOffset: Useful for people wanting to set offsets for Actor-Based Dynlights.