### PR TITLE
Make LevelLocals::ExecuteSpecial return int

### DIFF
--- a/src/p_lnspec.cpp
+++ b/src/p_lnspec.cpp
@@ -3960,8 +3960,6 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, ExecuteSpecial)
 	PARAM_INT(arg4);
 	PARAM_INT(arg5);
 
-	bool res = !!P_ExecuteSpecial(special, linedef, activator, lineside, arg1, arg2, arg3, arg4, arg5);
-
-	ACTION_RETURN_BOOL(res);
+	ACTION_RETURN_INT(P_ExecuteSpecial(special, linedef, activator, lineside, arg1, arg2, arg3, arg4, arg5));
 }
 

--- a/wadsrc/static/zscript/base.txt
+++ b/wadsrc/static/zscript/base.txt
@@ -692,7 +692,7 @@ struct LevelLocals native
 	native String GetUDMFString(int type, int index, Name key);
 	native int GetUDMFInt(int type, int index, Name key);
 	native double GetUDMFFloat(int type, int index, Name key);
-	native bool ExecuteSpecial(int special, Actor activator, line linedef, bool lineside, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0, int arg5 = 0);
+	native int ExecuteSpecial(int special, Actor activator, line linedef, bool lineside, int arg1 = 0, int arg2 = 0, int arg3 = 0, int arg4 = 0, int arg5 = 0);
 	native void GiveSecret(Actor activator, bool printmsg = true, bool playsound = true);
 	native static void StartSlideshow(Name whichone = 'none');
 	native static void WorldDone();


### PR DESCRIPTION
Currently it returns bool, which will not give the full breadth of responses `P_ExecuteSpecial` can actually return, for instance with `ACS_ExecuteWithResult`. This patch makes it equivalent to the BuiltinCallLineSpecial function, which will work backwards compatibly as int implicitly casts to bool.