### PR TITLE
Localized “FIND HELP” in Strife

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -471,7 +471,7 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 		for (i = 0; i < MAXPLAYERS; ++i)
 		{
 			if (playeringame[i])
-				players[i].SetLogText ("Find help");
+				players[i].SetLogText ("$TXT_FINDHELP");
 		}
 	}
 

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -1464,6 +1464,8 @@ TXT_DOES_NOT_WORK = "That doesn't seem to work";
 
 // Strife Quest messages
 
+TXT_FINDHELP = "FIND HELP";
+
 TXT_QUEST_14 = "You've Blown Up the Crystal";
 TXT_QUEST_16 = "You've Blown Up the Gates";
 TXT_QUEST_27 = "You've Blown Up the Computer";


### PR DESCRIPTION
The very first quest log that appears in Strife, “FIND HELP”, is located in a source file. This moves it to the language files.

While this pull request works, there’s probably a better way to go about it: [this](http://u.cubeupload.com/SashaRed/findhelp.png) shows up in the console when loading the game. Not pretty.