### PR TITLE
GetModifiedDamage + ModifyDamage Expansion

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -1422,7 +1422,7 @@ public:
 	}
 
 	int ApplyDamageFactor(FName damagetype, int damage) const;
-	int GetModifiedDamage(FName damagetype, int damage, bool passive);
+	int GetModifiedDamage(FName damagetype, int damage, bool passive, AActor *inflictor, AActor *source, int flags = 0);
 	void DeleteAttachedLights();
 	bool isFrozen();
 

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -1150,13 +1150,13 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 				// Handle active damage modifiers (e.g. PowerDamage)
 				if (damage > 0 && !(flags & DMG_NO_ENHANCE))
 				{
-					damage = source->GetModifiedDamage(mod, damage, false);
+					damage = source->GetModifiedDamage(mod, damage, false, inflictor, source, flags);
 				}
 			}
 			// Handle passive damage modifiers (e.g. PowerProtection), provided they are not afflicted with protection penetrating powers.
 			if (damage > 0 && !(flags & DMG_NO_PROTECT))
 			{
-				damage = target->GetModifiedDamage(mod, damage, true);
+				damage = target->GetModifiedDamage(mod, damage, true, inflictor, source, flags);
 			}
 			if (damage > 0 && !(flags & DMG_NO_FACTOR))
 			{
@@ -1747,7 +1747,7 @@ void P_PoisonDamage (player_t *player, AActor *source, int damage, bool playPain
 	// Take half damage in trainer mode
 	damage = int(damage * G_SkillProperty(SKILLP_DamageFactor) * sv_damagefactorplayer);
 	// Handle passive damage modifiers (e.g. PowerProtection)
-	damage = target->GetModifiedDamage(player->poisontype, damage, true);
+	damage = target->GetModifiedDamage(player->poisontype, damage, true, nullptr, source);
 	// Modify with damage factors
 	damage = target->ApplyDamageFactor(player->poisontype, damage);
 

--- a/src/p_mobj.cpp
+++ b/src/p_mobj.cpp
@@ -7217,15 +7217,15 @@ void AActor::ClearCounters()
 	}
 }
 
-int AActor::GetModifiedDamage(FName damagetype, int damage, bool passive)
+int AActor::GetModifiedDamage(FName damagetype, int damage, bool passive, AActor *inflictor, AActor *source, int flags)
 {
 	auto inv = Inventory;
 	while (inv != nullptr)
 	{
 		IFVIRTUALPTRNAME(inv, NAME_Inventory, ModifyDamage)
 		{
-			VMValue params[5] = { (DObject*)inv, damage, int(damagetype), &damage, passive };
-			VMCall(func, params, 5, nullptr, 0);
+			VMValue params[8] = { (DObject*)inv, damage, int(damagetype), &damage, passive, inflictor, source, flags };
+			VMCall(func, params, 8, nullptr, 0);
 		}
 		inv = inv->Inventory;
 	}

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -799,9 +799,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, ClearCounters, ClearCounters)
 	return 0;
 }
 
-static int GetModifiedDamage(AActor *self, int type, int damage, bool passive)
+static int GetModifiedDamage(AActor *self, int type, int damage, bool passive, AActor *inflictor, AActor *source, int flags)
 {
-	return self->GetModifiedDamage(ENamedName(type), damage, passive);
+	return self->GetModifiedDamage(ENamedName(type), damage, passive, inflictor, source, flags);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetModifiedDamage, GetModifiedDamage)
@@ -810,7 +810,10 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetModifiedDamage, GetModifiedDamage)
 	PARAM_NAME(type);
 	PARAM_INT(damage);
 	PARAM_BOOL(passive);
-	ACTION_RETURN_INT(self->GetModifiedDamage(type, damage, passive));
+	PARAM_OBJECT(inflictor, AActor);
+	PARAM_OBJECT(source, AActor);
+	PARAM_INT(flags);
+	ACTION_RETURN_INT(self->GetModifiedDamage(type, damage, passive, inflictor, source, flags));
 }
 
 static int ApplyDamageFactor(AActor *self, int type, int damage)

--- a/wadsrc/static/zscript/actor.txt
+++ b/wadsrc/static/zscript/actor.txt
@@ -651,7 +651,7 @@ class Actor : Thinker native
 	native void SpawnTeleportFog(Vector3 pos, bool beforeTele, bool setTarget);
 	native Actor RoughMonsterSearch(int distance, bool onlyseekable = false, bool frontonly = false);
 	native int ApplyDamageFactor(Name damagetype, int damage);
-	native int GetModifiedDamage(Name damagetype, int damage, bool passive);
+	native int GetModifiedDamage(Name damagetype, int damage, bool passive, Actor inflictor = null, Actor source = null, int flags = 0);
 	native bool CheckBossDeath();
 
 	void A_Light(int extralight) { if (player) player.extralight = clamp(extralight, -20, 20); }

--- a/wadsrc/static/zscript/inventory/inventory.txt
+++ b/wadsrc/static/zscript/inventory/inventory.txt
@@ -1002,7 +1002,7 @@ class Inventory : Actor
 	//
 	//===========================================================================
 
-	virtual void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive) {}
+	virtual void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor = null, Actor source = null, int flags = 0) {}
 	
 
 	virtual bool Use (bool pickup) { return false; }

--- a/wadsrc/static/zscript/inventory/powerups.txt
+++ b/wadsrc/static/zscript/inventory/powerups.txt
@@ -1655,7 +1655,7 @@ class PowerDamage : Powerup
 	//
 	//===========================================================================
 
-	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive)
+	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags)
 	{
 		if (!passive && damage > 0)
 		{
@@ -1749,7 +1749,7 @@ class PowerProtection : Powerup
 	//
 	//===========================================================================
 
-	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive)
+	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags)
 	{
 		if (passive && damage > 0)
 		{


### PR DESCRIPTION
Added inflictor, source and flag parameters to GetModifiedDamage on actors and ModifyDamage on inventory.

- The flags are used by DamageMobj so modders can determine radius damage, for example, by checking for DMG_EXPLOSION.