### PR TITLE
Localized “PERSON” in Strife

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -1619,6 +1619,8 @@ TXT_RANDOMGOODBYE_3 = "See you later!";
 TXT_HAVEENOUGH		= "You seem to have enough!";
 TXT_GOAWAY			= "Go away!";
 
+TXT_PERSON			= "Person";
+
 TXT_COMM0			= "Incoming Message";
 TXT_COMM1			= "Incoming Message from BlackBird";
 

--- a/wadsrc/static/language.fr
+++ b/wadsrc/static/language.fr
@@ -1663,6 +1663,8 @@ TXT_RANDOMGOODBYE_3 = "A plus tard!";
 TXT_HAVEENOUGH		= "Vous avez l'air d'en avoir assez!";
 TXT_GOAWAY			= "Allez-vous en!";
 
+TXT_PERSON			= "Personne";
+
 TXT_COMM0			= "Message reçu.";
 TXT_COMM1			= "Message reçu de BlackBird";
 

--- a/wadsrc/static/zscript/menu/conversationmenu.txt
+++ b/wadsrc/static/zscript/menu/conversationmenu.txt
@@ -387,7 +387,7 @@ class ConversationMenu : Menu
 		}
 		else
 		{
-			speakerName = players[consoleplayer].ConversationNPC.GetTag("Person");
+			speakerName = players[consoleplayer].ConversationNPC.GetTag(Stringtable.Localize("$TXT_PERSON"));
 		}
 
 		


### PR DESCRIPTION
Characters in Strife that have no assigned name show up as “PERSON” in dialogues. This puts the “PERSON” label in the language files and also contains a French translation.

[Example](https://cdn.discordapp.com/attachments/539442937734496258/542031263654084631/unknown.png)