### PR TITLE
Fix typo: add missing dollar sign in new stereo 3D submenu definition

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2529,7 +2529,7 @@ OptionMenu "OpenGLOptions" protected
 
 OptionMenu "VR3DMenu" protected
 {
-	Title "GLPREFMNU_VRMODE"
+	Title "$GLPREFMNU_VRMODE"
 	Option "$GLMNU_3DMODE",					vr_mode, 						"VRMode"
 	IfOption(Windows)
 	{


### PR DESCRIPTION
...because "GLPREFMNU_VRMODE" is a terrible options menu title to display on screen.