### PR TITLE
Add weapon depth offset option in stereo 3D

### DIFF
--- a/src/rendering/gl/renderer/gl_postprocess.cpp
+++ b/src/rendering/gl/renderer/gl_postprocess.cpp
@@ -125,7 +125,7 @@ void FGLRenderer::BlurScene(float gameinfobluramount)
 	for (int i = 0; i < eyeCount; ++i)
 	{
 		mBuffers->RenderEffect("BlurScene");
-		if (eyeCount - i > 1) mBuffers->NextEye(eyeCount);
+		if (eyeCount - i > 1) mBuffers->NextEye();
 	}
 }
 
@@ -155,7 +155,7 @@ void FGLRenderer::Flush()
 		{
 			screen->Draw2D();
 			if (eyeCount - eye_ix > 1)
-				mBuffers->NextEye(eyeCount);
+				mBuffers->NextEye();
 		}
 		screen->Clear2D();
 

--- a/src/rendering/gl/renderer/gl_renderbuffers.cpp
+++ b/src/rendering/gl/renderer/gl_renderbuffers.cpp
@@ -34,6 +34,7 @@
 #include "gl/renderer/gl_renderbuffers.h"
 #include "gl/renderer/gl_postprocessstate.h"
 #include "gl/shaders/gl_shaderprogram.h"
+#include "hwrenderer/utility/hw_vrmodes.h"
 #include <random>
 
 CVAR(Int, gl_multisample, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
@@ -1005,14 +1006,14 @@ void FGLRenderBuffers::RenderEffect(const FString &name)
 
 // Store the current stereo 3D eye buffer, and Load the next one
 
-int FGLRenderBuffers::NextEye(int eyeCount)
+void FGLRenderBuffers::NextEye()
 {
-	int nextEye = (mCurrentEye + 1) % eyeCount;
-	if (nextEye == mCurrentEye) return mCurrentEye;
-	BlitToEyeTexture(mCurrentEye);
-	mCurrentEye = nextEye;
-	BlitFromEyeTexture(mCurrentEye);
-	return mCurrentEye;
+	auto * vrmode = VRMode::GetVRMode();
+	int nextEye = (vrmode->mCurrentEye + 1) % vrmode->mEyeCount;
+	if (nextEye == vrmode->mCurrentEye) return;
+	BlitToEyeTexture(vrmode->mCurrentEye);
+	vrmode->mCurrentEye = nextEye;
+	BlitFromEyeTexture(nextEye);
 }
 
 }  // namespace OpenGLRenderer

--- a/src/rendering/gl/renderer/gl_renderbuffers.h
+++ b/src/rendering/gl/renderer/gl_renderbuffers.h
@@ -90,8 +90,7 @@ public:
 	void BlitToEyeTexture(int eye, bool allowInvalidate=true);
 	void BlitFromEyeTexture(int eye);
 	void BindEyeTexture(int eye, int texunit);
-	int NextEye(int eyeCount);
-	int & CurrentEye() { return mCurrentEye; }
+	void NextEye();
 
 	void BindDitherTexture(int texunit);
 
@@ -158,7 +157,6 @@ private:
 	// Eye buffers
 	TArray<PPGLTexture> mEyeTextures;
 	TArray<PPGLFrameBuffer> mEyeFBs;
-	int mCurrentEye = 0;
 
 	// Shadow map texture
 	PPGLTexture mShadowMapTexture;

--- a/src/rendering/gl/renderer/gl_scene.cpp
+++ b/src/rendering/gl/renderer/gl_scene.cpp
@@ -162,12 +162,12 @@ sector_t * FGLRenderer::RenderViewpoint (FRenderViewpoint &mainvp, AActor * came
 
     // Render (potentially) multiple views for stereo 3d
 	// Fixme. The view offsetting should be done with a static table and not require setup of the entire render state for the mode.
-	auto vrmode = VRMode::GetVRMode(mainview && toscreen);
+	auto * vrmode = VRMode::GetVRMode(mainview && toscreen);
 	const int eyeCount = vrmode->mEyeCount;
-	mBuffers->CurrentEye() = 0;  // always begin at zero, in case eye count changed
+	vrmode->mCurrentEye = 0;  // always begin at zero, in case eye count changed
 	for (int eye_ix = 0; eye_ix < eyeCount; ++eye_ix)
 	{
-		const auto &eye = vrmode->mEyes[mBuffers->CurrentEye()];
+		const auto &eye = vrmode->mEyes[vrmode->mCurrentEye];
 		screen->SetViewportRects(bounds);
 
 		if (mainview) // Bind the scene frame buffer and turn on draw buffers used by ssao
@@ -221,7 +221,7 @@ sector_t * FGLRenderer::RenderViewpoint (FRenderViewpoint &mainvp, AActor * came
 		}
 		di->EndDrawInfo();
 		if (eyeCount - eye_ix > 1)
-			mBuffers->NextEye(eyeCount);
+			mBuffers->NextEye();
 	}
 
 	return mainvp.sector;

--- a/src/rendering/gl/renderer/gl_stereo3d.cpp
+++ b/src/rendering/gl/renderer/gl_stereo3d.cpp
@@ -327,11 +327,11 @@ void FGLRenderer::PresentQuadStereo()
 
 void FGLRenderer::PresentStereo()
 {
-	auto vrmode = VRMode::GetVRMode(true);
+	auto const * vrmode = VRMode::GetVRMode(true);
 	const int eyeCount = vrmode->mEyeCount;
 	// Don't invalidate the bound framebuffer (..., false)
 	if (eyeCount > 1)
-		mBuffers->BlitToEyeTexture(mBuffers->CurrentEye(), false);
+		mBuffers->BlitToEyeTexture(vrmode->mCurrentEye, false);
 
 	switch (vr_mode)
 	{

--- a/src/rendering/hwrenderer/utility/hw_vrmodes.h
+++ b/src/rendering/hwrenderer/utility/hw_vrmodes.h
@@ -23,6 +23,8 @@ enum
 
 struct VREyeInfo
 {
+	friend struct VRMode;
+
 	float mShiftFactor;
 	float mScaleFactor;
 
@@ -30,7 +32,6 @@ struct VREyeInfo
 	DVector3 GetViewShift(float yaw) const;
 private:
 	float getShift() const;
-
 };
 
 struct VRMode
@@ -41,7 +42,10 @@ struct VRMode
 	float mWeaponProjectionScale;
 	VREyeInfo mEyes[2];
 
-	static const VRMode *GetVRMode(bool toscreen = true);
+	int mCurrentEye = 0;
+
+	static VRMode *GetVRMode(bool toscreen = true);
+
 	void AdjustViewport(DFrameBuffer *fb) const;
 	VSMatrix GetHUDSpriteProjection() const;
 };

--- a/src/rendering/hwrenderer/utility/hw_vrmodes.h
+++ b/src/rendering/hwrenderer/utility/hw_vrmodes.h
@@ -42,7 +42,7 @@ struct VRMode
 	float mWeaponProjectionScale;
 	VREyeInfo mEyes[2];
 
-	int mCurrentEye = 0;
+	int mCurrentEye;
 
 	static VRMode *GetVRMode(bool toscreen = true);
 


### PR DESCRIPTION
... and refactor mCurrentEye to reduce number of arguments passed around.

This patch adds a CVAR `vr_weapon_depth_offset`, which is used to adjust the apparent depth of the player sprites in stereo 3D. Previously, the player sprites would always appear in the plane of the display screen. Setting vr_weapon_depth_offset to zero places the players sprites in the plane of the screen. Positive values move the sprites away from the player, and negative values move them toward the player. Units are meters.

A small positive value is used as the default; because it's a large enough shift to create an interesting stereoscopic composition, while not violating any rules of good stereoscopic composition. A negative value would be even more interesting, but would be a terrible default mostly because of the occlusion inconsistency with the status bar; and also, less terribly, because it clips at the edge of the stereo window.