### PR TITLE
Use fallback implementation for C++ aligned_alloc for old glibc++

### DIFF
--- a/src/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h
+++ b/src/rendering/vulkan/thirdparty/vk_mem_alloc/vk_mem_alloc.h
@@ -2238,7 +2238,7 @@ remove them if not needed.
    #define VMA_NULL   nullptr
 #endif
 
-#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__)
+#if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) || (defined(__GLIBCXX__) && !defined(_GLIBCXX_HAVE_ALIGNED_ALLOC))
 #include <cstdlib>
 void *aligned_alloc(size_t alignment, size_t size)
 {


### PR DESCRIPTION
This function was introduced in C++17 and is not available on GCC 5.x or older.  Another version of this function is available since C11, but it's not exposed when including `<cstdlib>`.

This is needed to enable Vulkan renderer for GZDoom builds inside Steam Runtime environment: dreamer/luxtorpeda#35

