### PR TITLE
 fix build on non-glibc users after introduction of JIT (take 2)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1303,6 +1303,13 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
 	set( ZDOOM_LIBS ${ZDOOM_LIBS} nsl socket)
 endif()
 
+if( UNIX )
+	find_package( Backtrace )
+	if(Backtrace_FOUND)
+		set( ZDOOM_LIBS ${ZDOOM_LIBS} ${Backtrace_LIBRARIES} )
+	endif()
+endif()
+
 target_link_libraries( zdoom ${ZDOOM_LIBS} gdtoa dumb lzma )
 
 include_directories( .


### PR DESCRIPTION
the new JIT code uses backtrace function which is defined in glibc. This causes problems on systems without backtrace implementations on their own c library like OpenBSD.

Cmake has bundled module to fix the issue. The module first looks if the backtrace is already defined, if it is it does nothing. Next it looks for execinfo library ( OpenBSD uses this ) and lastly does fallback on backtrace library.

Added check so the module is only used on Unix systems. I don't know how other systems behave, MacOSX seems to have backtrace in libc, so does GNU/Linux with glibc so it won't do anything on those nor on Windows systems.