### PR TITLE
- added additional hires namespaces to prevent name conflicts for hires packages

### DIFF
--- a/src/gamedata/resourcefiles/file_wad.cpp
+++ b/src/gamedata/resourcefiles/file_wad.cpp
@@ -216,6 +216,10 @@ bool FWadFile::Open(bool quiet)
 		SetNamespace("TX_START", "TX_END", ns_newtextures);
 		SetNamespace("V_START", "V_END", ns_strifevoices);
 		SetNamespace("HI_START", "HI_END", ns_hires);
+		SetNamespace("HF_START", "HF_END", ns_hires_flats);
+		SetNamespace("HS_START", "HS_END", ns_hires_sprites);
+		SetNamespace("HG_START", "HG_END", ns_hires_graphics);
+		SetNamespace("HW_START", "HW_END", ns_hires_walltextures);
 		SetNamespace("VX_START", "VX_END", ns_voxels);
 		SkinHack();
 	}

--- a/src/gamedata/resourcefiles/resourcefile.cpp
+++ b/src/gamedata/resourcefiles/resourcefile.cpp
@@ -103,19 +103,23 @@ void FResourceLump::LumpNameSetup(FString iname)
 	// Map some directories to WAD namespaces.
 	// Note that some of these namespaces don't exist in WADS.
 	// CheckNumForName will handle any request for these namespaces accordingly.
-	Namespace =	!strncmp(iname, "flats/", 6)		? ns_flats :
-				!strncmp(iname, "textures/", 9)		? ns_newtextures :
-				!strncmp(iname, "hires/", 6)		? ns_hires :
-				!strncmp(iname, "sprites/", 8)		? ns_sprites :
-				!strncmp(iname, "voxels/", 7)		? ns_voxels :
-				!strncmp(iname, "colormaps/", 10)	? ns_colormaps :
-				!strncmp(iname, "acs/", 4)			? ns_acslibrary :
-				!strncmp(iname, "voices/", 7)		? ns_strifevoices :
-				!strncmp(iname, "patches/", 8)		? ns_patches :
-				!strncmp(iname, "graphics/", 9)		? ns_graphics :
-				!strncmp(iname, "sounds/", 7)		? ns_sounds :
-				!strncmp(iname, "music/", 6)		? ns_music : 
-				!strchr(iname, '/')					? ns_global :
+	Namespace =	!strncmp(iname, "flats/", 6)              ? ns_flats :
+				!strncmp(iname, "textures/", 9)           ? ns_newtextures :
+				!strncmp(iname, "hires/flats", 11)        ? ns_hires_flats :
+				!strncmp(iname, "hires/sprites", 13)      ? ns_hires_sprites :
+				!strncmp(iname, "hires/graphics", 14)     ? ns_hires_graphics :
+				!strncmp(iname, "hires/walltextures", 18) ? ns_hires_walltextures :
+				!strncmp(iname, "hires/", 6)              ? ns_hires :
+				!strncmp(iname, "sprites/", 8)            ? ns_sprites :
+				!strncmp(iname, "voxels/", 7)             ? ns_voxels :
+				!strncmp(iname, "colormaps/", 10)         ? ns_colormaps :
+				!strncmp(iname, "acs/", 4)                ? ns_acslibrary :
+				!strncmp(iname, "voices/", 7)             ? ns_strifevoices :
+				!strncmp(iname, "patches/", 8)            ? ns_patches :
+				!strncmp(iname, "graphics/", 9)           ? ns_graphics :
+				!strncmp(iname, "sounds/", 7)             ? ns_sounds :
+				!strncmp(iname, "music/", 6)              ? ns_music :
+				!strchr(iname, '/')                       ? ns_global :
 				ns_hidden;
 	
 	// Anything that is not in one of these subdirectories or the main directory 

--- a/src/gamedata/textures/texturemanager.cpp
+++ b/src/gamedata/textures/texturemanager.cpp
@@ -628,6 +628,8 @@ void FTextureManager::AddHiresTextures (int wadnum)
 {
 	int firsttx = Wads.GetFirstLump(wadnum);
 	int lasttx = Wads.GetLastLump(wadnum);
+	int ns;
+	ETextureType type;
 
 	FString Name;
 	TArray<FTextureID> tlist;
@@ -639,11 +641,31 @@ void FTextureManager::AddHiresTextures (int wadnum)
 
 	for (;firsttx <= lasttx; ++firsttx)
 	{
-		if (Wads.GetLumpNamespace(firsttx) == ns_hires)
+		ns = Wads.GetLumpNamespace(firsttx);
+		switch(ns)
+		{
+		case ns_hires_flats:
+			type = ETextureType::Flat;
+			break;
+		case ns_hires_sprites:
+			type = ETextureType::Sprite;
+			break;
+		case ns_hires_graphics:
+			type = ETextureType::MiscPatch;
+			break;
+		case ns_hires_walltextures:
+			type = ETextureType::Wall;
+			break;
+		default:
+			type = ETextureType::Override;
+			break;
+		}
+		
+		if (ns >= ns_hires && ns <= ns_hires_walltextures)
 		{
 			Wads.GetLumpName (Name, firsttx);
 
-			if (Wads.CheckNumForName (Name, ns_hires) == firsttx)
+			if (Wads.CheckNumForName (Name, ns) == firsttx)
 			{
 				tlist.Clear();
 				int amount = ListTextures(Name, tlist);
@@ -653,7 +675,7 @@ void FTextureManager::AddHiresTextures (int wadnum)
 					FTexture * newtex = FTexture::CreateTexture (Name, firsttx, ETextureType::Any);
 					if (newtex != NULL)
 					{
-						newtex->UseType=ETextureType::Override;
+						newtex->UseType = type;
 						AddTexture(newtex);
 					}
 				}
@@ -661,10 +683,15 @@ void FTextureManager::AddHiresTextures (int wadnum)
 				{
 					for(unsigned int i = 0; i < tlist.Size(); i++)
 					{
+						FTexture * oldtex = Textures[tlist[i].GetIndex()].Texture;
+						if (type != ETextureType::Override && oldtex->UseType != type)
+							continue;
+						
 						FTexture * newtex = FTexture::CreateTexture ("", firsttx, ETextureType::Any);
 						if (newtex != NULL)
 						{
-							FTexture * oldtex = Textures[tlist[i].GetIndex()].Texture;
+							newtex->UseType = type;
+							
 
 							// Replace the entire texture and adjust the scaling and offset factors.
 							newtex->bWorldPanning = true;
@@ -1360,6 +1387,10 @@ int FTextureManager::GuesstimateNumTextures ()
 		case ns_sprites:
 		case ns_newtextures:
 		case ns_hires:
+		case ns_hires_flats:
+		case ns_hires_sprites:
+		case ns_hires_graphics:
+		case ns_hires_walltextures:
 		case ns_patches:
 		case ns_graphics:
 			numtex++;

--- a/src/gamedata/w_wad.h
+++ b/src/gamedata/w_wad.h
@@ -51,6 +51,10 @@ typedef enum {
 	ns_bloodmisc,
 	ns_strifevoices,
 	ns_hires,
+	ns_hires_flats,
+	ns_hires_sprites,
+	ns_hires_graphics,
+	ns_hires_walltextures,
 	ns_voxels,
 
 	// These namespaces are only used to mark lumps in special subdirectories

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -851,6 +851,10 @@ struct Wads
 		ns_bloodmisc,
 		ns_strifevoices,
 		ns_hires,
+		ns_hires_flats,
+		ns_hires_sprites,
+		ns_hires_graphics,
+		ns_hires_walltextures,
 		ns_voxels,
 
 		ns_specialzipdirectory,


### PR DESCRIPTION
Since hires replaced *all* textures of the same name there could not be any name
conflicts in hires texture packs . This is a problem for Doom where STEP1/STEP2 are wall texture names as well as flat names. Add additional optional directories 'hires/flats', 'hires/sprites', 'hires/graphics', and 'hires/walltextures' which specify the usetype for the texture and only replace textures of the same type.
Also add 'HF_', 'HS_', 'HG_', and 'HW_' markers for wad namespacing.

Both 'NeuralNet' and 'DHTP' hires texture packs encounter this issue. See some discussion of it in regard to DHTP [here](https://forum.zdoom.org/viewtopic.php?style=12&f=3&t=47482)
I believe they work around the issue by renaming the flat image files and redefining them using a TEXTURES lump. But this doesn't seem like the 'right' fix to me, just a workaround.

I tested this with both a folder structure and a test wad replacing all flats, sprites, graphics, and wall textures. It is easiest to notice in e1m1, the flat used for the pillars in the left room is one of the STEP1/STEP2 flats, and is normally overridden by the image meant for the wall texture without the change.