### PR TITLE
CanTouchItem Virtual

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -460,6 +460,15 @@ class Actor : Thinker native
 	native void Substitute(Actor replacement);
 	native ui void DisplayNameTag();
 
+	// Called by inventory items to see if this actor is capable of touching them.
+	// If true, the item will attempt to be picked up. Useful for things like
+	// allowing morphs to pick up limited items such as keys while preventing
+	// them from picking other items up.
+	virtual bool CanTouchItem(Inventory item)
+	{
+		return true;
+	}
+
 	// Called by PIT_CheckThing to check if two actors actually can collide.
 	virtual bool CanCollideWith(Actor other, bool passive)
 	{

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -768,6 +768,9 @@ class Inventory : Actor
 
 		bool localview = toucher.CheckLocalView();
 
+		if (!toucher.CanTouchItem(self))
+			return;
+
 		bool res;
 		[res, toucher] = CallTryPickup(toucher);
 		if (!res) return;


### PR DESCRIPTION
Added CanTouchItem virtual. (Updated to fix conflict)

- Allows an actor with +PICKUP flag to determine if it can pick up specific items or not.