### PR TITLE
Adds option to use a quicksave rotation

### DIFF
--- a/src/g_game.h
+++ b/src/g_game.h
@@ -82,6 +82,8 @@ void G_DoLoadGame (void);
 
 // Called by M_Responder.
 void G_SaveGame (const char *filename, const char *description);
+// Called by messagebox
+void G_DoQuickSave ();
 
 // Only called by startup code.
 void G_RecordDemo (const char* name);

--- a/src/menu/loadsavemenu.cpp
+++ b/src/menu/loadsavemenu.cpp
@@ -318,7 +318,7 @@ DEFINE_ACTION_FUNCTION(FSavegameManager, ReadSaveStrings)
 //
 //=============================================================================
 
-void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, bool okForQuicksave)
+void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, bool okForQuicksave, bool forceQuicksave)
 {
 	FSaveGameNode *node;
 
@@ -342,7 +342,7 @@ void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, 
 			node->bMissingWads = false;
 			if (okForQuicksave)
 			{
-				if (quickSaveSlot == nullptr) quickSaveSlot = node;
+				if (quickSaveSlot == nullptr || forceQuicksave) quickSaveSlot = node;
 				LastAccessed = LastSaved = i;
 			}
 			return;
@@ -358,7 +358,7 @@ void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, 
 
 	if (okForQuicksave)
 	{
-		if (quickSaveSlot == nullptr) quickSaveSlot = node;
+		if (quickSaveSlot == nullptr || forceQuicksave) quickSaveSlot = node;
 		LastAccessed = LastSaved = index;
 	}
 }

--- a/src/menu/menu.h
+++ b/src/menu/menu.h
@@ -84,7 +84,7 @@ public:
 private:
 	int InsertSaveNode(FSaveGameNode *node);
 public:
-	void NotifyNewSave(const FString &file, const FString &title, bool okForQuicksave);
+	void NotifyNewSave(const FString &file, const FString &title, bool okForQuicksave, bool forceQuicksave);
 	void ClearSaveGames();
 
 	void ReadSaveStrings();

--- a/src/menu/messagebox.cpp
+++ b/src/menu/messagebox.cpp
@@ -44,6 +44,7 @@
 #include "vm.h"
 
 EXTERN_CVAR (Bool, saveloadconfirmation) // [mxd]
+EXTERN_CVAR (Bool, quicksaverotation)
 
 typedef void(*hfunc)();
 DEFINE_ACTION_FUNCTION(DMessageBoxMenu, CallHandler)
@@ -174,6 +175,13 @@ CCMD (quicksave)
 
 	if (gamestate != GS_LEVEL)
 		return;
+
+	// If the quick save rotation is enabled, it handles the save slot.
+	if (quicksaverotation)
+	{
+		G_DoQuickSave();
+		return;
+	}
 		
 	if (savegameManager.quickSaveSlot == NULL)
 	{

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1182,6 +1182,8 @@ OptionMenu "MiscOptions" protected
 	Option "$MISCMNU_ENABLEAUTOSAVES",			"disableautosave", "Autosave"
 	Option "$MISCMNU_SAVELOADCONFIRMATION",			"saveloadconfirmation", "OnOff"
 	Slider "$MISCMNU_AUTOSAVECOUNT",			"autosavecount", 1, 20, 1, 0
+	Option "$MISCMNU_QUICKSAVEROTATION",			"quicksaverotation", "OnOff"
+	Slider "$MISCMNU_QUICKSAVECOUNT",			"quicksaverotationcount", 1, 20, 1, 0
 	Option "$MISCMNU_DEHLOAD",					"dehload", "dehopt"
 	Option "$MISCMNU_ENABLESCRIPTSCREENSHOTS",		"enablescriptscreenshot", "OnOff"
 	Option "$MISCMNU_INTERSCROLL",				"nointerscrollabort", "OffOn"


### PR DESCRIPTION
This adds the ability to use a rotation of quicksaves instead of manually specifying a quicksave slot at the time of first saving. It also adds the ability to specify the size of the rotation, as the autosave rotation allows. It is disabled by default to avoid changing behavior for existing users.

A quicksave rotation avoids the hassle of having to specify a save slot on launch, and it also helps avoid situations where the player unintentionally quicksaves right before death, by giving them an opportunity to load an earlier quicksave instead of the autosave at the beginning of the level.

Strings:
MISCMNU_QUICKSAVEROTATION = "Enable quicksave rotation"
MISCMNU_QUICKSAVECOUNT = "Number of quicksaves in rotation"