### PR TITLE
Added support for monospacing alignment modes to HUDFont / BaseStatusBar.DrawString

### DIFF
--- a/src/g_statusbar/sbar.h
+++ b/src/g_statusbar/sbar.h
@@ -38,7 +38,6 @@
 #include "dobject.h"
 #include "v_collection.h"
 #include "v_text.h"
-#include "v_video.h"
 #include "r_data/renderstyle.h"
 
 class player_t;
@@ -52,6 +51,8 @@ enum EHudState
 
 	HUD_AltHud // Used for passing through popups to the alt hud
 };
+
+enum EMonospacing : int;
 
 // HUD Message base object --------------------------------------------------
 

--- a/src/g_statusbar/sbar.h
+++ b/src/g_statusbar/sbar.h
@@ -38,6 +38,7 @@
 #include "dobject.h"
 #include "v_collection.h"
 #include "v_text.h"
+#include "v_video.h"
 #include "r_data/renderstyle.h"
 
 class player_t;
@@ -332,12 +333,12 @@ class DHUDFont : public DObject
 public:
 	FFont *mFont;
 	int mSpacing;
-	bool mMonospaced;
+	EMonospacing mMonospacing;
 	int mShadowX;
 	int mShadowY;
 
-	DHUDFont(FFont *f, int sp, bool ms, int sx, int sy)
-		: mFont(f), mSpacing(sp), mMonospaced(ms), mShadowX(sx), mShadowY(sy)
+	DHUDFont(FFont *f, int sp, EMonospacing ms, int sx, int sy)
+		: mFont(f), mSpacing(sp), mMonospacing(ms), mShadowX(sx), mShadowY(sy)
 	{}
 };
 
@@ -434,7 +435,7 @@ public:
 	void DrawAltHUD();
 
 	void DrawGraphic(FTextureID texture, double x, double y, int flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY);
-	void DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, bool monospaced, int shadowX, int shadowY);
+	void DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY);
 	void TransformRect(double &x, double &y, double &w, double &h, int flags = 0);
 	void Fill(PalEntry color, double x, double y, double w, double h, int flags = 0);
 	void SetClipRect(double x, double y, double w, double h, int flags = 0);

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -1586,8 +1586,10 @@ void DBaseStatusBar::DrawGraphic(FTextureID texture, double x, double y, int fla
 //
 //============================================================================
 
-void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, bool monospaced, int shadowX, int shadowY)
+void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY)
 {
+	bool monospaced = monospacing != EMonospacing::Off;
+
 	switch (flags & DI_TEXT_ALIGN)
 	{
 	default:
@@ -1671,6 +1673,11 @@ void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, d
 		rw = c->GetDisplayWidthDouble();
 		rh = c->GetDisplayHeightDouble();
 
+		if (monospacing == EMonospacing::CellCenter)
+			rx += (spacing - rw) / 2;
+		else if (monospacing == EMonospacing::CellRight)
+			rx += (spacing - rw);
+
 		if (!fullscreenOffsets)
 		{
 			StatusbarToRealCoords(rx, ry, rw, rh);
@@ -1707,7 +1714,6 @@ void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, d
 		else
 			x += spacing;
 	}
-
 }
 
 void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string, double x, double y, int flags, int trans, double alpha, int wrapwidth, int linespacing)
@@ -1729,13 +1735,13 @@ void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string
 		auto brk = V_BreakLines(font->mFont, wrapwidth, string, true);
 		for (auto &line : brk)
 		{
-			self->DrawString(font->mFont, line.Text, x, y, flags, alpha, trans, font->mSpacing, font->mMonospaced, font->mShadowX, font->mShadowY);
+			self->DrawString(font->mFont, line.Text, x, y, flags, alpha, trans, font->mSpacing, font->mMonospacing, font->mShadowX, font->mShadowY);
 			y += font->mFont->GetHeight() + linespacing;
 		}
 	}
 	else
 	{
-		self->DrawString(font->mFont, string, x, y, flags, alpha, trans, font->mSpacing, font->mMonospaced, font->mShadowX, font->mShadowY);
+		self->DrawString(font->mFont, string, x, y, flags, alpha, trans, font->mSpacing, font->mMonospacing, font->mShadowX, font->mShadowY);
 	}
 }
 

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2632,9 +2632,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(DBaseStatusBar, GetInventoryIcon, GetInventoryIcon
 //
 //=====================================================================================
 
-DHUDFont *CreateHudFont(FFont *fnt, int spac, bool mono, int sx, int sy)
+DHUDFont *CreateHudFont(FFont *fnt, int spac, int mono, int sx, int sy)
 {
-	return (Create<DHUDFont>(fnt, spac, mono, sy, sy));
+	return (Create<DHUDFont>(fnt, spac, EMonospacing(mono), sy, sy));
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DHUDFont, Create, CreateHudFont)
@@ -2642,10 +2642,10 @@ DEFINE_ACTION_FUNCTION_NATIVE(DHUDFont, Create, CreateHudFont)
 	PARAM_PROLOGUE;
 	PARAM_POINTER(fnt, FFont);
 	PARAM_INT(spac);
-	PARAM_BOOL(mono);
+	PARAM_INT(mono);
 	PARAM_INT(sx);
 	PARAM_INT(sy);
-	ACTION_RETURN_POINTER(Create<DHUDFont>(fnt, spac, mono, sy, sy));
+	ACTION_RETURN_POINTER(Create<DHUDFont>(fnt, spac, EMonospacing(mono), sy, sy));
 }
 
 

--- a/src/v_video.h
+++ b/src/v_video.h
@@ -240,7 +240,7 @@ enum
 	DTA_Monospace,			// Fonts only: Use a fixed distance between characters.
 };
 
-enum EMonospacing
+enum EMonospacing : int
 {
 	Off = 0,
 	CellLeft = 1,

--- a/wadsrc/static/zscript/ui/statusbar/doom_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/doom_sbar.zs
@@ -13,9 +13,9 @@ class DoomStatusBar : BaseStatusBar
 
 		// Create the font used for the fullscreen HUD
 		Font fnt = "HUDFONT_DOOM";
-		mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), true, 1, 1);
+		mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft, 1, 1);
 		fnt = "INDEXFONT_DOOM";
-		mIndexFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), true);
+		mIndexFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft);
 		mAmountFont = HUDFont.Create("INDEXFONT");
 		diparms = InventoryBarState.Create();
 	}

--- a/wadsrc/static/zscript/ui/statusbar/heretic_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/heretic_sbar.zs
@@ -16,11 +16,11 @@ class HereticStatusBar : BaseStatusBar
 
 		// Create the font used for the fullscreen HUD
 		Font fnt = "HUDFONT_RAVEN";
-		mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0") + 1, true, 1, 1);
+		mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0") + 1, Mono_CellLeft, 1, 1);
 		fnt = "INDEXFONT_RAVEN";
-		mIndexFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), true);
+		mIndexFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft);
 		fnt = "BIGFONT";
-		mBigFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), true, 2, 2);
+		mBigFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft, 2, 2);
 		diparms = InventoryBarState.Create(mIndexFont);
 		diparms_sbar = InventoryBarState.CreateNoBox(mIndexFont, boxsize:(31, 31), arrowoffs:(0,-10));
 		mHealthInterpolator = DynamicValueInterpolator.Create(0, 0.25, 1, 8);

--- a/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
@@ -16,11 +16,11 @@ class HexenStatusBar : BaseStatusBar
 
 		// Create the font used for the fullscreen HUD
 		Font fnt = "HUDFONT_RAVEN";
-		mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0") + 1, true, 1, 1);
+		mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0") + 1, Mono_CellLeft, 1, 1);
 		fnt = "INDEXFONT_RAVEN";
-		mIndexFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), true);
+		mIndexFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft);
 		fnt = "BIGFONT";
-		mBigFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), true, 2, 2);
+		mBigFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft, 2, 2);
 		diparms = InventoryBarState.Create(mIndexFont);
 		diparms_sbar = InventoryBarState.CreateNoBox(mIndexFont, boxsize:(31, 31), arrowoffs:(0,-10));
 		mHealthInterpolator = DynamicValueInterpolator.Create(0, 0.25, 1, 8);

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -18,7 +18,7 @@ struct MugShot
 class HUDFont native ui
 {
 	native Font mFont;
-	native static HUDFont Create(Font fnt, int spacing = 0, bool monospaced = false, int shadowx = 0, int shadowy = 0);
+	native static HUDFont Create(Font fnt, int spacing = 0, EMonospacing monospacing = Mono_Off, int shadowx = 0, int shadowy = 0);
 }
 
 class InventoryBarState ui

--- a/wadsrc/static/zscript/ui/statusbar/strife_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/strife_sbar.zs
@@ -63,9 +63,9 @@ class StrifeStatusBar : BaseStatusBar
 
 		CursorImage = Images[imgINVCURS].IsValid() ? imgINVCURS : imgCURSOR01;
 		
-		mYelFont = HUDFont.Create("Indexfont_Strife_Yellow", 7, true, 1, 1);
-		mGrnFont = HUDFont.Create("Indexfont_Strife_Green", 7, true, 1, 1);
-		mBigFont = HUDFont.Create("BigFont", 0, false, 2, 2);
+		mYelFont = HUDFont.Create("Indexfont_Strife_Yellow", 7, Mono_CellLeft, 1, 1);
+		mGrnFont = HUDFont.Create("Indexfont_Strife_Green", 7, Mono_CellLeft, 1, 1);
+		mBigFont = HUDFont.Create("BigFont", 0, Mono_Off, 2, 2);
 	}
 
 	override void NewGame ()


### PR DESCRIPTION
This PR adds support for monospacing alignment modes to HUDFont (and therefore to BaseStatusBar.DrawString). See [here](https://forum.zdoom.org/viewtopic.php?f=15&t=64268) for details. Updated test WAD / screenshot can be found in the thread.