### PR TITLE
Update language list in MENUDEF

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2651,12 +2651,14 @@ OptionMenu "ReverbSave" protected
 OptionString "LanguageOptions"
 {
 	"auto", "Auto"
+	"default", "English (US)"
 	"eng", "English (UK)"
-	"enu", "English (US)"
-	"fr", "Français (FR)"
-	"ita", "Italiano (ITA)"
-	"ptb", "Português do Brasil (PTB)"
-	"rus", "Русский (RU)"
+	"de", "Deutsch"
+	"es", "Español (España)"
+	"esm", "Español (Latino)"
+	"fr", "Français"
+	"it", "Italiano"
+	"ru", "Русский"
 }
 
 /*=======================================


### PR DESCRIPTION
The file renames “enu” to “default” for consistency and only contains languages that are complete/up to date, i.e. American English, British English, German, Castilian Spanish, Latin American Spanish, French, and Russian. Italian, while not 100% complete, contains a full engine translation, so it has enough material to make it here.