### PR TITLE
Greek Sigma character fallback

### DIFF
--- a/src/gamedata/fonts/v_font.cpp
+++ b/src/gamedata/fonts/v_font.cpp
@@ -869,6 +869,9 @@ int stripaccent(int code)
 		case 0x201e:
 			return '"';	// typographic quotation marks
 			
+		case 0x3c2:
+			return 0x3c3;	// Lowercase Sigma character in Greek, which changes depending on its positioning in a word; if the font is uppercase only or features a smallcaps style, the second variant of the letter will remain unused
+			
 			// Cyrillic characters with equivalents in the Latin alphabet.
 		case 0x400:
 			return 0xc8;


### PR DESCRIPTION
The lowercase Sigma letter in Greek has two different forms (σ and ς), which changes depending on its placement in a word, but in uppercase and smallcaps contexts, it only has one look regardless of word positioning. If the character ς is missing, it should fall back to σ.