### PR TITLE
option search improvements

### DIFF
--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -256,6 +256,7 @@ version "3.8"
 #include "zscript/ui/menu/search/menu.zs"
 #include "zscript/ui/menu/search/searchfield.zs"
 #include "zscript/ui/menu/search/query.zs"
+#include "zscript/ui/menu/search/anyoralloption.zs"
 
 #include "zscript/ui/statscreen/statscreen.zs"
 #include "zscript/ui/statscreen/statscreen_coop.zs"

--- a/wadsrc/static/zscript/ui/menu/search/anyoralloption.zs
+++ b/wadsrc/static/zscript/ui/menu/search/anyoralloption.zs
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+// os_AnyOrAllOption class represents an Option Item for Option Search menu.
+// Changing the value of this option causes the menu to refresh the search
+// results.
+//
+//=============================================================================
+
+class os_AnyOrAllOption : OptionMenuItemOption
+{
+	os_AnyOrAllOption Init(os_Menu menu)
+	{
+		Super.Init("", "os_isanyof", "os_isanyof_values");
+
+		mMenu = menu;
+
+		return self;
+	}
+
+	override bool MenuEvent(int mkey, bool fromcontroller)
+	{
+		bool result = Super.MenuEvent(mkey, fromcontroller);
+
+		if (mKey == Menu.MKEY_Left || mKey == Menu.MKEY_Right)
+		{
+			mMenu.search();
+		}
+
+		return result;
+	}
+
+	private os_Menu mMenu;
+}

--- a/wadsrc/static/zscript/ui/menu/search/query.zs
+++ b/wadsrc/static/zscript/ui/menu/search/query.zs
@@ -19,8 +19,6 @@ class os_Query
 
 		str.Split(query.mQueryParts, " ", TOK_SKIPEMPTY);
 
-		query.mText = str;
-
 		return query;
 	}
 
@@ -30,8 +28,6 @@ class os_Query
 			? matchesAny(text)
 			: matchesAll(text);
 	}
-
-	string getText() { return mText; }
 
 	// private: //////////////////////////////////////////////////////////////////
 
@@ -73,6 +69,5 @@ class os_Query
 		return contains;
 	}
 
-	private string        mText;
 	private Array<String> mQueryParts;
 }

--- a/wadsrc/static/zscript/ui/menu/search/searchfield.zs
+++ b/wadsrc/static/zscript/ui/menu/search/searchfield.zs
@@ -30,10 +30,9 @@ class os_SearchField : OptionMenuItemTextField
 		}
 		if (mkey == Menu.MKEY_Input)
 		{
-			string text  = mEnter.GetText();
-			let    query = os_Query.fromString(text);
+			mtext = mEnter.GetText();
 
-			mMenu.search(query);
+			mMenu.search();
 		}
 
 		return Super.MenuEvent(mkey, fromcontroller);
@@ -45,6 +44,8 @@ class os_SearchField : OptionMenuItemTextField
 			? mEnter.GetText() .. SmallFont.GetCursor()
 			: mText;
 	}
+
+	String GetText() { return mText; }
 
 	private os_Menu mMenu;
 	private string  mText;


### PR DESCRIPTION
1. Top-level menu names are now properly handled.
2. Changing "Any or All terms" option now immediately updates the results.
3. Reformatted menu.zs to have tabs instead of spaces.

This string from https://github.com/coelckers/gzdoom/pull/786 is not needed anymore:
`OS_MAIN       = "Main Options";`