### PR TITLE
Add language menu to Options

### DIFF
--- a/wadsrc/static/language.enu
+++ b/wadsrc/static/language.enu
@@ -1739,6 +1739,7 @@ OPTMNU_DEFAULTS				= "Reset to defaults";
 OPTMNU_RESETTOSAVED			= "Reset to last saved";
 OPTMNU_CONSOLE				= "Go to console";
 OPTMNU_REVERB				= "Reverb environment editor";
+OPTMNU_LANGUAGE				= "Language";
 
 // Controls Menu
 

--- a/wadsrc/static/language.fr
+++ b/wadsrc/static/language.fr
@@ -1774,6 +1774,7 @@ OPTMNU_DEFAULTS				= "Réinitialiser les paramètres";
 OPTMNU_RESETTOSAVED			= "Recharger dernière config.";
 OPTMNU_CONSOLE				= "Ouvrir la console";
 OPTMNU_REVERB				= "Editeur environement de révérb.";
+OPTMNU_LANGUAGE				= "Langage";
 // Controls Menu
 
 CNTRLMNU_TITLE					= "MODIFIER CONTROLES";

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2521,3 +2521,27 @@ OptionMenu "ReverbSave" protected
 	StaticText "Environments to save"
 	// Rest is filled in by code.
 }
+
+/*=======================================
+ *
+ * Language menu
+ *
+ *=======================================*/
+
+OptionMenu "LanguageOptions"
+{
+	Title "$OPTMNU_LANGUAGE"
+	StaticText " "
+	Command "English (UK)", "language eng"
+	Command "English (US)", "language enu"
+	Command "Français (FR)", "language fr"
+	Command "Italiano (ITA)", "language ita"
+	Command "Português do Brasil (PTB)", "language ptb"
+	Command "Русский (RU)", "language rus"
+}
+
+AddOptionMenu "OptionsMenu"
+{
+	StaticText " "
+	Submenu "$OPTMNU_LANGUAGE", "LanguageOptions"
+}


### PR DESCRIPTION
In this menu, all languages supported by GZDoom are selectable with one simple click! Credits to @PROPHESSOR for making it!

(This only edits the English and French languages because they are the only languages currently up to date with GZDoom’s development. A Russian translation will follow suit at a later date.)

[Preview 1](https://s.put.re/bGzMdoPH.png)
[Preview 2](https://s.put.re/cFsGHXEK.png) (tested with an old version without alphabetical sorting, but the layout is roughly the same)