### PR TITLE
Add handling of left and right mousewheel events to the SDL2 input path

### DIFF
--- a/src/posix/sdl/i_input.cpp
+++ b/src/posix/sdl/i_input.cpp
@@ -378,7 +378,12 @@ void MessagePump (const SDL_Event &sev)
 		else
 		{
 			event.type = EV_KeyDown;
-			event.data1 = sev.wheel.y > 0 ? KEY_MWHEELUP : KEY_MWHEELDOWN;
+
+			if (sev.wheel.y != 0)
+				event.data1 = sev.wheel.y > 0 ? KEY_MWHEELUP : KEY_MWHEELDOWN;
+			else
+				event.data1 = sev.wheel.x > 0 ? KEY_MWHEELRIGHT : KEY_MWHEELLEFT;
+
 			D_PostEvent (&event);
 			event.type = EV_KeyUp;
 			D_PostEvent (&event);


### PR DESCRIPTION
So, at least on Linux and other platforms that use SDL2 as the input method, scrolling left and right with the scroll-wheel didn't work and just registered as a scroll-wheel down. Turns out that even though there are keymap constants for horizontal scrolling, the event handler was just assuming all scrolls were vertical scrolls. To remedy this, I added a check to see if the wheel Y had changed, and if not, passed along the wheel X data instead.

Some notes:
- I have no idea whether or not horizontal scrolling works on other, non-SDL2 platforms or not
- If it doesn't, then I'm not knowledgeable enough to fix the Win32 and Cocoa input handlers
- I didn't modify the case for GUI capture, so it still assumes that all scrolls are vertical. I'm not aware this being a problem currently, as I don't know whether or not GUI capture even had horizontal scrolling at any point to begin with. If you'd like me to handle it, even if only to stop horizontal scrolls from generating spurious vertical scrolls, I'd be more than happy to do so.
- I'm not handling [possible mouse-wheel flipping](https://wiki.libsdl.org/SDL_MouseWheelEvent#Remarks) in any way. The vertical code isn't handling it, so I figured I'd follow suit. It happens that my horizontal scrolling is flipped, but it doesn't personally bother me. Again, if you'd like, I can add this handling to all cases if desired.

Thanks!