### PR TITLE
Fix for premature destruction of in-use HUD messages

### DIFF
--- a/src/g_statusbar/sbar.h
+++ b/src/g_statusbar/sbar.h
@@ -458,6 +458,8 @@ public:
 	void RefreshBackground () const;
 	void RefreshViewBorder ();
 
+	virtual size_t PropagateMark() override;
+
 private:
 	DObject *AltHud = nullptr;
 

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -1899,6 +1899,33 @@ void DBaseStatusBar::SetClipRect(double x, double y, double w, double h, int fla
 	screen->SetClipRect(x1, y1, ww, hh);
 }
 
+//============================================================================
+//
+// Garbage collection stuff
+//
+//============================================================================
+
+size_t DBaseStatusBar::PropagateMark()
+{
+	size_t marked = sizeof *this;
+
+	for (size_t i = 0; i < countof(Messages); ++i)
+	{
+		DHUDMessageBase *message = Messages[i];
+
+		while (message != nullptr)
+		{
+			GC::Mark(message);
+			marked += sizeof *message;
+
+			message = message->Next;
+		}
+	}
+
+	marked += Super::PropagateMark();
+
+	return marked;
+}
 
 //============================================================================
 //


### PR DESCRIPTION
Garbage collector must be notified explicitly about active HUD messages
Othewise, arbitrary node(s) from status bar's internal linked lists can be destructed prematurely

https://forum.zdoom.org/viewtopic.php?t=64823