### PR TITLE
MusPlayingInfo ZScript Exposure

### DIFF
--- a/src/s_sound.cpp
+++ b/src/s_sound.cpp
@@ -143,7 +143,7 @@ static FString	 LastSong;			// last music that was played
 static FPlayList *PlayList;
 static int		RestartEvictionsAt;	// do not restart evicted channels before this time
 
-DEFINE_GLOBAL(mus_playing);
+DEFINE_GLOBAL_NAMED(mus_playing, musplaying);
 DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, name);
 DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, baseorder);
 DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, loop);

--- a/src/s_sound.cpp
+++ b/src/s_sound.cpp
@@ -143,6 +143,11 @@ static FString	 LastSong;			// last music that was played
 static FPlayList *PlayList;
 static int		RestartEvictionsAt;	// do not restart evicted channels before this time
 
+DEFINE_GLOBAL(mus_playing);
+DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, name);
+DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, baseorder);
+DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, loop);
+
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
 int sfx_empty;

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -42,6 +42,7 @@ struct _ native	// These are the global variables, the struct is only here to av
 	native readonly Weapon WP_NOCHANGE;
 	deprecated("3.8") native readonly bool globalfreeze;
 	native int LocalViewPitch;
+	native readonly @MusPlayingInfo mus_playing;
 
 // sandbox state in multi-level setups:
 
@@ -51,6 +52,13 @@ struct _ native	// These are the global variables, the struct is only here to av
 	native play LevelLocals Level;
 
 }
+
+struct MusPlayingInfo native
+{
+	native String name;
+	native int baseorder;
+	native bool loop;
+};
 
 struct TexMan
 {

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -42,7 +42,7 @@ struct _ native	// These are the global variables, the struct is only here to av
 	native readonly Weapon WP_NOCHANGE;
 	deprecated("3.8") native readonly bool globalfreeze;
 	native int LocalViewPitch;
-	native readonly @MusPlayingInfo mus_playing;
+	native readonly @MusPlayingInfo musplaying;
 
 // sandbox state in multi-level setups:
 


### PR DESCRIPTION
Exposed MusPlayingInfo to ZScript.

- Allows grabbing the currently playing song, base order, and loop properties under the global `mus_playing` named struct.