### PR TITLE
Fix OBJ face normal direction

### DIFF
--- a/src/r_data/models/models_obj.cpp
+++ b/src/r_data/models/models_obj.cpp
@@ -388,7 +388,7 @@ void FOBJModel::BuildVertexBuffer(FModelRenderer *renderer)
 					side + j * 3 + // Current surface and previous triangles
 					surfaces[i].vbStart; // Previous surfaces
 
-				OBJFaceSide &curSide = surfaces[i].tris[j].sides[side];
+				OBJFaceSide &curSide = surfaces[i].tris[j].sides[2 - side];
 
 				int vidx = curSide.vertref;
 				int uvidx = (curSide.uvref >= 0 && (unsigned int)curSide.uvref < uvs.Size()) ? curSide.uvref : 0;


### PR DESCRIPTION
Translucent models were rendered with faces pointing in the wrong direction

https://forum.zdoom.org/viewtopic.php?f=2&t=64740