### PR TITLE
Fixes for Door_AnimatedClose

### DIFF
--- a/src/g_shared/a_doors.cpp
+++ b/src/g_shared/a_doors.cpp
@@ -799,7 +799,6 @@ bool FLevelLocals::EV_SlidingDoor (line_t *line, AActor *actor, int tag, int spe
 			if (sec->ceilingdata->IsA (RUNTIME_CLASS(DAnimatedDoor)))
 			{
 				DAnimatedDoor *door = barrier_cast<DAnimatedDoor *>(sec->ceilingdata);
-				door->StartClosing();
 				if (door->m_Status == DAnimatedDoor::Waiting)
 				{
 					door->StartClosing();

--- a/src/g_shared/a_doors.cpp
+++ b/src/g_shared/a_doors.cpp
@@ -777,6 +777,9 @@ bool FLevelLocals::EV_SlidingDoor (line_t *line, AActor *actor, int tag, int spe
 			}
 			return false;
 		}
+		// Do not attempt to close the door if it already is
+		else if (type == DAnimatedDoor::adClose)
+			return false;
 		FDoorAnimation *anim = TexMan.FindAnimatedDoor (line->sidedef[0]->GetTexture(side_t::top));
 		if (anim != NULL)
 		{
@@ -792,8 +795,21 @@ bool FLevelLocals::EV_SlidingDoor (line_t *line, AActor *actor, int tag, int spe
 		sec = &sectors[secnum];
 		if (sec->ceilingdata != NULL)
 		{
+			// Check if the animated door is already open and waiting, if so, close it.
+			if (sec->ceilingdata->IsA (RUNTIME_CLASS(DAnimatedDoor)))
+			{
+				DAnimatedDoor *door = barrier_cast<DAnimatedDoor *>(sec->ceilingdata);
+				door->StartClosing();
+				if (door->m_Status == DAnimatedDoor::Waiting)
+				{
+					door->StartClosing();
+				}
+			}
 			continue;
 		}
+		// Do not attempt to close the door if it already is
+		else if (type == DAnimatedDoor::adClose)
+			continue;
 
 		for (auto line : sec->Lines)
 		{


### PR DESCRIPTION
- Fixing that Door_AnimatedClose would be activated on an already closed door (playing the sound and the 1st frame of the animation)
- There was no check if the Door is already Animated when a tag was used with Door_AnimatedClose