### PR TITLE
Remove array length() function from shadowmap shader

### DIFF
--- a/src/rendering/gl/renderer/gl_renderer.cpp
+++ b/src/rendering/gl/renderer/gl_renderer.cpp
@@ -195,6 +195,7 @@ void FGLRenderer::UpdateShadowMap()
 
 		mShadowMapShader->Bind();
 		mShadowMapShader->Uniforms->ShadowmapQuality = gl_shadowmap_quality;
+		mShadowMapShader->Uniforms->NodesCount = screen->mShadowMap.NodesCount();
 		mShadowMapShader->Uniforms.Set();
 
 		glViewport(0, 0, gl_shadowmap_quality, 1024);

--- a/src/rendering/hwrenderer/dynlights/hw_aabbtree.h
+++ b/src/rendering/hwrenderer/dynlights/hw_aabbtree.h
@@ -53,6 +53,7 @@ public:
 	const void *Lines() const { return treelines.Data(); }
 	size_t NodesSize() const { return nodes.Size() * sizeof(AABBTreeNode); }
 	size_t LinesSize() const { return treelines.Size() * sizeof(AABBTreeLine); }
+	unsigned int NodesCount() const { return nodes.Size(); }
 
 	const void *DynamicNodes() const { return nodes.Data() + dynamicStartNode; }
 	const void *DynamicLines() const { return treelines.Data() + dynamicStartLine; }

--- a/src/rendering/hwrenderer/dynlights/hw_shadowmap.h
+++ b/src/rendering/hwrenderer/dynlights/hw_shadowmap.h
@@ -34,6 +34,12 @@ public:
 		UpdateCycles.Clock();
 	}
 
+	unsigned int NodesCount() const
+	{
+		assert(mAABBTree);
+		return mAABBTree->NodesCount();
+	}
+
 protected:
 	void CollectLights();
 	bool ValidateAABBTree(FLevelLocals *lev);

--- a/src/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
+++ b/src/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
@@ -845,6 +845,7 @@ void PPShadowMap::Update(PPRenderState *renderstate)
 {
 	ShadowMapUniforms uniforms;
 	uniforms.ShadowmapQuality = (float)gl_shadowmap_quality;
+	uniforms.NodesCount = screen->mShadowMap.NodesCount();
 
 	renderstate->PushGroup("shadowmap");
 

--- a/src/rendering/hwrenderer/postprocessing/hw_postprocess.h
+++ b/src/rendering/hwrenderer/postprocessing/hw_postprocess.h
@@ -762,16 +762,17 @@ public:
 struct ShadowMapUniforms
 {
 	float ShadowmapQuality;
-	float Padding0, Padding1, Padding2;
+	int NodesCount;
+	float Padding0, Padding1;
 
 	static std::vector<UniformFieldDesc> Desc()
 	{
 		return
 		{
 			{ "ShadowmapQuality", UniformType::Float, offsetof(ShadowMapUniforms, ShadowmapQuality) },
+			{ "NodesCount", UniformType::Int, offsetof(ShadowMapUniforms, NodesCount) },
 			{ "Padding0", UniformType::Float, offsetof(ShadowMapUniforms, Padding0) },
 			{ "Padding1", UniformType::Float, offsetof(ShadowMapUniforms, Padding1) },
-			{ "Padding2", UniformType::Float, offsetof(ShadowMapUniforms, Padding2) },
 		};
 	}
 };

--- a/wadsrc/static/shaders/glsl/shadowmap.fp
+++ b/wadsrc/static/shaders/glsl/shadowmap.fp
@@ -111,7 +111,7 @@ float rayTest(vec2 ray_start, vec2 ray_end)
 
 	int stack[32];
 	int stack_pos = 1;
-	stack[0] = nodes.length() - 1;
+	stack[0] = NodesCount - 1;
 	while (stack_pos > 0)
 	{
 		int node_index = stack[stack_pos - 1];


### PR DESCRIPTION
Array's length() function is not yet supported by SPIRV-Cross and MoltenVK
Its usage was replaced by explicit nodes count value passed as uniform