### PR TITLE
Fix settings_controller not updating for new arbitrator

### DIFF
--- a/src/p_user.cpp
+++ b/src/p_user.cpp
@@ -1922,9 +1922,11 @@ void P_UnPredictPlayer ()
 
 		TObjPtr<AActor*> InvSel = act->InvSel;
 		int inventorytics = player->inventorytics;
+		const bool settings_controller = player->settings_controller;
 
 		*player = PredictionPlayerBackup;
 
+		player->settings_controller = settings_controller;
 		// Restore the camera instead of using the backup's copy, because spynext/prev
 		// could cause it to change during prediction.
 		player->camera = savedcamera;


### PR DESCRIPTION
This PR fixes [this bug](https://forum.zdoom.org/viewtopic.php?f=2&t=62968).

When a player is picked as the new arbitrator in a network session after the current one has disconnected, its settings_controller field is set to true. However, P_UnPredictPlayer causes it to be overwritten, and the player can't control settings even after they've become the arbitator. This PR fixes this issue by remembering the original value before the player instance is replaced with PredictionPlayerBackup and restoring it afterwards.