### PR TITLE
CheckReplacee

### DIFF
--- a/src/events.h
+++ b/src/events.h
@@ -81,6 +81,8 @@ void E_Console(int player, FString name, int arg1, int arg2, int arg3, bool manu
 
 // called when looking up the replacement for an actor class
 bool E_CheckReplacement(PClassActor* replacee, PClassActor** replacement);
+// called when looking up the replaced for an actor class
+bool E_CheckReplacee(PClassActor** replacee, PClassActor* replacement);
 
 // called on new game
 void E_NewGame(EventHandlerType handlerType);
@@ -187,6 +189,7 @@ public:
 
 	//
 	void CheckReplacement(PClassActor* replacee, PClassActor** replacement, bool* final);
+	void CheckReplacee(PClassActor** replacee, PClassActor* replacement, bool* final);
 
 	//
 	void NewGame();
@@ -295,6 +298,13 @@ struct FConsoleEvent
 };
 
 struct FReplaceEvent
+{
+	PClassActor* Replacee;
+	PClassActor* Replacement;
+	bool IsFinal;
+};
+
+struct FReplacedEvent
 {
 	PClassActor* Replacee;
 	PClassActor* Replacement;

--- a/src/info.cpp
+++ b/src/info.cpp
@@ -593,6 +593,16 @@ PClassActor *PClassActor::GetReplacee(bool lookskill)
 		}
 	}
 	PClassActor *savedrep = ActorInfo()->Replacee;
+	// [MC] Same code as CheckReplacement but turned around so modders can indicate
+	// what monsters spawn from which entity. I.e. instead of a randomspawner
+	// showing up, one can assign an Arachnotron as the one being replaced
+	// so functions like CheckReplacee and A_BossDeath can actually work, given
+	// modders set it up that way.
+	if (E_CheckReplacee(&savedrep, this))
+	{
+		// [MK] the replacement is final, so don't continue with the chain
+		return savedrep ? savedrep : this;
+	}
 	if (savedrep == nullptr && (!lookskill || skillrepname == NAME_None))
 	{
 		return this;

--- a/wadsrc/static/zscript/events.txt
+++ b/wadsrc/static/zscript/events.txt
@@ -300,6 +300,13 @@ struct ReplaceEvent native version("2.4")
 	native bool IsFinal;
 }
 
+struct ReplacedEvent native version("3.7")
+{
+	native Class<Actor> Replacee;
+	native readonly Class<Actor> Replacement;
+	native bool IsFinal;
+}
+
 class StaticEventHandler : Object native play version("2.4")
 {
     // static event handlers CAN register other static event handlers.
@@ -312,7 +319,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void OnUnregister() {}
 
     // actual handlers are here
-virtual void WorldLoaded(WorldEvent e) {}
+	virtual void WorldLoaded(WorldEvent e) {}
     virtual void WorldUnloaded(WorldEvent e) {}
     virtual void WorldThingSpawned(WorldEvent e) {}
     virtual void WorldThingDied(WorldEvent e) {}
@@ -348,6 +355,7 @@ virtual void WorldLoaded(WorldEvent e) {}
     
     //
     virtual void CheckReplacement(ReplaceEvent e) {}
+	virtual void CheckReplacee(ReplacedEvent e) {}
 
     //
     virtual  void NewGame() {}


### PR DESCRIPTION
Added CheckReplacee.

- Allows defining of what actor is replacing another for information.
- If multiple arachnotrons, a modder can attribute them as being a replacer of Arachnotron itself, allowing A_BossDeath and GetReplacee to work with it.

https://forum.zdoom.org/viewtopic.php?f=15&t=63449