### PR TITLE
- fix building on FreeBSD

### DIFF
--- a/src/gamedata/resourcefiles/file_wad.cpp
+++ b/src/gamedata/resourcefiles/file_wad.cpp
@@ -33,6 +33,7 @@
 **
 */
 
+#include <ctype.h>
 #include "resourcefile.h"
 #include "v_text.h"
 #include "w_wad.h"

--- a/src/intermission/intermission_parse.cpp
+++ b/src/intermission/intermission_parse.cpp
@@ -34,6 +34,7 @@
 */
 
 
+#include <ctype.h>
 #include "intermission/intermission.h"
 #include "g_level.h"
 #include "w_wad.h"

--- a/src/r_data/voxels.cpp
+++ b/src/r_data/voxels.cpp
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <algorithm>
+#include <ctype.h>
 
 #include "m_swap.h"
 #include "m_argv.h"


### PR DESCRIPTION
I'm doing this via pull request mainly because it modifies a vital file which will cause many files of the project to be rebuilt once this is merged.

This fixes FreeBSD not being able to find vital locale-specific functions such as `tolower()` and `isdigit()` etc.