### PR TITLE
Removal of redundant #include "actorinlines.h"

### DIFF
--- a/src/b_game.cpp
+++ b/src/b_game.cpp
@@ -93,7 +93,6 @@ Everything that is changed is marked (maybe commented) with "Added by MC"
 #include "events.h"
 #include "vm.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 
 static FRandom pr_botspawn ("BotSpawn");
 

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -64,7 +64,6 @@
 #include "events.h"
 #include "i_time.h"
 #include "vm.h"
-#include "actorinlines.h"
 
 EXTERN_CVAR (Int, disableautosave)
 EXTERN_CVAR (Int, autosavecount)

--- a/src/gl/renderer/gl_renderer.cpp
+++ b/src/gl/renderer/gl_renderer.cpp
@@ -39,7 +39,6 @@
 #include "g_game.h"
 #include "swrenderer/r_swscene.h"
 #include "hwrenderer/utility/hw_clock.h"
-#include "actorinlines.h"
 
 #include "gl_load/gl_interface.h"
 #include "gl/system/gl_framebuffer.h"

--- a/src/gl/renderer/gl_scene.cpp
+++ b/src/gl/renderer/gl_scene.cpp
@@ -39,7 +39,6 @@
 #include "p_local.h"
 #include "serializer.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "r_data/models/models.h"
 #include "hwrenderer/dynlights/hw_dynlightdata.h"
 #include "hwrenderer/utility/hw_clock.h"

--- a/src/hwrenderer/dynlights/hw_dynlightdata.cpp
+++ b/src/hwrenderer/dynlights/hw_dynlightdata.cpp
@@ -25,7 +25,6 @@
 **
 **/
 
-#include "actorinlines.h"
 
 #include "hw_dynlightdata.h"
 

--- a/src/hwrenderer/scene/hw_flats.cpp
+++ b/src/hwrenderer/scene/hw_flats.cpp
@@ -32,7 +32,6 @@
 #include "doomstat.h"
 #include "d_player.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "p_lnspec.h"
 #include "r_data/matrix.h"
 #include "hwrenderer/dynlights/hw_dynlightdata.h"

--- a/src/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/hwrenderer/scene/hw_spritelight.cpp
@@ -30,7 +30,6 @@
 #include "p_effect.h"
 #include "g_level.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "hwrenderer/dynlights/hw_dynlightdata.h"
 #include "hwrenderer/dynlights/hw_shadowmap.h"
 #include "hwrenderer/scene/hw_drawinfo.h"

--- a/src/hwrenderer/scene/hw_walls.cpp
+++ b/src/hwrenderer/scene/hw_walls.cpp
@@ -29,7 +29,6 @@
 #include "p_maputl.h"
 #include "doomdata.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "hwrenderer/dynlights/hw_dynlightdata.h"
 #include "hwrenderer/textures/hw_material.h"
 #include "hwrenderer/utility/hw_cvars.h"

--- a/src/maploader/polyobjects.cpp
+++ b/src/maploader/polyobjects.cpp
@@ -34,7 +34,6 @@
 #include "p_maputl.h"
 #include "r_utility.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "v_text.h"
 
 #include "maploader/maploader.h"

--- a/src/p_effect.cpp
+++ b/src/p_effect.cpp
@@ -46,7 +46,6 @@
 #include "d_player.h"
 #include "r_utility.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "vm.h"
 
 CVAR (Int, cl_rockettrails, 1, CVAR_ARCHIVE);

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -60,7 +60,6 @@
 #include "vm.h"
 #include "g_levellocals.h"
 #include "events.h"
-#include "actorinlines.h"
 
 static FRandom pr_botrespawn ("BotRespawn");
 static FRandom pr_killmobj ("ActorDie");

--- a/src/p_pspr.cpp
+++ b/src/p_pspr.cpp
@@ -43,7 +43,6 @@
 #include "v_text.h"
 #include "cmdlib.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "vm.h"
 #include "sbar.h"
 

--- a/src/p_secnodes.cpp
+++ b/src/p_secnodes.cpp
@@ -27,7 +27,6 @@
 #include "g_levellocals.h"
 #include "p_maputl.h"
 #include "actor.h"
-#include "actorinlines.h"
 
 //=============================================================================
 // phares 3/21/98

--- a/src/p_teleport.cpp
+++ b/src/p_teleport.cpp
@@ -42,7 +42,6 @@
 #include "r_utility.h"
 #include "p_spec.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "vm.h"
 
 #define FUDGEFACTOR		10

--- a/src/polyrenderer/poly_renderer.cpp
+++ b/src/polyrenderer/poly_renderer.cpp
@@ -34,7 +34,6 @@
 #include "st_stuff.h"
 #include "g_levellocals.h"
 #include "p_effect.h"
-#include "actorinlines.h"
 #include "polyrenderer/scene/poly_light.h"
 #include "swrenderer/scene/r_scene.h"
 #include "swrenderer/drawers/r_draw_rgba.h"

--- a/src/polyrenderer/scene/poly_model.cpp
+++ b/src/polyrenderer/scene/poly_model.cpp
@@ -30,7 +30,6 @@
 #include "polyrenderer/scene/poly_light.h"
 #include "polyrenderer/poly_renderthread.h"
 #include "r_data/r_vanillatrans.h"
-#include "actorinlines.h"
 #include "i_time.h"
 
 void PolyRenderModel(PolyRenderThread *thread, const Mat4f &worldToClip, uint32_t stencilValue, float x, float y, float z, FSpriteModelFrame *smf, AActor *actor)

--- a/src/polyrenderer/scene/poly_sprite.cpp
+++ b/src/polyrenderer/scene/poly_sprite.cpp
@@ -31,7 +31,6 @@
 #include "polyrenderer/poly_renderthread.h"
 #include "polyrenderer/scene/poly_model.h"
 #include "r_data/r_vanillatrans.h"
-#include "actorinlines.h"
 
 EXTERN_CVAR(Float, transsouls)
 EXTERN_CVAR(Int, r_drawfuzz)

--- a/src/portal.cpp
+++ b/src/portal.cpp
@@ -49,7 +49,6 @@
 #include "p_maputl.h"
 #include "p_spec.h"
 #include "g_levellocals.h"
-#include "actorinlines.h"
 #include "vm.h"
 
 // simulation recurions maximum

--- a/src/r_data/models/models.cpp
+++ b/src/r_data/models/models.cpp
@@ -42,7 +42,6 @@
 #include "r_data/models/models_ue1.h"
 #include "r_data/models/models_obj.h"
 #include "i_time.h"
-#include "actorinlines.h"
 
 #ifdef _MSC_VER
 #pragma warning(disable:4244) // warning C4244: conversion from 'double' to 'float', possible loss of data

--- a/src/s_advsound.cpp
+++ b/src/s_advsound.cpp
@@ -47,7 +47,6 @@
 #include "g_levellocals.h"
 #include "r_data/sprites.h"
 #include "vm.h"
-#include "actorinlines.h"
 
 // MACROS ------------------------------------------------------------------
 

--- a/src/s_sound.cpp
+++ b/src/s_sound.cpp
@@ -82,7 +82,6 @@
 #include "d_player.h"
 #include "g_levellocals.h"
 #include "vm.h"
-#include "actorinlines.h"
 
 // MACROS ------------------------------------------------------------------
 

--- a/src/scripting/thingdef_properties.cpp
+++ b/src/scripting/thingdef_properties.cpp
@@ -54,7 +54,6 @@
 #include "a_keys.h"
 #include "g_levellocals.h"
 #include "types.h"
-#include "actorinlines.h"
 
 //==========================================================================
 //

--- a/src/scriptutil.cpp
+++ b/src/scriptutil.cpp
@@ -29,7 +29,6 @@
 #include "vm.h"
 #include "scriptutil.h"
 #include "p_acs.h"
-#include "actorinlines.h"
 
 
 static TArray<VMValue> parameters;

--- a/src/swrenderer/things/r_model.cpp
+++ b/src/swrenderer/things/r_model.cpp
@@ -27,7 +27,6 @@
 #include "r_data/r_translate.h"
 #include "r_model.h"
 #include "r_data/r_vanillatrans.h"
-#include "actorinlines.h"
 #include "i_time.h"
 #include "swrenderer/r_memory.h"
 #include "swrenderer/r_swcolormaps.h"

--- a/src/v_blend.cpp
+++ b/src/v_blend.cpp
@@ -44,7 +44,6 @@
 #include "d_player.h"
 #include "g_levellocals.h"
 #include "vm.h"
-#include "actorinlines.h"
 
 CVAR( Float, blood_fade_scalar, 1.0f, CVAR_ARCHIVE )	// [SP] Pulled from Skulltag - changed default from 0.5 to 1.0
 CVAR( Float, pickup_fade_scalar, 1.0f, CVAR_ARCHIVE )	// [SP] Uses same logic as blood_fade_scalar except for pickups


### PR DESCRIPTION
Lots of now redundant #include's were added recently. Is it a right time to remove it?