### PR TITLE
Switch command buffers to be one-time-submittable

### DIFF
--- a/src/rendering/vulkan/system/vk_objects.h
+++ b/src/rendering/vulkan/system/vk_objects.h
@@ -551,7 +551,7 @@ inline void VulkanCommandBuffer::begin()
 {
 	VkCommandBufferBeginInfo beginInfo = {};
 	beginInfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-	beginInfo.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
+	beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 	beginInfo.pInheritanceInfo = nullptr;
 
 	VkResult result = vkBeginCommandBuffer(buffer, &beginInfo);


### PR DESCRIPTION
It appears that the command buffers are only submitted once, based on the usage. If that's the case, setting `VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT` instead of `VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT` would allow the driver to perform more efficient optimizations.