### PR TITLE
Invalidate unresolved textures explicitly

### DIFF
--- a/src/gamedata/textures/multipatchtexturebuilder.cpp
+++ b/src/gamedata/textures/multipatchtexturebuilder.cpp
@@ -988,6 +988,7 @@ void FMultipatchTextureBuilder::ResolveAllPatches()
 			for (auto &b : BuiltTextures)
 			{
 				Printf("%s\n", b.Name.GetChars());
+				b.tex->SetUseType(ETextureType::Null);
 			}
 			break;
 		}


### PR DESCRIPTION
This should prohibit any attempt to access missing texture's data

https://forum.zdoom.org/viewtopic.php?t=63736