### PR TITLE
Fix for "A_SpawnProjectile height is different in gf10ded756"

### DIFF
--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -6710,7 +6710,7 @@ AActor *P_SpawnPlayerMissile (AActor *source, double x, double y, double z,
 	if (z != ONFLOORZ && z != ONCEILINGZ)
 	{
 		// Doom spawns missiles 4 units lower than hitscan attacks for players.
-		z += source->Center() - source->Floorclip + source->AttackOffset(4);
+		z += source->Center() - source->Floorclip + source->AttackOffset(-4);
 		// Do not fire beneath the floor.
 		if (z < source->floorz)
 		{


### PR DESCRIPTION
This PR fixes the following bug: [A_SpawnProjectile height is different in gf10ded756](https://forum.zdoom.org/viewtopic.php?f=2&t=63138) reported by Nash.

The problem: `P_SpawnPlayerMissile` should pass -4 instead of 4 to `source->AttackOffset` when calculating the Z coordinate. This was probably overlooked during refactoring.