### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/gamedata/fonts/font.cpp
+++ b/src/gamedata/fonts/font.cpp
@@ -35,6 +35,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <cwctype>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>

--- a/src/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h
+++ b/src/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h
@@ -2229,7 +2229,7 @@ remove them if not needed.
 #include <mutex> // for std::mutex
 #include <atomic> // for std::atomic
 
-#if !defined(_WIN32) && !defined(__APPLE__)
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__FreeBSD__)
     #include <malloc.h> // for aligned_alloc()
 #endif
 


### PR DESCRIPTION
On FreeBSD malloc.h is deprecated.
cwctype is needed for iswalpha.