### PR TITLE
DOOM.WAD fixes

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -353,6 +353,10 @@ class LevelCompatibility play
 				SetWallTexture(865, Line.back, Side.bottom, "STEP5");
 				SetWallTexture(1062, Line.front, Side.top, "GSTVINE1");
 				SetWallTexture(1071, Line.front, Side.top, "MARBLE1");
+				// Door requiring yellow keycard can only be opened once,
+				// change other side to one-shot Door_Open
+				SetLineSpecial(165, Door_Open, 0, 16);
+				SetLineFlags(165, 0, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 			
@@ -362,6 +366,11 @@ class LevelCompatibility play
 				SetWallTexture(590, Line.back, Side.top, "GRAYBIG");
 				SetWallTexture(590, Line.front, Side.bottom, "BROWN1");
 				SetWallTexture(1027, Line.back, Side.top, "SP_HOT1");
+				// Replace tag for eastern secret at level start to not
+				// cause any action to the two-Baron trap
+				AddSectorTag(127, 100);
+				SetLineSpecial(382, Door_Open, 100, 16);
+				SetLineSpecial(388, Door_Open, 100, 16);
 				break;
 			}
 			
@@ -385,6 +394,13 @@ class LevelCompatibility play
 				SetWallTexture(121, Line.back, Side.top, "SW1LION");
 				SetWallTexture(123, Line.back, Side.top, "GSTONE1");
 				SetWallTexture(140, Line.back, Side.top, "GSTONE1");
+				break;
+			}
+			
+			case 'BBDC4253AE277DA5FCE2F19561627496': // Doom E3M2
+			{
+				// Switch at index finger repeatable in case of being stuck
+				SetLineFlags(368, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 			
@@ -423,14 +439,29 @@ class LevelCompatibility play
 			
 			case 'FE97DCB9E6235FB3C52AE7C143160D73': // Doom E3M9
 			{
-				// Missing texture
+				// Missing textures
 				SetWallTexture(102, Line.back, Side.bottom, "STONE3");
+				SetWallTexture(445, Line.back, Side.bottom, "GRAY4");
+				// First door cannot be opened from inside and can stop you
+				// from finishing the level if somehow locked in.
+				SetLineSpecial(24, Door_Open, 0, 16);
+				SetLineActivation(24, SPAC_Use);
+				SetLineFlags(24, Line.ML_REPEAT_SPECIAL);
+				// Door that requires blue skull can only be opened once,
+				// make it repeatable in case of being locked
+				SetLineFlags(194, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 			
 			case 'DA0C8281AC70EEC31127C228BCD7FE2C': // doom.wad e4m1
 			{
-				// missing texture
+				// missing textures
+				TextureID support3 = TexMan.CheckForTexture("SUPPORT3", TexMan.Type_Wall);
+				for(int i=0; i<4; i++)
+				{
+					SetWallTextureID(252+i, Line.back, Side.top, SUPPORT3);
+				}
+				SetWallTexture(322, Line.back, Side.bottom, "GSTONE1");
 				SetWallTexture(470, Line.front, Side.top, "GSTONE1");
 				break;
 			}
@@ -466,6 +497,13 @@ class LevelCompatibility play
 				SetSectorSpecial(151, 0);
 				SetSectorSpecial(152, 0);
 				SetSectorSpecial(155, 0);
+				// Stuck Imp
+				SetThingXY(69, -656, -1696);
+				// One line special at the northern lifts is incorrect, change
+				// to a repeatable line you can walk over to lower lift
+				SetLineSpecial(46, Plat_DownWaitUpStayLip, 1, 32, 105, 0);
+				SetLineActivation(46, SPAC_AnyCross);
+				SetLineFlags(46, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 			


### PR DESCRIPTION
E2M4: The yellow key door has one side with a repeatable Door_Raise action, so if the door was lowered from there, you can't open the door again from the yellow key side since it's a one-shot Door_Open action. The other side has been changed to also be a one-shot Door_Open action.
E2M5: The left secret from the map start is tagged with the two-Baron trap, so if the lines for this secret were activated after crossing the line for the Baron trap, this can cause the ceilings of the Baron trap to lower for some odd reason. Changed the tags of the lines to fix this.
E3M2: Switch at index finger can only be used once so if used before the door finished closing, you can be trap here. Changed to a repeatable action.
E3M9: First door cannot be opened from inside, so have it where you can open it from there if locked in. Have the blue key door repeatable since the other side is a repeatable Door_Raise action.
E4M3: One line has an incorrect action where instead of crossing it to lower the lift, it does nothing since it's a "shoot line to raise floor to next higher floor." Changed the action to be one where it would lower when either a player or monster crosses it.
![e4m3_lift](https://user-images.githubusercontent.com/35357202/50493213-fa35d880-0a13-11e9-96a9-b4879dcc27d2.png)
