### PR TITLE
Fixed "Force respawn" and "Respawn protection" not being DM-only

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -231,7 +231,7 @@ class PlayerPawn : Actor
 
 	virtual void OnRespawn()
 	{
-		if (sv_respawnprotect && (multiplayer || alwaysapplydmflags))
+		if (sv_respawnprotect && (deathmatch || alwaysapplydmflags))
 		{
 			let invul = Powerup(Spawn("PowerInvulnerable"));
 			invul.EffectTics = 3 * TICRATE;
@@ -718,7 +718,7 @@ class PlayerPawn : Actor
 		}		
 
 		if ((player.cmd.buttons & BT_USE ||
-			((multiplayer || alwaysapplydmflags) && sv_forcerespawn)) && !sv_norespawn)
+			((deathmatch || alwaysapplydmflags) && sv_forcerespawn)) && !sv_norespawn)
 		{
 			if (Level.maptime >= player.respawn_time || ((player.cmd.buttons & BT_USE) && player.Bot == NULL))
 			{


### PR DESCRIPTION
The two deathmatch-only DMFlags, "Force respawn" and "Respawn protection", do not currently function as deathmatch-only despite being placed in the "Deathmatch settings" submenu. This is because the correct condition to test for when checking whether these flags are enabled should be `deathmatch || alwaysapplydmflags` instead of `multiplayer || alwaysapplydmflags`. Multiplayer is always true for net games regardless of whether the current game is a deathmatch game, so the current logic is obviously flawed.