### PR TITLE
New CVar: am_showkeys_always

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -83,6 +83,7 @@ CVAR (Bool,  am_customcolors,		true,		CVAR_ARCHIVE);
 CVAR (Int,   am_map_secrets,		1,			CVAR_ARCHIVE);
 CVAR (Int,	 am_drawmapback,		1,			CVAR_ARCHIVE);
 CVAR (Bool,  am_showkeys,			true,		CVAR_ARCHIVE);
+CVAR (Bool,  am_showkeys_always,			false,		CVAR_ARCHIVE);
 CVAR (Int,   am_showtriggerlines,	0,			CVAR_ARCHIVE);
 CVAR (Int,   am_showthingsprites,		0,		CVAR_ARCHIVE);
 
@@ -3056,7 +3057,7 @@ void AM_drawThings ()
 						// That is the case for all default keys, however.
 						if (t->IsKindOf(NAME_Key))
 						{
-							if (G_SkillProperty(SKILLP_EasyKey))
+							if (G_SkillProperty(SKILLP_EasyKey) || am_showkeys_always)
 							{
 								// Already drawn by AM_drawKeys(), so don't draw again
 								color.Index = -1;
@@ -3283,7 +3284,7 @@ void AM_Drawer (int bottom)
 
 	AM_drawWalls(allmap);
 	AM_drawPlayers();
-	if (G_SkillProperty(SKILLP_EasyKey))
+	if (G_SkillProperty(SKILLP_EasyKey) || am_showkeys_always)
 		AM_drawKeys();
 	if ((am_cheat >= 2 && am_cheat != 4) || allthings)
 		AM_drawThings();


### PR DESCRIPTION
New CVar: am_showkeys_always.

Works as EasyKey skill property, but without skills being modified in mapinfo.

Simplifies key hunting without clutter given by "am_cheat 2".
