### PR TITLE
Fix build on big-endian platforms

### DIFF
--- a/src/utility/m_swap.h
+++ b/src/utility/m_swap.h
@@ -129,6 +129,16 @@ inline int BigLong(int &x)
 	return x;
 }
 
+inline unsigned int BigLong(unsigned int x)
+{
+	return x;
+}
+
+inline int BigLong(int x)
+{
+	return x;
+}
+
 #else
 
 inline short LittleShort(short x)


### PR DESCRIPTION
GCC 8 complains that it can't find relevant functions:
```
/wrkdirs/usr/ports/games/gzdoom/work/gzdoom-g3.7.2/src/m_png.cpp:669:42: error: call of overloaded 'BigLong(uint32_t)' is ambiguous
     chunklen = BigLong((unsigned int)x[1]);
                                          ^
In file included from /wrkdirs/usr/ports/games/gzdoom/work/gzdoom-g3.7.2/src/m_png.cpp:44:
/wrkdirs/usr/ports/games/gzdoom/work/gzdoom-g3.7.2/src/m_swap.h:212:15: note: candidate: 'long unsigned int BigLong(long unsigned int)' <deleted>
 unsigned long BigLong(unsigned long) = delete;
               ^~~~~~~
/wrkdirs/usr/ports/games/gzdoom/work/gzdoom-g3.7.2/src/m_swap.h:213:6: note: candidate: 'long int BigLong(long int)' <deleted>
 long BigLong(long) = delete;
```
This is on FreeBSD/powerpc64.