### PR TITLE
+DONTSINK (disables sinking physics in water)

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -407,6 +407,7 @@ enum ActorFlag8
 	MF8_HITOWNER		= 0x00000010,	// projectile can hit the actor that fired it
 	MF8_NOFRICTION		= 0x00000020,	// friction doesn't apply to the actor at all
 	MF8_NOFRICTIONBOUNCE	= 0x00000040,	// don't bounce off walls when on icy floors
+	MF8_DONTSINK		= 0x00000080,	// actor doesn't sink in water or try to match sink speed
 };
 
 // --- mobj.renderflags ---

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -321,6 +321,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, HITOWNER, AActor, flags8),
 	DEFINE_FLAG(MF8, NOFRICTION, AActor, flags8),
 	DEFINE_FLAG(MF8, NOFRICTIONBOUNCE, AActor, flags8),
+	DEFINE_FLAG(MF8, DONTSINK, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
https://forum.zdoom.org/viewtopic.php?f=15&t=63154

Right now, the sinking behavior is mostly hardcoded, and the few ways you can mess with it are either hacky (messing with player.cmd to stop it on a player) or hacky and limited (modifying mass). This lets you turn it off, which lets you implement your own sinking/buoyancy in ZScript, or more easily implement swimming monsters, or just not do it, or whatever.