### PR TITLE
Add a linear transformation system to Shape2D

### DIFF
--- a/src/rendering/2d/v_2ddrawer.h
+++ b/src/rendering/2d/v_2ddrawer.h
@@ -9,6 +9,18 @@
 
 struct DrawParms;
 
+class DShape2DTransform : public DObject
+{
+
+DECLARE_CLASS(DShape2DTransform, DObject)
+public:
+	DShape2DTransform()
+	{
+		transform.Identity();
+	}
+	DMatrix3x3 transform;
+};
+
 // intermediate struct for shape drawing
 
 enum EClearWhich
@@ -23,9 +35,21 @@ class DShape2D : public DObject
 
 	DECLARE_CLASS(DShape2D,DObject)
 public:
+	DShape2D()
+	{
+		transform.Identity();
+	}
+
 	TArray<int> mIndices;
 	TArray<DVector2> mVertices;
 	TArray<DVector2> mCoords;
+
+	DMatrix3x3 transform;
+
+	// dirty stores whether we need to re-apply the transformation
+	// otherwise it uses the cached values
+	bool dirty = true;
+	TArray<DVector2> mTransformedVertices;
 };
 
 class F2DDrawer

--- a/src/utility/vectors.h
+++ b/src/utility/vectors.h
@@ -979,6 +979,35 @@ Outside comments: A faster version with only 10 (not 24) multiplies.
 
 	TMatrix3x3(const Vector3 &axis, TAngle<vec_t> degrees);
 
+	static TMatrix3x3 Rotate2D(double radians)
+	{
+		double c = g_cos(radians);
+		double s = g_sin(radians);
+		TMatrix3x3 ret;
+		ret.Cells[0][0] = c; ret.Cells[0][1] = -s; ret.Cells[0][2] = 0;
+		ret.Cells[1][0] = s; ret.Cells[1][1] =  c; ret.Cells[1][2] = 0;
+		ret.Cells[2][0] = 0; ret.Cells[2][1] =  0; ret.Cells[2][2] = 1;
+		return ret;
+	}
+
+	static TMatrix3x3 Scale2D(TVector2<vec_t> scaleVec)
+	{
+		TMatrix3x3 ret;
+		ret.Cells[0][0] = scaleVec.X; ret.Cells[0][1] =          0; ret.Cells[0][2] = 0;
+		ret.Cells[1][0] =          0; ret.Cells[1][1] = scaleVec.Y; ret.Cells[1][2] = 0;
+		ret.Cells[2][0] =          0; ret.Cells[2][1] =          0; ret.Cells[2][2] = 1;
+		return ret;
+	}
+
+	static TMatrix3x3 Translate2D(TVector2<vec_t> translateVec)
+	{
+		TMatrix3x3 ret;
+		ret.Cells[0][0] = 1; ret.Cells[0][1] = 0; ret.Cells[0][2] = translateVec.X;
+		ret.Cells[1][0] = 0; ret.Cells[1][1] = 1; ret.Cells[1][2] = translateVec.Y;
+		ret.Cells[2][0] = 0; ret.Cells[2][1] = 0; ret.Cells[2][2] =              1;
+		return ret;
+	}
+
 	void Zero()
 	{
 		memset (this, 0, sizeof *this);

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -193,6 +193,14 @@ enum DrawTextureTags
 	DTA_Monospace,			// Strings only: Use a fixed distance between characters.
 };
 
+class Shape2DTransform : Object native
+{
+	native void Clear();
+	native void Rotate(double angle);
+	native void Scale(Vector2 scaleVec);
+	native void Translate(Vector2 translateVec);
+}
+
 class Shape2D : Object native
 {
 	enum EClearWhich
@@ -201,6 +209,8 @@ class Shape2D : Object native
 		C_Coords = 2,
 		C_Indices = 4,
 	};
+
+	native void SetTransform(Shape2DTransform transform);
 
 	native void Clear( int which = C_Verts|C_Coords|C_Indices );
 	native void PushVertex( Vector2 v );


### PR DESCRIPTION
A lot of the usefulness of Shape2D comes from the fact that it's the only thing allowing people to draw rotated stuff to the screen right now. So it makes sense that a lot of the use of Shape2D is just to take a set of vertices, apply a linear transformation to it, then draw. Until this PR there was no way to change the linear transformation without clearing the entire vertex list and repushing everything, which is a slow operation. So this PR adds a system which natively allows a linear transformation using an associated Shape2DTransform class. The reason this is a separate class is so that the same transformation can be easily re-used over multiple Shape2Ds, as using multiple Shape2Ds is how you can use multiple textures in one.
On one of my more intensive tests of Shape2D, this can result in a substantial FPS increase, for example from ~95 fps without it to 170 fps with it. This results from caching the basic shape and then just setting the transformation when necessary.