### PR TITLE
Fixed random generation of friendly obituaries

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -252,7 +252,7 @@ class PlayerPawn : Actor
 		if (victim.player != player && victim.IsTeammate(self))
 		{
 			victim = self;
-			return String.Format("$OB_FRIENDLY%c", random[Obituary](49, 53));
+			return String.Format("$OB_FRIENDLY%d", random[Obituary](1, 4));
 		}
 		else
 		{


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?f=2&t=64493) for details.

This PR fixes a bug where "friendly kill" obituaries are sometimes replaced with the generic "Player died" obituary. My original assumption was incorrect, though - this is just an issue with random generation. The current code can return values from OB_FRIENDLY1 to OB_FRIENDLY5, but since OB_FRIENDLY5 does not exist, the game falls back to OB_DEFAULT ("Player died"). I also made that whole part of code more obvious by replacing ~magic numbers~ ASCII character codes with integer values that get substituted directly into the format string.