### PR TITLE
Fix bot vertical aim

### DIFF
--- a/src/b_move.cpp
+++ b/src/b_move.cpp
@@ -380,7 +380,7 @@ void DBot::Pitch (AActor *target)
 
 	diff = target->Z() - player->mo->Z();
 	aim = g_atan(diff / player->mo->Distance2D(target));
-	player->mo->Angles.Pitch = DAngle::ToDegrees(aim);
+	player->mo->Angles.Pitch = -DAngle::ToDegrees(aim);
 }
 
 //Checks if a sector is dangerous.


### PR DESCRIPTION
Bots aim upwards when an enemy is below, and vice versa. This is a crude fix.
Easily seen when going to Doom II's MAP01, running "addbot" and "spynext" to watch the bot aiming upwards (or downwards with this patch).

I am sure this is supposed to be done in some better way, but so far it works.