### PR TITLE
Add application data folder to IWADSearch list

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -101,6 +101,7 @@ FGameConfigFile::FGameConfigFile ()
 #elif !defined(__unix__)
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);
+		SetValueForKey ("Path", "$APPDATA\GZDoom", true);
 #else
 		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
 		// Arch Linux likes them in /usr/share/doom

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -101,7 +101,7 @@ FGameConfigFile::FGameConfigFile ()
 #elif !defined(__unix__)
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);
-		SetValueForKey ("Path", "$APPDATA\GZDoom", true);
+		SetValueForKey ("Path", "$APPDATA\" GAMENAME, true);
 #else
 		SetValueForKey ("Path", "$HOME/" GAME_DIR, true);
 		// Arch Linux likes them in /usr/share/doom


### PR DESCRIPTION
The Ultimate Doom and Doom 2 are both available on the Internet Archive, and come as ZIP files rather than anything which is installed to a standardised location. It's not unreasonable to grab just the WAD files from these packages and put them somewhere out of the way, and setting an environment variable comes off to me as weirdly heavy for something as trivial as a game. GZDoom's application data directory seems a reasonable enough alternative to be worth adding to the defaults.