### PR TITLE
Converts keyboard turnspeeds into global CVars

### DIFF
--- a/src/console/c_cvars.h
+++ b/src/console/c_cvars.h
@@ -119,7 +119,6 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const = 0;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const = 0;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type) = 0;
-	virtual const void* GetReference() {return NULL;}
 
 	FBaseCVar &operator= (const FBaseCVar &var)
 		{ UCVarValue val; ECVarType type; val = var.GetFavoriteRep (&type); SetGenericRep (val, type); return *this; }
@@ -225,7 +224,6 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
-	virtual const void *GetReference() { return &Value; }
 
 	inline bool operator= (bool boolval)
 		{ UCVarValue val; val.Bool = boolval; SetGenericRep (val, CVAR_Bool); return boolval; }
@@ -252,7 +250,6 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
-	virtual const void* GetReference() { return &Value; }
 
 	int operator= (int intval)
 		{ UCVarValue val; val.Int = intval; SetGenericRep (val, CVAR_Int); return intval; }
@@ -281,7 +278,6 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
-	virtual const void *GetReference() { return &Value; }
 	const char *GetHumanString(int precision) const override;
 
 	float operator= (float floatval)
@@ -310,7 +306,6 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
-	virtual const void *GetReference() { return &Value; }
 
 	const char *operator= (const char *stringrep)
 		{ UCVarValue val; val.String = const_cast<char *>(stringrep); SetGenericRep (val, CVAR_String); return stringrep; }

--- a/src/console/c_cvars.h
+++ b/src/console/c_cvars.h
@@ -119,6 +119,7 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const = 0;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const = 0;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type) = 0;
+	virtual const void* GetReference() {return NULL;}
 
 	FBaseCVar &operator= (const FBaseCVar &var)
 		{ UCVarValue val; ECVarType type; val = var.GetFavoriteRep (&type); SetGenericRep (val, type); return *this; }
@@ -224,6 +225,7 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
+	virtual const void *GetReference() { return &Value; }
 
 	inline bool operator= (bool boolval)
 		{ UCVarValue val; val.Bool = boolval; SetGenericRep (val, CVAR_Bool); return boolval; }
@@ -250,6 +252,7 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
+	virtual const void* GetReference() { return &Value; }
 
 	int operator= (int intval)
 		{ UCVarValue val; val.Int = intval; SetGenericRep (val, CVAR_Int); return intval; }
@@ -278,6 +281,7 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
+	virtual const void *GetReference() { return &Value; }
 	const char *GetHumanString(int precision) const override;
 
 	float operator= (float floatval)
@@ -306,6 +310,7 @@ public:
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type);
+	virtual const void *GetReference() { return &Value; }
 
 	const char *operator= (const char *stringrep)
 		{ UCVarValue val; val.String = const_cast<char *>(stringrep); SetGenericRep (val, CVAR_String); return stringrep; }

--- a/src/g_cvars.cpp
+++ b/src/g_cvars.cpp
@@ -56,6 +56,22 @@ CVAR(Bool, var_friction, true, CVAR_SERVERINFO);
 // Option Search
 CVAR(Bool, os_isanyof, true, CVAR_ARCHIVE);
 
+CUSTOM_CVAR (Int, turnspeedwalkfast, 640, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self <= 0) self = 1;
+}
+CUSTOM_CVAR (Int, turnspeedsprintfast, 1280, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self <= 0) self = 1;
+}
+CUSTOM_CVAR (Int, turnspeedwalkslow, 320, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self <= 0) self = 1;
+}
+CUSTOM_CVAR (Int, turnspeedsprintslow, 320, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self <= 0) self = 1;
+}
 
 
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -191,14 +191,12 @@ EXTERN_CVAR (Int, turnspeedsprintslow)
 const char *TURNSPEEDCVARKEYS[4] = {"turnspeedwalkfast", "turnspeedsprintfast", "turnspeedwalkslow", "turnspeedsprintslow"};
 
 
-const int **getTurnSpeeds()
+FBaseCVar **getTurnSpeeds()
 {
-	const int **turnspeeds = new const int*[4];
-	FBaseCVar *cvar;
+	FBaseCVar **turnspeeds = new FBaseCVar*[4];
 	for (int i = 0; i < 4; ++i)
 	{
-		cvar = FindCVar(TURNSPEEDCVARKEYS[i], NULL);
-		turnspeeds[i] = (const int*)cvar->GetReference();
+		turnspeeds[i] = FindCVar(TURNSPEEDCVARKEYS[i], NULL);
 	}
 
 	return turnspeeds;
@@ -206,7 +204,7 @@ const int **getTurnSpeeds()
 }
 
 int				forwardmove[2], sidemove[2];
-const int		 		**angleturn = getTurnSpeeds();
+FBaseCVar		 		**angleturn = getTurnSpeeds();
 int				flyspeed[2] = {1*256, 3*256};
 int				lookspeed[2] = {450, 512};
 
@@ -278,16 +276,18 @@ CUSTOM_CVAR (Float, turbo, 100.f, CVAR_NOINITCALL)
 #pragma optimize("", on)
 #endif // _M_X64 && _MSC_VER < 1910
 
+#define ANGLETURN(at) at->GetGenericRep(CVAR_Int).Int
 CCMD (turnspeeds)
 {
+	int turnspeeds[4] = {ANGLETURN(angleturn[0]), ANGLETURN(angleturn[1]), ANGLETURN(angleturn[2]), ANGLETURN(angleturn[3])};
 	if (argv.argc() == 1)
 	{
 		Printf ("\034H Current turn speeds:\n\
 				\034N turnspeedwalkfast: \034D %d\n\
 				\034N turnspeedsprintfast: \034D %d\n\
 				\034N turnspeedwalkslow: \034D %d\n\
-				\034N turnspeedsprintslow: \034D %d\n", *(angleturn[0]),
-			*(angleturn[1]), *(angleturn[2]), *(angleturn[3]));
+				\034N turnspeedsprintslow: \034D %d\n", turnspeeds[0],
+			turnspeeds[1], turnspeeds[2], turnspeeds[3]);
 	}
 	else
 	{
@@ -299,17 +299,17 @@ CCMD (turnspeeds)
 		}
 		if (i <= 2)
 		{
-			sprintf(val, "%d", *(angleturn[0]) * 2);
+			sprintf(val, "%d", turnspeeds[0] * 2);
 			cvar_forceset(TURNSPEEDCVARKEYS[1], val);
 		}
 		if (i <= 3)
 		{
-			sprintf(val, "%d", *(angleturn[0]) / 2);
+			sprintf(val, "%d", turnspeeds[0] / 2);
 			cvar_forceset(TURNSPEEDCVARKEYS[2], val);
 		}
 		if (i <= 4)
 		{
-			sprintf(val, "%d", *(angleturn[2]));
+			sprintf(val, "%d", turnspeeds[2]);
 			cvar_forceset(TURNSPEEDCVARKEYS[3], val);
 		}
 	}
@@ -597,11 +597,11 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 		
 		if (Button_Right.bDown)
 		{
-			G_AddViewAngle (*(angleturn[tspeed]));
+			G_AddViewAngle (ANGLETURN(angleturn[tspeed]));
 		}
 		if (Button_Left.bDown)
 		{
-			G_AddViewAngle (-*(angleturn[tspeed]));
+			G_AddViewAngle (-ANGLETURN(angleturn[tspeed]));
 		}
 	}
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -195,11 +195,9 @@ const int **getTurnSpeeds()
 {
 	const int **turnspeeds = new const int*[4];
 	FBaseCVar *cvar;
-	const int *speed;
 	for (int i = 0; i < 4; ++i)
 	{
 		cvar = FindCVar(TURNSPEEDCVARKEYS[i], NULL);
-		speed = 
 		turnspeeds[i] = (const int*)cvar->GetReference();
 	}
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -184,9 +184,31 @@ short			consistancy[MAXPLAYERS][BACKUPTICS];
  
 #define TURBOTHRESHOLD	12800
 
+EXTERN_CVAR (Int, turnspeedwalkfast)
+EXTERN_CVAR (Int, turnspeedsprintfast)
+EXTERN_CVAR (Int, turnspeedwalkslow)
+EXTERN_CVAR (Int, turnspeedsprintslow)
+const char *TURNSPEEDCVARKEYS[4] = {"turnspeedwalkfast", "turnspeedsprintfast", "turnspeedwalkslow", "turnspeedsprintslow"};
+
+
+const int **getTurnSpeeds()
+{
+	const int **turnspeeds = new const int*[4];
+	FBaseCVar *cvar;
+	const int *speed;
+	for (int i = 0; i < 4; ++i)
+	{
+		cvar = FindCVar(TURNSPEEDCVARKEYS[i], NULL);
+		speed = 
+		turnspeeds[i] = (const int*)cvar->GetReference();
+	}
+
+	return turnspeeds;
+
+}
 
 int				forwardmove[2], sidemove[2];
-int		 		angleturn[4] = {640, 1280, 320, 320};		// + slow turn
+const int		 		**angleturn = getTurnSpeeds();
 int				flyspeed[2] = {1*256, 3*256};
 int				lookspeed[2] = {450, 512};
 
@@ -262,28 +284,35 @@ CCMD (turnspeeds)
 {
 	if (argv.argc() == 1)
 	{
-		Printf ("Current turn speeds: %d %d %d %d\n", angleturn[0],
-			angleturn[1], angleturn[2], angleturn[3]);
+		Printf ("\034H Current turn speeds:\n\
+				\034N turnspeedwalkfast: \034D %d\n\
+				\034N turnspeedsprintfast: \034D %d\n\
+				\034N turnspeedwalkslow: \034D %d\n\
+				\034N turnspeedsprintslow: \034D %d\n", *(angleturn[0]),
+			*(angleturn[1]), *(angleturn[2]), *(angleturn[3]));
 	}
 	else
 	{
 		int i;
-
+		char val[10];
 		for (i = 1; i <= 4 && i < argv.argc(); ++i)
 		{
-			angleturn[i-1] = atoi (argv[i]);
+			cvar_forceset(TURNSPEEDCVARKEYS[i - 1], argv[i]);
 		}
 		if (i <= 2)
 		{
-			angleturn[1] = angleturn[0] * 2;
+			sprintf(val, "%d", *(angleturn[0]) * 2);
+			cvar_forceset(TURNSPEEDCVARKEYS[1], val);
 		}
 		if (i <= 3)
 		{
-			angleturn[2] = angleturn[0] / 2;
+			sprintf(val, "%d", *(angleturn[0]) / 2);
+			cvar_forceset(TURNSPEEDCVARKEYS[2], val);
 		}
 		if (i <= 4)
 		{
-			angleturn[3] = angleturn[2];
+			sprintf(val, "%d", *(angleturn[2]));
+			cvar_forceset(TURNSPEEDCVARKEYS[3], val);
 		}
 	}
 }
@@ -570,11 +599,11 @@ void G_BuildTiccmd (ticcmd_t *cmd)
 		
 		if (Button_Right.bDown)
 		{
-			G_AddViewAngle (angleturn[tspeed]);
+			G_AddViewAngle (*(angleturn[tspeed]));
 		}
 		if (Button_Left.bDown)
 		{
-			G_AddViewAngle (-angleturn[tspeed]);
+			G_AddViewAngle (-*(angleturn[tspeed]));
 		}
 	}
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -190,21 +190,8 @@ EXTERN_CVAR (Int, turnspeedwalkslow)
 EXTERN_CVAR (Int, turnspeedsprintslow)
 const char *TURNSPEEDCVARKEYS[4] = {"turnspeedwalkfast", "turnspeedsprintfast", "turnspeedwalkslow", "turnspeedsprintslow"};
 
-
-FBaseCVar **getTurnSpeeds()
-{
-	FBaseCVar **turnspeeds = new FBaseCVar*[4];
-	for (int i = 0; i < 4; ++i)
-	{
-		turnspeeds[i] = FindCVar(TURNSPEEDCVARKEYS[i], NULL);
-	}
-
-	return turnspeeds;
-
-}
-
 int				forwardmove[2], sidemove[2];
-FBaseCVar		 		**angleturn = getTurnSpeeds();
+FIntCVar		*angleturn[4] = {&turnspeedwalkfast, &turnspeedsprintfast, &turnspeedwalkslow, &turnspeedsprintslow};
 int				flyspeed[2] = {1*256, 3*256};
 int				lookspeed[2] = {450, 512};
 
@@ -276,10 +263,15 @@ CUSTOM_CVAR (Float, turbo, 100.f, CVAR_NOINITCALL)
 #pragma optimize("", on)
 #endif // _M_X64 && _MSC_VER < 1910
 
-#define ANGLETURN(at) at->GetGenericRep(CVAR_Int).Int
+ECVarType dummy;
+#define ANGLETURN(at) at->GetFavoriteRep(&dummy).Int
 CCMD (turnspeeds)
 {
-	int turnspeeds[4] = {ANGLETURN(angleturn[0]), ANGLETURN(angleturn[1]), ANGLETURN(angleturn[2]), ANGLETURN(angleturn[3])};
+	int turnspeeds[4] = {
+		ANGLETURN(angleturn[0]), 
+		ANGLETURN(angleturn[0]), 
+		ANGLETURN(angleturn[0]), 
+		ANGLETURN(angleturn[0])};
 	if (argv.argc() == 1)
 	{
 		Printf ("\034H Current turn speeds:\n\

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -267,19 +267,14 @@ ECVarType dummy;
 #define ANGLETURN(at) at->GetFavoriteRep(&dummy).Int
 CCMD (turnspeeds)
 {
-	int turnspeeds[4] = {
-		ANGLETURN(angleturn[0]), 
-		ANGLETURN(angleturn[0]), 
-		ANGLETURN(angleturn[0]), 
-		ANGLETURN(angleturn[0])};
 	if (argv.argc() == 1)
 	{
 		Printf ("\034H Current turn speeds:\n\
 				\034N turnspeedwalkfast: \034D %d\n\
 				\034N turnspeedsprintfast: \034D %d\n\
 				\034N turnspeedwalkslow: \034D %d\n\
-				\034N turnspeedsprintslow: \034D %d\n", turnspeeds[0],
-			turnspeeds[1], turnspeeds[2], turnspeeds[3]);
+				\034N turnspeedsprintslow: \034D %d\n", ANGLETURN(angleturn[0]),
+			ANGLETURN(angleturn[1]), ANGLETURN(angleturn[2]), ANGLETURN(angleturn[3]));
 	}
 	else
 	{
@@ -291,17 +286,17 @@ CCMD (turnspeeds)
 		}
 		if (i <= 2)
 		{
-			sprintf(val, "%d", turnspeeds[0] * 2);
+			sprintf(val, "%d", ANGLETURN(angleturn[0]) * 2);
 			cvar_forceset(TURNSPEEDCVARKEYS[1], val);
 		}
 		if (i <= 3)
 		{
-			sprintf(val, "%d", turnspeeds[0] / 2);
+			sprintf(val, "%d", ANGLETURN(angleturn[0]) / 2);
 			cvar_forceset(TURNSPEEDCVARKEYS[2], val);
 		}
 		if (i <= 4)
 		{
-			sprintf(val, "%d", turnspeeds[2]);
+			sprintf(val, "%d", ANGLETURN(angleturn[2]));
 			cvar_forceset(TURNSPEEDCVARKEYS[3], val);
 		}
 	}


### PR DESCRIPTION
Changes keyboard turnspeed settings into cvars, so they persist between restarts.

The output for the `turnspeeds` command is now both more intuitive and prettier:
![New format](https://i.imgur.com/d28jn7s.png)

Some CVar types now have a GetReference() method, which returns a pointer to the value held by the CVar (upgraded to const to enforce read-only). Some types of cvars only return NULL. While on the surface this seems like a less-than-ideal addition, it was important for a few reasons:

-Turnspeeds are initialized before the configuration file is read, but not before cvars and their default values are propagated into memory.

-Using pointers allows up-to-date access to the value of the given cvar, which means the cvar linked list only has to be traversed once during engine init. Otherwise, the list would have to be traversed every tick the player was pressing one of the rotation buttons.