### PR TITLE
CanPickupItem virtual

### DIFF
--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -462,8 +462,7 @@ class Actor : Thinker native
 	// {MC] Called by inventory TryPickup function to determine if this actor
 	// can pick it up. If touched is true, it was called by an inventory's
 	// Touch function. Otherwise, touched is false if called directly from
-	// CallTryPickup. Caution must be used here! Player starting items that
-	// return false when touched is false will throw a VM abort!
+	// CallTryPickup.
 
 	virtual bool CanPickupItem(Inventory item, bool touched = false)
 	{

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -459,6 +459,17 @@ class Actor : Thinker native
 	native void Substitute(Actor replacement);
 	native ui void DisplayNameTag();
 
+	// {MC] Called by inventory TryPickup function to determine if this actor
+	// can pick it up. If touched is true, it was called by an inventory's
+	// Touch function. Otherwise, touched is false if called directly from
+	// CallTryPickup. Caution must be used here! Player starting items that
+	// return false when touched is false will throw a VM abort!
+
+	virtual bool CanPickupItem(Inventory item, bool touched = false)
+	{
+		return true;
+	}
+
 	// Called by PIT_CheckThing to check if two actors actually can collide.
 	virtual bool CanCollideWith(Actor other, bool passive)
 	{

--- a/wadsrc/static/zscript/inventory/inventory.txt
+++ b/wadsrc/static/zscript/inventory/inventory.txt
@@ -581,13 +581,16 @@ class Inventory : Actor
 	//
 	//===========================================================================
 
-	bool, Actor CallTryPickup(Actor toucher)
+	bool, Actor CallTryPickup(Actor toucher, bool touched = false)
 	{
 		let saved_toucher = toucher;
 		let Invstack = Inv; // A pointer of the inventories item stack.
 
 		// unmorphed versions of a currently morphed actor cannot pick up anything. 
 		if (bUnmorphed) return false, null;
+
+		if (!touched && toucher != null && !toucher.CanPickupItem(self))
+			return false, null;
 
 		bool res;
 		if (CanPickup(toucher))
@@ -760,8 +763,10 @@ class Inventory : Actor
 
 		bool localview = toucher.CheckLocalView(consoleplayer);
 
+		if (!toucher.CanPickupItem(self, true))	return;
+
 		bool res;
-		[res, toucher] = CallTryPickup(toucher);
+		[res, toucher] = CallTryPickup(toucher, true);
 		if (!res) return;
 
 		// This is the only situation when a pickup flash should ever play.

--- a/wadsrc/static/zscript/inventory/inventory.txt
+++ b/wadsrc/static/zscript/inventory/inventory.txt
@@ -590,7 +590,7 @@ class Inventory : Actor
 		if (bUnmorphed) return false, null;
 
 		if (!touched && toucher != null && !toucher.CanPickupItem(self))
-			return false, null;
+			return false, toucher;
 
 		bool res;
 		if (CanPickup(toucher))


### PR DESCRIPTION
Added CanPickupItem.

- This allows the ability to more directly control which items can be picked up via the one picking up.
- Touched is true if attempting to pick up the item via collision, false if given directly via A_GiveInventory and so on.