### PR TITLE
Added "const" qualifiers to the new UTF-8-aware string methods

### DIFF
--- a/src/utility/zstring.cpp
+++ b/src/utility/zstring.cpp
@@ -681,7 +681,7 @@ void FString::ToLower ()
 	UnlockBuffer();
 }
 
-FString FString::MakeLower()
+FString FString::MakeLower() const
 {
 	TArray<uint8_t> builder(Len());
 	int pos = 0;
@@ -694,7 +694,7 @@ FString FString::MakeLower()
 	return FString(builder);
 }
 
-FString FString::MakeUpper()
+FString FString::MakeUpper() const
 {
 	TArray<uint8_t> builder(Len());
 	int pos = 0;

--- a/src/utility/zstring.h
+++ b/src/utility/zstring.h
@@ -238,8 +238,8 @@ public:
 
 	void ToUpper ();
 	void ToLower ();
-	FString MakeUpper();
-	FString MakeLower();
+	FString MakeUpper() const;
+	FString MakeLower() const;
 
 	void StripLeft ();
 	void StripLeft (const FString &charset);

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -909,8 +909,8 @@ struct StringStruct native
 	native int RightIndexOf(String substr, int endIndex = 2147483647) const;
 	deprecated("4.1") native void ToUpper();
 	deprecated("4.1") native void ToLower();
-	native String MakeUpper();
-	native String MakeLower();
+	native String MakeUpper() const;
+	native String MakeLower() const;
 	native static int CharUpper(int ch);
 	native static int CharLower(int ch);
 	native int ToInt(int base = 0) const;
@@ -918,8 +918,8 @@ struct StringStruct native
 	native void Split(out Array<String> tokens, String delimiter, EmptyTokenType keepEmpty = TOK_KEEPEMPTY) const;
 	native void AppendCharacter(int c);
 	native void DeleteLastCharacter();
-	native int CodePointCount();
-	native int, int GetNextCodePoint(int position);
+	native int CodePointCount() const;
+	native int, int GetNextCodePoint(int position) const;
 }
 
 class SectorEffect : Thinker native


### PR DESCRIPTION
The recently added methods lack "const" qualifiers on the script side; `MakeUpper` and `MakeLower` lack them in the source code as well.