### PR TITLE
- Fixed a buffer overflow with Timidity++ when playing Sigil e5m5 music.

### DIFF
--- a/src/sound/timiditypp/resample.cpp
+++ b/src/sound/timiditypp/resample.cpp
@@ -933,7 +933,8 @@ void pre_resample(Sample * sp)
 		return;
 	}
 
-	dest = newdata = (sample_t *)safe_malloc((int32_t)(newlen >> (FRACTION_BITS - 1)) + 2);
+	// [EP] Fix the bad allocation count.
+	dest = newdata = (sample_t *)safe_malloc(((int32_t)(newlen >> (FRACTION_BITS - 1)) + 2)*sizeof(sample_t));
 	dest[newlen >> FRACTION_BITS] = 0;
 
 	*dest++ = src[0];


### PR DESCRIPTION
See https://forum.zdoom.org/viewtopic.php?f=2&t=64910 .