### PR TITLE
- set language cvar to global config, it should not be game-specific

### DIFF
--- a/src/g_cvars.cpp
+++ b/src/g_cvars.cpp
@@ -129,7 +129,7 @@ CUSTOM_CVAR(Float, teamdamage, 0.f, CVAR_SERVERINFO | CVAR_NOINITCALL)
 	}
 }
 
-CUSTOM_CVAR(String, language, "auto", CVAR_ARCHIVE | CVAR_NOINITCALL)
+CUSTOM_CVAR(String, language, "auto", CVAR_ARCHIVE | CVAR_NOINITCALL | CVAR_GLOBALCONFIG)
 {
 	SetLanguageIDs();
 	GStrings.UpdateLanguage();


### PR DESCRIPTION
Just my opinion - language should be a global variable, currently you have to set it for every single IWAD.