### PR TITLE
Split “Linear” option value into three

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1755,7 +1755,7 @@ OptionString SpeakerModes
 OptionString Resamplers
 {
 	"NoInterp",		"$OPTSTR_NOINTERPOLATION"
-	"Linear",		"$OPTVAL_LINEAR"
+	"Linear",		"$OPTVAL_LINEAR_1"
 	"Cubic",		"$OPTVAL_CUBIC"
 	"Spline",		"$OPTSTR_SPLINE"
 }
@@ -1893,7 +1893,7 @@ OptionValue ModReplayers
 OptionValue ModQuality
 {
 	0.0, "$OPTVAL_ALIASING"
-	1.0, "$OPTVAL_LINEAR"
+	1.0, "$OPTVAL_LINEAR_1"
 	2.0, "$OPTVAL_CUBIC"
 	3.0, "$OPTVAL_BLEP"		// Band-limited step
 	4.0, "$OPTVAL_LINEARSLOW"
@@ -2224,7 +2224,7 @@ OptionValue "FilterModes"
 	1, "$OPTVAL_NONENEARESTMIPMAP"
 	5, "$OPTVAL_NONELINEARMIPMAP"
 	6, "$OPTVAL_NONETRILINEAR"
-	2, "$OPTVAL_LINEAR"
+	2, "$OPTVAL_LINEAR_2"
 	3, "$OPTVAL_BILINEAR"
 	4, "$OPTVAL_TRILINEAR"
 }
@@ -2235,7 +2235,7 @@ OptionValue "TonemapModes"
 	1, "$OPTVAL_UNCHARTED2"
 	2, "$OPTVAL_HEJLDAWSON"
 	3, "$OPTVAL_REINHARD"
-	4, "$OPTVAL_LINEAR"
+	4, "$OPTVAL_LINEAR_3"
 	5, "$OPTVAL_PALETTE"
 }
 


### PR DESCRIPTION
This option value is used for 4 different options, and splitting it up into three will allow for languages based on grammatical gender systems to have different endings. Necessary for e.g. Russian in order to sound correctly.

The corresponding strings are already in the language spreadsheet.

(Based on [this](https://forum.zdoom.org/viewtopic.php?p=1093787#p1093787) post)

(I might have taken a bad approach to editing the “OptionString Resamplers” at line 1755, because I’m not sure how option strings work. I defaulted it to the first line, which corresponds to neuter in Russian.)