### PR TITLE
Fix for NOFRICTION when flying

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -2530,9 +2530,13 @@ void P_ZMovement (AActor *mo, double oldfloorz)
 		{
 			mo->AddZ(DAngle(360 / 80.f * level.maptime).Sin() / 8);
 		}
-		mo->Vel.Z *= FRICTION_FLY;
+
+		if (!(mo->flags8 & MF8_NOFRICTION))
+		{
+			mo->Vel.Z *= FRICTION_FLY;
+		}
 	}
-	if (mo->waterlevel && !(mo->flags & MF_NOGRAVITY))
+	if (mo->waterlevel && !(mo->flags & MF_NOGRAVITY) && !(mo->flags8 & MF8_NOFRICTION))
 	{
 		double friction = -1;
 


### PR DESCRIPTION
I screwed up with NOFRICTION - it doesn't apply to Z velocity when flying or swimming, and somehow I didn't notice it when testing.

That's dealt with now, but to avoid doing this a third time, are there any corner cases where friction (or strange speed caps, like the crouching/underwater speed caps in P_XYMovement) applies? I've tested running around, swimming through water, and flying (with `fly` and `noclip2`), all crouched and uncrouched.