### PR TITLE
PowerDamage: Passing Target for Source

### DIFF
--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -1150,7 +1150,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 				// Handle active damage modifiers (e.g. PowerDamage)
 				if (damage > 0 && !(flags & DMG_NO_ENHANCE))
 				{
-					damage = source->GetModifiedDamage(mod, damage, false, inflictor, source, flags);
+					damage = source->GetModifiedDamage(mod, damage, false, inflictor, target, flags);
 				}
 			}
 			// Handle passive damage modifiers (e.g. PowerProtection), provided they are not afflicted with protection penetrating powers.


### PR DESCRIPTION
Pass the target as the source for active damage modifiers (i.e. PowerDamage) instead of the actual source.

- Getting the victim would be impossible otherwise, and passing in the original source is redundant when there's already the owner.