### PR TITLE
Ability to customize font of automap marks, take 2

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -2003,6 +2003,8 @@ AUTOMAPMNU_SHOWTRIGGERLINES		= "Show trigger lines";
 AUTOMAPMNU_SHOWTHINGSPRITES		= "Show things as sprites";
 AUTOMAPMNU_PTOVERLAY			= "Overlay portals";
 AUTOMAPMNU_EMPTYSPACEMARGIN		= "Empty space margin";
+AUTOMAPMNU_MARKFONT				= "Mark font";
+AUTOMAPMNU_MARKCOLOR			= "Mark color";
 
 // Automap Controls
 MAPCNTRLMNU_TITLE 			= "CUSTOMIZE MAP CONTROLS";
@@ -2503,6 +2505,9 @@ OPTVAL_VTAVANILLA			= "Auto (Vanilla Preferred)";
 OPTVAL_SCALENEAREST			= "Scaled (Nearest)";
 OPTVAL_SCALELINEAR			= "Scaled (Linear)";
 OPTVAL_LETTERBOX			= "Letterbox";
+OPTVAL_SMALL				= "Small";
+OPTVAL_LARGE				= "Large";
+OPTVAL_CONSOLE				= "Console";
 
 // Colors
 C_BRICK					= "\cabrick";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1077,6 +1077,14 @@ OptionValue MapTriggers
 	2, "$OPTVAL_ON"
 }
 
+OptionString MapMarkFont
+{
+	"AMMNUMx", "$OPTVAL_DEFAULT"
+	"SmallFont", "$OPTVAL_SMALL"
+	"BigFont", "$OPTVAL_LARGE"
+	"ConsoleFont", "$OPTVAL_CONSOLE"
+}
+
 OptionMenu AutomapOptions protected
 {
 	Title "$AUTOMAPMNU_TITLE"
@@ -1103,6 +1111,9 @@ OptionMenu AutomapOptions protected
 	Option "$AUTOMAPMNU_SHOWKEYS",				"am_showkeys", "OnOff"
 	Option "$AUTOMAPMNU_SHOWTRIGGERLINES",		"am_showtriggerlines", "MapTriggers"
 	Option "$AUTOMAPMNU_SHOWTHINGSPRITES",		"am_showthingsprites", "STSTypes"
+	StaticText " "
+	Option "$AUTOMAPMNU_MARKFONT",				"am_markfont", "MapMarkFont"
+	Option "$AUTOMAPMNU_MARKCOLOR",				"am_markcolor", "TextColors"
 }
 
 //-------------------------------------------------------------------------------------------


### PR DESCRIPTION
Set am_markfont CVAR to a desired font name
Use am_markcolor to select a text color, has no effect with the default font, AMMNUMx