### PR TITLE
Fix weapon switch not working if there is a PendingWeapon

### DIFF
--- a/wadsrc/static/zscript/shared/player.txt
+++ b/wadsrc/static/zscript/shared/player.txt
@@ -1924,7 +1924,11 @@ class PlayerPawn : Actor native
 		let ReadyWeapon = player.ReadyWeapon;
 		if (player.PendingWeapon != WP_NOCHANGE)
 		{
-			return player.weapons.LocateWeapon(player.PendingWeapon.GetClass());
+			bool found;
+			int slot;
+			int index;
+			[found, slot, index] = player.weapons.LocateWeapon(player.PendingWeapon.GetClass());
+			return found, slot, index;
 		}
 		else if (ReadyWeapon != null)
 		{


### PR DESCRIPTION
Then again, the real issue might be the ZScript compiler or VM being [unable to recursively return](https://forum.zdoom.org/viewtopic.php?f=2&t=62965) multiple values.