### PR TITLE
UNCLEARABLE Inventory Flag

### DIFF
--- a/wadsrc/static/zscript/actor_inventory.txt
+++ b/wadsrc/static/zscript/actor_inventory.txt
@@ -336,7 +336,7 @@ extend class Actor
 		while (last.inv != NULL)
 		{
 			let inv = last.inv;
-			if (!inv.bUndroppable)
+			if (!inv.bUndroppable && !inv.bUnclearable)
 			{
 				inv.DepleteOrDestroy();
 				if (!inv.bDestroyed) last = inv;	// was only depleted so advance the pointer manually.

--- a/wadsrc/static/zscript/inventory/inventory.txt
+++ b/wadsrc/static/zscript/inventory/inventory.txt
@@ -64,6 +64,7 @@ class Inventory : Actor
 	flagdef IsArmor: ItemFlags, 21;
 	flagdef IsHealth: ItemFlags, 22;
 	flagdef AlwaysPickup: ItemFlags, 23;
+	flagdef Unclearable: ItemFlags, 24;
 
 	flagdef ForceRespawnInSurvival: none, 0;
 	flagdef PickupFlash: none, 6;

--- a/wadsrc/static/zscript/shared/player.txt
+++ b/wadsrc/static/zscript/shared/player.txt
@@ -2042,7 +2042,7 @@ class PlayerPawn : Actor
 				if (item.bINVBAR && item.Amount > item.InterHubAmount)
 				{
 					item.Amount = item.InterHubAmount;
-					if (level.REMOVEITEMS && !item.bUNDROPPABLE)
+					if (level.REMOVEITEMS && !item.bUNDROPPABLE && !item.bUNCLEARABLE)
 					{
 						todelete.Push(item);
 					}


### PR DESCRIPTION
Added Inventory UNCLEARABLE flag.
- Allows prevention of ClearInventory without stopping it from being dropped.