### PR TITLE
Fixed “Finished:” and “Now entering” in Heretic

### DIFF
--- a/wadsrc/static/zscript/statscreen/statscreen.txt
+++ b/wadsrc/static/zscript/statscreen/statscreen.txt
@@ -224,7 +224,7 @@ class StatusScreen abstract play version("2.5")
 		if (y < (NG_STATSY - finished.mFont.GetHeight()*3/4) * CleanYfac)
 		{
 			// don't draw 'finished' if the level name is too tall
-			y = DrawPatchText(y, finished, "$FINISHED");
+			y = DrawPatchText(y, finished, "$WI_FINISHED");
 		}
 		return y;
 	}
@@ -243,7 +243,7 @@ class StatusScreen abstract play version("2.5")
 	{
 		int y = TITLEY * CleanYfac;
 
-		y = DrawPatchText(y, entering, "$ENTERING");
+		y = DrawPatchText(y, entering, "$WI_ENTERING");
 		y += entering.mFont.GetHeight() * CleanYfac / 4;
 		DrawName(y, wbs.LName1, lnametexts[1]);
 	}


### PR DESCRIPTION
The text file [*statscreen.txt*](https://github.com/coelckers/gzdoom/blob/master/wadsrc/static/zscript/statscreen/statscreen.txt#L227) is set to use strings called “**$ENTERING**” and “**$FINISHED**”, located in the language files, in intermission screens between levels in Heretic. However, these strings are named incorrectly in the language files, instead being written as “**$WI_ENTERING**” and “**$WI_FINISHED**” for some reason I’m unaware of. After renaming the strings in the original script, the ingame text shows up through what is written in the language files, which, I assume, is the way it should work.

On a miscellaneous note: in GZDoom, the default text between levels in Heretic says “Entering:”. In the DOS version, it says “Now entering:”. This is accurately reflected in the English language file, though, and thus faithful to the original when displayed ingame.

(Followup to #728)