### PR TITLE
Fixed misplaced vertex on Community Chest MAP16

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1307,6 +1307,11 @@ class LevelCompatibility native play
 				break;
 			}
 
+			case '5E9AF879343D6E44E429F91D57777D26': // cchest.wad map16
+			{
+				// Fix misplaced vertex
+				SetVertex(202, -2, -873);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes [a misplaced vertex](https://imgur.com/hwNEQUh) on [Community Chest MAP16](https://doomwiki.org/wiki/MAP16:_Methods_of_Fear_(Community_Chest)). The position of the vertex in question does not prevent the map from being completed but produces [a rather gross visual glitch](https://imgur.com/uRQT5hT). Moving the vertex 2 units to the north [averts the crisis](https://imgur.com/re2prmp).