### PR TITLE
fix build on non-glibc users after introduction of JIT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1303,6 +1303,11 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
 	set( ZDOOM_LIBS ${ZDOOM_LIBS} nsl socket)
 endif()
 
+find_package( Backtrace )
+if(Backtrace_FOUND)
+	set( ZDOOM_LIBS ${ZDOOM_LIBS} ${Backtrace_LIBRARIES} )
+endif()
+
 target_link_libraries( zdoom ${ZDOOM_LIBS} gdtoa dumb lzma )
 
 include_directories( .


### PR DESCRIPTION
the backtrace functionality needs libexecinfo on non-glibc systems. Fix CMake
file to include it if needed by using cmake's Backtrace module.