### PR TITLE
FPS counter no longer blocks level time on automap

### DIFF
--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -617,6 +617,7 @@ void DBaseStatusBar::DoDrawAutomapHUD(int crdefault, int highlight)
 
 	if (am_showtime)
 	{
+		if (vid_fps) y += (NewConsoleFont->GetHeight() * active_con_scale() + 5) / scale;
 		sec = Tics2Seconds(primaryLevel->time);
 		textbuffer.Format("%02d:%02d:%02d", sec / 3600, (sec % 3600) / 60, sec % 60);
 		screen->DrawText(font, crdefault, vwidth - zerowidth * 8 - textdist, y, textbuffer, DTA_VirtualWidth, vwidth, DTA_VirtualHeight, vheight,


### PR DESCRIPTION
https://forum.zdoom.org/viewtopic.php?f=2&t=64535

Turns out the DoDrawAutomapHUD routine didn't take the vid_fps CVAR into account.

EDIT: Now takes Console and HUD scaling into account.