### PR TITLE
Fixed “Finished:” and “Now entering” in Heretic

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2550,8 +2550,8 @@ NOTSET				= "Not set";
 SAFEMESSAGE			= "Do you really want to do this?";
 MNU_COLORPICKER		= "SELECT COLOR";
 
-WI_FINISHED			= "finished";
-WI_ENTERING			= "Now entering:";
+FINISHED			= "finished";
+ENTERING			= "Now entering:";
 
 AM_MONSTERS			= "Monsters:";
 AM_SECRETS			= "Secrets:";

--- a/wadsrc/static/language.fr
+++ b/wadsrc/static/language.fr
@@ -2511,8 +2511,8 @@ SAFEMESSAGE			= "Voulez-vous vraiment faire ça?";
 MNU_COLORPICKER		= "CHOISIR COULEUR";
 
 
-WI_FINISHED			= "terminé";
-WI_ENTERING			= "Entrant:";
+FINISHED			= "terminé";
+ENTERING			= "Entrant:";
 
 AM_MONSTERS			= "Monstres:";
 AM_ITEMS			= "Objets:";

--- a/wadsrc/static/language.ptb
+++ b/wadsrc/static/language.ptb
@@ -1584,8 +1584,8 @@ $ifgame(heretic) SWSTRING = "SOMENTE DISPONIVEL NA VERSAO REGISTRADA";
 
 MNU_EPISODE			= "Selecione um episodio";
 
-WI_FINISHED			= "finalizado";
-WI_ENTERING			= "Entrando:";
+FINISHED			= "finalizado";
+ENTERING			= "Entrando:";
 
 // Bloodbath announcer (não traduzido ainda)
 


### PR DESCRIPTION
The text file [*statscreen.txt*](https://github.com/coelckers/gzdoom/blob/master/wadsrc/static/zscript/statscreen/statscreen.txt#L227) is set to use strings called “**$ENTERING**” and “**$FINISHED**”, located in the language files, in intermission screens between levels in Heretic. However, these strings are named incorrectly in the language files, instead being written as “**$WI_ENTERING**” and “**$WI_FINISHED**” for some reason I’m unaware of. After renaming them, the ingame text shows up through what is written in the language files, which, I assume, is the way it should work.

On a miscellaneous note: in GZDoom, the default text between levels in Heretic says “Entering:”. In the DOS version, it says “Now entering:”. This is accurately reflected in the English language file, though, and thus faithful to the original when displayed ingame.