### PR TITLE
Fix the unreachable soulsphere in Alien Vendetta MAP28

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -1155,6 +1155,13 @@ class LevelCompatibility play
 				SetLineFlags(4884, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
+			
+			case '7FB847B522DE80D0B2A217E1EF8D1A15': // av.wad map28
+			{
+				// Fix the soulsphere in a secret area (sector 324)
+				// so that it doesn't end up in an unreachable position.
+				SetThingXY(516, -934, 48);
+			}
 		}
 	}
 


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?f=7&t=27107). The problem is that the soulsphere's center is directly between two sectors with different heights, and in GZDoom it ends up in the wrong sector, which makes it unreachable without cheating. This PR moves the soulsphere to the center of the sector where it should be in, thus making it reachable again.

I can also fix this for the old version of this map, if I can find the first release of AV. If you want me to do that, I will modify the PR to include the old map's checksum also.