### PR TITLE
DOOM2.WAD fixes

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.txt
+++ b/wadsrc/static/zscript/level_compatibility.txt
@@ -627,6 +627,28 @@ class LevelCompatibility native play
 				break;
 			}
 			
+			case '6C620F43705BEC0ABBABBF46AC3E62D2': // Doom II MAP10
+			{
+				// Allow player to leave exit room
+				SetLineSpecial(786, Door_Raise, 0, 16, 150, 0);
+				SetLineActivation(786, SPAC_Use);
+				SetLineFlags(786, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+			
+			case '1AF4DEC2627360A55B3EB397BC15C39D': // Doom II MAP12
+			{
+				// Missing texture
+				SetWallTexture(648, Line.back, Side.bottom, "PIPES");
+				// Change locked door at last room to a repeatable Door_LockedRaise
+				// instead of a one-shot Door_Open (red keycard only on deathmatch)
+				SetLineSpecial(632, Door_LockedRaise, 0, 16, 150, 129);
+				SetLineFlags(632, Line.ML_REPEAT_SPECIAL);
+				// Remove erroneous tag for teleporter at the south building
+				ClearSectorTags(149);
+				break;
+			}
+			
 			case 'FBA6547B9FD44E95671A923A066E516F': // Doom II MAP13
 			{
 				// Missing texture
@@ -662,14 +684,14 @@ class LevelCompatibility native play
 					SetWallTextureID(1137+i, Line.back, Side.top, BSTONE1);
 					SetWallTextureID(1140+i, Line.back, Side.top, BSTONE1);
 				}
-				
-				// Raise floor between lifts to correspond with others.
+				// Raise floor between lifts to fix HOMs
 				OffsetSectorPlane(106, Sector.floor, 16);
 				break;
 			}
 			
 			case '1A540BA717BF9EC85F8522594C352F2A': // Doom II, map15
 			{
+				// Remove unreachable secret
 				SetSectorSpecial(147, 0);
 				// Missing textures
 				SetWallTexture(94, Line.back, Side.top, "METAL");
@@ -706,15 +728,17 @@ class LevelCompatibility native play
 			case 'B5506B1E8F2FC272AD0C77B9E0DF5491': // doom2.wad map19
 			{
 				// missing textures
-				SetWallTexture(355, Line.back, Side.top, "STONE2");
-				SetWallTexture(736, Line.front, Side.top, "SLADWALL");
-				SetWallTexture(1181, Line.back, Side.top, "MARBLE1");
-				
 				TextureID step4 = TexMan.CheckForTexture("STEP4", TexMan.Type_Wall);
 				for(int i=0; i<3; i++)
 				{
 					SetWallTextureID(286+i, Line.back, Side.bottom, STEP4);
 				}
+				SetWallTexture(355, Line.back, Side.top, "STONE2");
+				SetWallTexture(736, Line.front, Side.top, "SLADWALL");
+				SetWallTexture(1181, Line.back, Side.top, "MARBLE1");
+				// Southwest teleporter in the teleporter room now works on
+				// easier difficulties
+				SetThingSkills(112, 31);
 				break;
 			}
 			
@@ -723,6 +747,13 @@ class LevelCompatibility native play
 				// push ceiling down in glitchy sectors above the stair switches
 				OffsetSectorPlane(50, Sector.ceiling, -56);
 				OffsetSectorPlane(54, Sector.ceiling, -56);
+				break;
+			}
+			
+			case '4AA9B3CE449FB614497756E96509F096': // Doom II MAP22
+			{
+				// Only use switch once to raise sector to rocket launcher
+				SetLineFlags(120, 0, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 			
@@ -742,8 +773,17 @@ class LevelCompatibility native play
 			
 			case '110F84DE041052B59307FAF0293E6BC0': // Doom II, map27
 			{
+				// Remove unreachable secret
 				SetSectorSpecial(93, 0);
+				// Missing texture
 				SetWallTexture(582, Line.back, Side.top, "ZIMMER3");
+				// Make line near switch to level exit passable
+				SetLineFlags(342, 0, Line.ML_BLOCKING);
+				// Can leave Pain Elemental room if stuck
+				SetLineSpecial(580, Door_Open, 0, 16);
+				SetLineActivation(580, SPAC_Use);
+				SetLineSpecial(581, Door_Open, 0, 16);
+				SetLineActivation(581, SPAC_Use);
 				break;
 			}
 			
@@ -760,6 +800,12 @@ class LevelCompatibility native play
 				SetWallTexture(531, Line.back, Side.top, "WOOD8");
 				SetWallTexture(547, Line.back, Side.top, "WOOD8");
 				SetWallTexture(548, Line.back, Side.top, "WOOD8");
+				// Raise holes near level exit when walking over them
+				for(int i=0; i<12; i++)
+				{
+					SetLineSpecial(584+i, Floor_RaiseToNearest, 5, 8);
+					SetLineActivation(584+i, SPAC_Cross);
+				}
 				break;
 			}
 			


### PR DESCRIPTION
MAP10: Unlike other maps, you cannot leave the exit room once the door locks behind you strangely enough. The side inside the room has been given a Door_Raise action.
MAP12: Change will go unnoticed for most people, but the red key side of the door leading to the last room can only be used once, so if the yellow key side was used the door will close and the red key side cannot be used again. Changed to a repeatable Door_LockedRaise action.
MAP19: Southwest teleporter in teleporter room works on easier difficulties now.
![map19_tele](https://user-images.githubusercontent.com/35357202/52085298-0c1f1400-259c-11e9-9e6d-9194c8f81ede.png)
MAP22: Switch to rocket launcher can be used repeatedly and reveal a small HOM, make it a one-time action.
MAP27: Make unpassable line passable. Have the door sides inside the PE trap room be usable if the lines tagged to open said doors were not crossed.
![map27_line](https://user-images.githubusercontent.com/35357202/52085375-425c9380-259c-11e9-89b0-de280db92ae0.png)
MAP28: Since players can walk over monsters and the Revenants don't appear in the holes on easy difficulties, walking across any of the holes now raises all of them.