### PR TITLE
Add Kerning for Strife BIGFONT

### DIFF
--- a/wadsrc_extra/static/filter/game-strife/fonts/bigfont/font.inf
+++ b/wadsrc_extra/static/filter/game-strife/fonts/bigfont/font.inf
@@ -1,0 +1,1 @@
+Kerning -1


### PR DESCRIPTION
Very simple change. Strife was missing kerning for its BIGFONT, so I thought to add it.