### PR TITLE
Postponed destruction of Vulkan resources

### DIFF
--- a/src/rendering/vulkan/renderer/vk_renderpass.cpp
+++ b/src/rendering/vulkan/renderer/vk_renderpass.cpp
@@ -33,6 +33,15 @@ void VkRenderPassManager::RenderBuffersReset()
 
 void VkRenderPassManager::TextureSetPoolReset()
 {
+	if (auto fb = GetVulkanFrameBuffer())
+	{
+		auto &deleteList = fb->FrameDeleteList;
+
+		for (auto &desc : TextureDescriptorPools)
+		{
+			deleteList.DescriptorPools.push_back(std::move(desc));
+		}
+	}
 	TextureDescriptorPools.clear();
 	TextureDescriptorSetsLeft = 0;
 	TextureDescriptorsLeft = 0;

--- a/src/rendering/vulkan/system/vk_framebuffer.cpp
+++ b/src/rendering/vulkan/system/vk_framebuffer.cpp
@@ -188,6 +188,7 @@ void VulkanFrameBuffer::DeleteFrameObjects()
 	FrameDeleteList.ImageViews.clear();
 	FrameDeleteList.Buffers.clear();
 	FrameDeleteList.Descriptors.clear();
+	FrameDeleteList.DescriptorPools.clear();
 	FrameDeleteList.CommandBuffers.clear();
 }
 

--- a/src/rendering/vulkan/system/vk_framebuffer.h
+++ b/src/rendering/vulkan/system/vk_framebuffer.h
@@ -59,6 +59,7 @@ public:
 		std::vector<std::unique_ptr<VulkanImageView>> ImageViews;
 		std::vector<std::unique_ptr<VulkanBuffer>> Buffers;
 		std::vector<std::unique_ptr<VulkanDescriptorSet>> Descriptors;
+		std::vector<std::unique_ptr<VulkanDescriptorPool>> DescriptorPools;
 		std::vector<std::unique_ptr<VulkanCommandBuffer>> CommandBuffers;
 	} FrameDeleteList;
 

--- a/src/rendering/vulkan/textures/vk_hwtexture.cpp
+++ b/src/rendering/vulkan/textures/vk_hwtexture.cpp
@@ -53,32 +53,34 @@ VkHardwareTexture::~VkHardwareTexture()
 	if (Prev) Prev->Next = Next;
 	else First = Next;
 
-	auto fb = GetVulkanFrameBuffer();
-	if (fb)
+	Reset();
+}
+
+void VkHardwareTexture::Reset()
+{
+	if (auto fb = GetVulkanFrameBuffer())
 	{
+		ResetDescriptors();
+
 		auto &deleteList = fb->FrameDeleteList;
-		for (auto &it : mDescriptorSets)
-		{
-			deleteList.Descriptors.push_back(std::move(it.descriptor));
-			it.descriptor = nullptr;
-		}
-		mDescriptorSets.clear();
 		if (mImage) deleteList.Images.push_back(std::move(mImage));
 		if (mImageView) deleteList.ImageViews.push_back(std::move(mImageView));
 		if (mStagingBuffer) deleteList.Buffers.push_back(std::move(mStagingBuffer));
 	}
 }
 
-void VkHardwareTexture::Reset()
-{
-	mDescriptorSets.clear();
-	mImage.reset();
-	mImageView.reset();
-	mStagingBuffer.reset();
-}
-
 void VkHardwareTexture::ResetDescriptors()
 {
+	if (auto fb = GetVulkanFrameBuffer())
+	{
+		auto &deleteList = fb->FrameDeleteList;
+
+		for (auto &it : mDescriptorSets)
+		{
+			deleteList.Descriptors.push_back(std::move(it.descriptor));
+		}
+	}
+
 	mDescriptorSets.clear();
 }
 


### PR DESCRIPTION
Provided uniform way to handle lifetime of some of Vulkan resources
This helps to avoid issues like descriptor set that outlives its pool

https://forum.zdoom.org/viewtopic.php?t=64341