### PR TITLE
- added ability to customize font of automap marks

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -189,6 +189,9 @@ CVAR(Bool, am_portaloverlay, true, CVAR_ARCHIVE)
 CVAR(Bool, am_showgrid, false, CVAR_ARCHIVE)
 CVAR(Float, am_zoomdir, 0, CVAR_ARCHIVE)
 
+CVAR(Int, am_markfont, 0, CVAR_ARCHIVE)
+CVAR(Int, am_markcolor, CR_GREY, CVAR_ARCHIVE)
+
 CCMD(am_togglefollow)
 {
 	am_followplayer = !am_followplayer;
@@ -1128,7 +1131,9 @@ void DAutomap::restoreScaleAndLoc ()
 
 int DAutomap::addMark ()
 {
-	if (marknums[0].isValid())
+	// Add a mark when default font is selected and its textures (AMMNUM?)
+	// are loaded. Mark is always added when custom font is selected
+	if (am_markfont != 0 || marknums[0].isValid())
 	{
 		auto m = markpointnum;
 		markpoints[markpointnum].x = m_x + m_w/2;
@@ -3036,8 +3041,19 @@ void DAutomap::drawMarks ()
 	{
 		if (markpoints[i].x != -1)
 		{
-			DrawMarker (TexMan.GetTexture(marknums[i], true), markpoints[i].x, markpoints[i].y, -3, 0,
-				1, 1, 0, 1, 0, LegacyRenderStyles[STYLE_Normal]);
+			if (am_markfont == 0)
+			{
+				DrawMarker(TexMan.GetTexture(marknums[i], true), markpoints[i].x, markpoints[i].y, -3, 0,
+					1, 1, 0, 1, 0, LegacyRenderStyles[STYLE_Normal]);
+			}
+			else
+			{
+				char numstr[10];
+				mysnprintf(numstr, countof(numstr), "%d", i);
+
+				screen->DrawText(am_markfont == 1 ? SmallFont : BigFont, am_markcolor, 
+					CXMTOF(markpoints[i].x), CYMTOF(markpoints[i].y), numstr, TAG_DONE);
+			}
 		}
 	}
 }

--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2003,6 +2003,8 @@ AUTOMAPMNU_SHOWTRIGGERLINES		= "Show trigger lines";
 AUTOMAPMNU_SHOWTHINGSPRITES		= "Show things as sprites";
 AUTOMAPMNU_PTOVERLAY			= "Overlay portals";
 AUTOMAPMNU_EMPTYSPACEMARGIN		= "Empty space margin";
+AUTOMAPMNU_MARKFONT				= "Mark font";
+AUTOMAPMNU_MARKCOLOR			= "Mark color";
 
 // Automap Controls
 MAPCNTRLMNU_TITLE 			= "CUSTOMIZE MAP CONTROLS";
@@ -2503,6 +2505,8 @@ OPTVAL_VTAVANILLA			= "Auto (Vanilla Preferred)";
 OPTVAL_SCALENEAREST			= "Scaled (Nearest)";
 OPTVAL_SCALELINEAR			= "Scaled (Linear)";
 OPTVAL_LETTERBOX			= "Letterbox";
+OPTVAL_SMALL				= "Small";
+OPTVAL_LARGE				= "Large";
 
 // Colors
 C_BRICK					= "\cabrick";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1077,6 +1077,13 @@ OptionValue MapTriggers
 	2, "$OPTVAL_ON"
 }
 
+OptionValue MapMarkFont
+{
+	0, "$OPTVAL_DEFAULT"
+	1, "$OPTVAL_SMALL"
+	2, "$OPTVAL_LARGE"
+}
+
 OptionMenu AutomapOptions protected
 {
 	Title "$AUTOMAPMNU_TITLE"
@@ -1103,6 +1110,9 @@ OptionMenu AutomapOptions protected
 	Option "$AUTOMAPMNU_SHOWKEYS",				"am_showkeys", "OnOff"
 	Option "$AUTOMAPMNU_SHOWTRIGGERLINES",		"am_showtriggerlines", "MapTriggers"
 	Option "$AUTOMAPMNU_SHOWTHINGSPRITES",		"am_showthingsprites", "STSTypes"
+	StaticText " "
+	Option "$AUTOMAPMNU_MARKFONT",				"am_markfont", "MapMarkFont"
+	Option "$AUTOMAPMNU_MARKCOLOR",				"am_markcolor", "TextColors", "am_markfont"
 }
 
 //-------------------------------------------------------------------------------------------


### PR DESCRIPTION
Set am_markfont CVAR to 1 for a small font and 2 for a large one
Use am_markcolor to select a text color, has no effect on default font (AMMNUM? textures)

https://forum.zdoom.org/viewtopic.php?t=63490