### PR TITLE
Ensure consistent behavior when determining distinct ammo types

### DIFF
--- a/wadsrc/static/zscript/inventory/ammo.txt
+++ b/wadsrc/static/zscript/inventory/ammo.txt
@@ -249,11 +249,10 @@ class BackpackItem : Inventory
 		uint end = AllActorClasses.Size();
 		for (uint i = 0; i < end; ++i)
 		{
-			let type = AllActorClasses[i];
+			let ammotype = (class<Ammo>)(AllActorClasses[i]);
 
-			if (type.GetParentClass() == 'Ammo')
+			if (ammotype && GetDefaultByType(ammotype).GetParentAmmo() == ammotype)
 			{
-				let ammotype = (class<Ammo>)(type);
 				let ammoitem = Ammo(other.FindInventory(ammotype));
 				int amount = GetDefaultByType(ammotype).BackpackAmount;
 				// extra ammo in baby mode and nightmare mode
@@ -314,20 +313,22 @@ class BackpackItem : Inventory
 		{
 			for (let probe = Owner.Inv; probe != NULL; probe = probe.Inv)
 			{
-				if (probe.GetParentClass() == 'Ammo')
+				let ammoitem = Ammo(probe);
+
+				if (ammoitem && ammoitem.GetParentAmmo() == ammoitem.GetClass())
 				{
-					if (probe.Amount < probe.MaxAmount || sv_unlimited_pickup)
+					if (ammoitem.Amount < ammoitem.MaxAmount || sv_unlimited_pickup)
 					{
-						int amount = Ammo(probe).Default.BackpackAmount;
+						int amount = ammoitem.Default.BackpackAmount;
 						// extra ammo in baby mode and nightmare mode
 						if (!bIgnoreSkill)
 						{
 							amount = int(amount * G_SkillPropertyFloat(SKILLP_AmmoFactor));
 						}
-						probe.Amount += amount;
-						if (probe.Amount > probe.MaxAmount && !sv_unlimited_pickup)
+						ammoitem.Amount += amount;
+						if (ammoitem.Amount > ammoitem.MaxAmount && !sv_unlimited_pickup)
 						{
-							probe.Amount = probe.MaxAmount;
+							ammoitem.Amount = ammoitem.MaxAmount;
 						}
 					}
 				}

--- a/wadsrc/static/zscript/shared/player_cheat.txt
+++ b/wadsrc/static/zscript/shared/player_cheat.txt
@@ -99,14 +99,14 @@ extend class PlayerPawn
 			// he doesn't have it already, and set each to its maximum.
 			for (i = 0; i < AllActorClasses.Size(); ++i)
 			{
-				type = (class<Inventory>)(AllActorClasses[i]);
+				let ammotype = (class<Ammo>)(AllActorClasses[i]);
 
-				if (type != null && type.GetParentClass() == "Ammo")
+				if (ammotype && GetDefaultByType(ammotype).GetParentAmmo() == ammotype)
 				{
-					let ammoitem = FindInventory(type);
+					let ammoitem = FindInventory(ammotype);
 					if (ammoitem == NULL)
 					{
-						ammoitem = Inventory(Spawn (type));
+						ammoitem = Inventory(Spawn (ammotype));
 						ammoitem.AttachToOwner (self);
 						ammoitem.Amount = ammoitem.MaxAmount;
 					}


### PR DESCRIPTION
The problem: When Ammo::GetParentAmmo was made virtual, a potential inconsistency was introduced because there is still some code that considers any direct descendant of Ammo to be a distinct ammo type. This includes BackpackItem and the "give ammo" cheat handler in PlayerPawn::CheatGive.

This PR solves this issue by replacing parent class checks with calls to GetParentAmmo. It is logical to assume that an ammo class is a distinct ammo type if it returns itself as a result of a call to GetParentAmmo.

Granted, this won't work well if GetParentAmmo doesn't always return the same value for the same ammo class at all times, but that would probably be an error on the modder's part, as I don't see much sense in this kind of behavior.

I'm not entirely sure if this is all that needs to be fixed, but it looks like it. I've also run some tests to verify that everything works correctly. This includes a script file with a simple ammo class hierarchy where the base class features a GetParentAmmo override:

```
class MyBaseAmmo : Ammo
{
    override class<Ammo> GetParentAmmo()
    {
        class<Object> cls = GetClass();
        while (cls && cls.GetParentClass() != 'MyBaseAmmo')
        {
            cls = cls.GetParentClass();
        }
        
        return (class<Ammo>)(cls);
    }
}

class MyAmmo1 : MyBaseAmmo
{
    Default
    {
        Inventory.Amount 1;
        Inventory.MaxAmount 50;
        
        Ammo.BackpackAmount 1;
        Ammo.BackpackMaxAmount 100;
    }
}

class MyAmmo1Box : MyAmmo1
{
    Default
    {
        Inventory.Amount 10;
    }
}

class MyAmmo2 : MyBaseAmmo
{
    Default
    {
        Inventory.Amount 3;
        Inventory.MaxAmount 30;
        
        Ammo.BackpackAmount 3;
        Ammo.BackpackMaxAmount 60;
    }
}

class MyAmmo2Box : MyAmmo2
{
    Default
    {
        Inventory.Amount 9;
    }
}
```

With the current devbuild, using the IDFA cheat or picking up a backpack adds MyBaseAmmo to the player's inventory. This is definitely not expected behavior. With the fixed code, however, MyAmmo1 and MyAmmo2 are added instead. I've also subclassed them to make sure that subclasses are not added to the inventory.