### PR TITLE
- Fixed uninitialized variable in case GL_MAX_VERTEX_SHADER_STORAGE_B…

### DIFF
--- a/src/rendering/gl_load/gl_interface.cpp
+++ b/src/rendering/gl_load/gl_interface.cpp
@@ -177,7 +177,7 @@ void gl_LoadExtensions()
 
 	// Mesa implements shader storage only for fragment shaders.
 	// Just disable the feature there. The light buffer may just use a uniform buffer without any adverse effects.
-	int v;
+	int v = 0;
 	glGetIntegerv(GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS, &v);
 	if (v == 0)
 		gl.flags &= ~RFL_SHADER_STORAGE_BUFFER;


### PR DESCRIPTION
…LOCKS does not exist.

Old graphics, like mine (Intel Sandybridge Mobile, GL 3.0 Mesa) do not support this, therefore most of the time RFL_SHADER_STORAGE_BUFFER wasn't unset (I found no consequence of this on my machine, but better safe than sorry).

Found out by Valgrind.