### PR TITLE
NoScreenWipe in MAPINFO to disable wipe effect for map

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -890,7 +890,8 @@ void D_Display ()
 		GSnd->DrawWaveDebug(snd_drawoutput);
 	}
 
-	if (!wipe || NoWipe < 0 || wipe_type == wipe_None)
+	
+	if (!wipe || NoWipe < 0 || wipe_type == wipe_None || ((primaryLevel->flags3 & LEVEL3_NOSCREENWIPE) && gamestate == GS_LEVEL))
 	{
 		if (wipe != nullptr) delete wipe;
 		wipe = nullptr;

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1626,6 +1626,7 @@ MapFlagHandlers[] =
 	{ "nolightfade",					MITYPE_SETFLAG3,	LEVEL3_NOLIGHTFADE, 0 },
 	{ "nocoloredspritelighting",		MITYPE_SETFLAG3,	LEVEL3_NOCOLOREDSPRITELIGHTING, 0 },
 	{ "forceworldpanning",				MITYPE_SETFLAG3,	LEVEL3_FORCEWORLDPANNING, 0 },
+	{ "noscreenwipe",					MITYPE_SETFLAG3,	LEVEL3_NOSCREENWIPE, 0 },
 	{ "nobotnodes",						MITYPE_IGNORE,	0, 0 },		// Skulltag option: nobotnodes
 	{ "compat_shorttex",				MITYPE_COMPATFLAG, COMPATF_SHORTTEX, 0 },
 	{ "compat_stairs",					MITYPE_COMPATFLAG, COMPATF_STAIRINDEX, 0 },

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -248,6 +248,8 @@ enum ELevelFlags : unsigned int
 	LEVEL3_EXITNORMALUSED		= 0x00000020,
 	LEVEL3_EXITSECRETUSED		= 0x00000040,
 	LEVEL3_FORCEWORLDPANNING	= 0x00000080,	// Forces the world panning flag for all textures, even those without it explicitly set.
+	
+	LEVEL3_NOSCREENWIPE			= 0x00000100,	// Disables screen wipe effect for this map 
 };
 
 


### PR DESCRIPTION
Allows mapper to disable screen wipe when transitioning to map with NoScreenWipe set in MAPINFO.
This can be used to implement more complex screen fade effects through ZScript, so the default wipe effect won't get in a way when showing them.