### PR TITLE
Fix clang/32-bit build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1458,10 +1458,9 @@ if( ZD_CMAKE_COMPILER_IS_GNUCXX_COMPATIBLE )
 	# Need to enable intrinsics for these files.
 	if( SSE_MATTERS )
 		set_source_files_properties(
-			gl/system/gl_swframebuffer.cpp
-			polyrenderer/poly_all.cpp
-			swrenderer/r_all.cpp
-			x86.cpp
+			rendering/polyrenderer/poly_all.cpp
+			rendering/swrenderer/r_all.cpp
+			utility/x86.cpp
 			PROPERTIES COMPILE_FLAGS "-msse2 -mmmx" )
 	endif()
 endif()


### PR DESCRIPTION
Rendering bits got restructured and the SSE_MATTERS paths were not updated
to reflect that. A 32-bit build with clang subsequently complaints as the
files in question are not compiled with -mmmx.