### PR TITLE
added PickFirstWeapon and hooked it up to the options menu.

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -307,6 +307,26 @@ CCMD (slot)
 	}
 }
 
+CCMD (firstslot)
+{
+	if (argv.argc() > 1)
+	{
+		int slot = atoi (argv[1]);
+
+		auto mo = players[consoleplayer].mo;
+		if (slot < NUM_WEAPON_SLOTS && mo)
+		{
+			// Needs to be redone
+			IFVIRTUALPTRNAME(mo, NAME_PlayerPawn, PickFirstWeapon)
+			{
+				VMValue param[] = { mo, slot, !(dmflags2 & DF2_DONTCHECKAMMO) };
+				VMReturn ret((void**)&SendItemUse);
+				VMCall(func, param, 3, &ret, 1);
+			}
+		}
+	}
+}
+
 CCMD (centerview)
 {
 	Net_WriteByte (DEM_CENTERVIEW);

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -551,6 +551,19 @@ OptionMenu "WeaponsControlMenu" protected
 	Control    "$CNTRLMNU_SLOT8"          , "slot 8"
 	Control    "$CNTRLMNU_SLOT9"          , "slot 9"
 	Control    "$CNTRLMNU_SLOT0"          , "slot 0"
+
+	StaticText ""
+	Control    "$CNTRLMNU_FIRSTSLOT1"     , "firstslot 1"
+	Control    "$CNTRLMNU_FIRSTSLOT2"     , "firstslot 2"
+	Control    "$CNTRLMNU_FIRSTSLOT3"     , "firstslot 3"
+	Control    "$CNTRLMNU_FIRSTSLOT4"     , "firstslot 4"
+	Control    "$CNTRLMNU_FIRSTSLOT5"     , "firstslot 5"
+	Control    "$CNTRLMNU_FIRSTSLOT6"     , "firstslot 6"
+	Control    "$CNTRLMNU_FIRSTSLOT7"     , "firstslot 7"
+	Control    "$CNTRLMNU_FIRSTSLOT8"     , "firstslot 8"
+	Control    "$CNTRLMNU_FIRSTSLOT9"     , "firstslot 9"
+	Control    "$CNTRLMNU_FIRSTSLOT0"     , "firstslot 0"
+
 }
 
 OptionMenu "InventoryControlsMenu" protected

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2128,6 +2128,71 @@ class PlayerPawn : Actor
 
 	//===========================================================================
 	//
+	// FWeaponSlot :: PickFirstWeapon
+	//
+	// Picks the first weapon from this slot. If no weapon is selected in this
+	// slot then it returns the first weapon. If the first weapon is selected
+	// then it returns the last weapon. Otherwise, returns the previous weapon in
+	// this slot. Useful for acessing typically weaker weapons with a single
+	// action. Does not return weapons you have no ammo for or which you do not
+	// possess.
+	//===========================================================================
+
+	virtual Weapon PickFirstWeapon(int slot, bool checkammo)
+	{
+		int i, j;
+
+		let player = self.player;
+		int Size = player.weapons.SlotSize(slot);
+		// Does this slot even have any weapons?
+		if (Size == 0)
+		{
+			return player.ReadyWeapon;
+		}
+		let ReadyWeapon = player.ReadyWeapon;
+		if (ReadyWeapon != null)
+		{
+			for (i = 0; i < Size; i++)
+			{
+				let weapontype = player.weapons.GetWeapon(slot, i);
+				if (weapontype == ReadyWeapon.GetClass() ||
+					(ReadyWeapon.bPOWERED_UP && ReadyWeapon.SisterWeapon != null && ReadyWeapon.SisterWeapon.GetClass() == weapontype))
+				{
+					for (j = (i == 0 ? Size - 1 : i - 1);
+						j != i;
+						j = (j == 0 ? Size - 1 : j - 1))
+					{
+						let weapontype2 = player.weapons.GetWeapon(slot, j);
+						let weap = Weapon(player.mo.FindInventory(weapontype2));
+
+						if (weap != null)
+						{
+							if (!checkammo || weap.CheckAmmo(Weapon.EitherFire, false))
+							{
+								return weap;
+							}
+						}
+					}
+				}
+			}
+		}		
+		{
+			let weapontype = player.weapons.GetWeapon(slot, 0);
+			let weap = Weapon(player.mo.FindInventory(weapontype));
+
+			if (weap != null)
+			{
+				if (!checkammo || weap.CheckAmmo(Weapon.EitherFire, false))
+				{
+					return weap;
+				}
+			}
+		}
+		return ReadyWeapon;
+	}
+
+	//===========================================================================
+	//
 	// FindMostRecentWeapon
 	//
 	// Locates the slot and index for the most recently selected weapon. If the


### PR DESCRIPTION
This lets users bind a hotkey to select the first weapon in a given slot with a single button and hooks it up to the options menu. 
If the user already has the slot selected then it should function the same as pressing the hotkey for the slot does with PickWeapon. 

I think this is easier than creating hotkeys for single weapons, and its a lot more civilized if you're switching between mods with different weapons a lot. Also I think its pretty good to have an easy way to access the regular shotgun without editing text files or using the console. 

I'm not really sure if the naming for the options menu is the best that it can be, but I can't think of anything better.