### PR TITLE
- don't reset the gamma table on exit if vid_hwgamma is active

### DIFF
--- a/src/posix/sdl/sdlglvideo.cpp
+++ b/src/posix/sdl/sdlglvideo.cpp
@@ -71,6 +71,7 @@ EXTERN_CVAR (Int, vid_displaybits)
 EXTERN_CVAR (Int, vid_maxfps)
 EXTERN_CVAR (Int, vid_defwidth)
 EXTERN_CVAR (Int, vid_defheight)
+EXTERN_CVAR (Int, vid_hwgamma)
 EXTERN_CVAR (Bool, cl_capfps)
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
@@ -268,7 +269,8 @@ SystemGLFrameBuffer::~SystemGLFrameBuffer ()
 {
 	if (Screen)
 	{
-		ResetGammaTable();
+		if (m_supportsGamma && ((vid_hwgamma == 0) || (vid_hwgamma == 2 && IsFullscreen())))
+			ResetGammaTable();
 
 		if (GLContext)
 		{

--- a/src/win32/base_sysfb.cpp
+++ b/src/win32/base_sysfb.cpp
@@ -64,6 +64,7 @@ extern "C" {
 
 EXTERN_CVAR(Int, vid_defwidth)
 EXTERN_CVAR(Int, vid_defheight)
+EXTERN_CVAR(Int, vid_hwgamma)
 
 //==========================================================================
 //
@@ -369,7 +370,8 @@ SystemBaseFrameBuffer::SystemBaseFrameBuffer(void *hMonitor, bool fullscreen) : 
 
 SystemBaseFrameBuffer::~SystemBaseFrameBuffer()
 {
-	ResetGammaTable();
+	if (m_supportsGamma && ((vid_hwgamma == 0) || (vid_hwgamma == 2 && IsFullscreen())))
+		ResetGammaTable();
 	if (!m_Fullscreen) SaveWindowedPos();
 
 	ShowWindow (Window, SW_SHOW);


### PR DESCRIPTION
Would like this merged for 3.7.2, if possible, but using a pull request to ensure this is desired and done correctly.

This prevents GZDoom from resetting the desktop gamma on exit, if it is not actually using it anyhow.