### PR TITLE
Plutonia MAP16 pit fix

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -232,6 +232,15 @@ class LevelCompatibility play
 				break;
 			}
 			
+			case 'ECA0559E85EFFB6966ECB8DE01E3A35B': // Plutonia Experiment MAP16
+			{
+				// Have it so that the slime pit at the end of the level can
+				// actually kill the player.
+				SetSectorSpecial(95, 768);
+				SetSectorSpecial(96, 768);
+				break;
+			}
+			
 			case '9D84B423D8FD28553DDE23B55F97CF4A': // Plutonia Experiment MAP25
 			{
 				// Missing texture at level exit.


### PR DESCRIPTION
Alright, going with separate PRs, anyways Plutonia MAP16 has an ending pit that oddly has no effect so if you fall on it, it wouldn't kill you. This change is just so it can instead of just trapping you with no way of getting out.
![pl16_pit](https://user-images.githubusercontent.com/35357202/50489296-cb613780-09fe-11e9-9fd3-b48ce4c00ee4.png)
