### PR TITLE
Allow status bars to override notifications/prints/chat prompt

### DIFF
--- a/src/console/c_console.cpp
+++ b/src/console/c_console.cpp
@@ -773,6 +773,19 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 		con_notifylines == 0)
 		return;
 
+	// [MK] allow the status bar to take over notify printing
+	if (StatusBar != nullptr)
+	{
+		IFVIRTUALPTR(StatusBar, DBaseStatusBar, ProcessNotify)
+		{
+			VMValue params[] = { (DObject*)StatusBar, printlevel, &source };
+			int rv;
+			VMReturn ret(&rv);
+			VMCall(func, params, countof(params), &ret, 1);
+			if (!!rv) return;
+		}
+	}
+
 	width = DisplayWidth / active_con_scaletext(generic_ui);
 
 	FFont *font = generic_ui ? NewSmallFont : AlternativeSmallFont;
@@ -960,6 +973,12 @@ int DPrintf (int level, const char *format, ...)
 void C_FlushDisplay ()
 {
 	NotifyStrings.Clear();
+	if (StatusBar == nullptr) return;
+	IFVIRTUALPTR(StatusBar, DBaseStatusBar, FlushNotify)
+	{
+		VMValue params[] = { (DObject*)StatusBar };
+		VMCall(func, params, countof(params), nullptr, 1);
+	}
 }
 
 void C_AdjustBottom ()
@@ -1739,6 +1758,17 @@ void C_MidPrint (FFont *font, const char *msg, bool bold)
 {
 	if (StatusBar == nullptr || screen == nullptr)
 		return;
+
+	// [MK] allow the status bar to take over MidPrint
+	IFVIRTUALPTR(StatusBar, DBaseStatusBar, ProcessMidPrint)
+	{
+		FString msgstr = msg;
+		VMValue params[] = { (DObject*)StatusBar, font, &msg, bold };
+		int rv;
+		VMReturn ret(&rv);
+		VMCall(func, params, countof(params), &ret, 1);
+		if (!!rv) return;
+	}
 
 	if (msg != nullptr)
 	{

--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -41,6 +41,7 @@
 #include "v_video.h"
 #include "utf8.h"
 #include "gstrings.h"
+#include "vm.h"
 
 enum
 {
@@ -233,8 +234,30 @@ void CT_PasteChat(const char *clip)
 void CT_Drawer (void)
 {
 	FFont *displayfont = NewConsoleFont;
+
+	if (players[consoleplayer].camera != NULL &&
+		(Button_ShowScores.bDown ||
+		 players[consoleplayer].camera->health <= 0 ||
+		 SB_ForceActive) &&
+		 // Don't draw during intermission, since it has its own scoreboard in wi_stuff.cpp.
+		 gamestate != GS_INTERMISSION)
+	{
+		HU_DrawScores (&players[consoleplayer]);
+	}
 	if (chatmodeon)
 	{
+		// [MK] allow the status bar to take over chat prompt drawing
+		bool skip = false;
+		IFVIRTUALPTR(StatusBar, DBaseStatusBar, DrawChat)
+		{
+			FString txt = ChatQueue;
+			VMValue params[] = { (DObject*)StatusBar, &txt };
+			int rv;
+			VMReturn ret(&rv);
+			VMCall(func, params, countof(params), &ret, 1);
+			if (!!rv) return;
+		}
+
 		FStringf prompt("%s ", GStrings("TXT_SAY"));
 		int x, scalex, y, promptwidth;
 
@@ -267,16 +290,6 @@ void CT_Drawer (void)
 			DTA_VirtualWidth, screen_width, DTA_VirtualHeight, screen_height, DTA_KeepRatio, true, TAG_DONE);
 		screen->DrawText (displayfont, CR_GREY, promptwidth, y, printstr, 
 			DTA_VirtualWidth, screen_width, DTA_VirtualHeight, screen_height, DTA_KeepRatio, true, TAG_DONE);
-	}
-
-	if (players[consoleplayer].camera != NULL &&
-		(Button_ShowScores.bDown ||
-		 players[consoleplayer].camera->health <= 0 ||
-		 SB_ForceActive) &&
-		 // Don't draw during intermission, since it has its own scoreboard in wi_stuff.cpp.
-		 gamestate != GS_INTERMISSION)
-	{
-		HU_DrawScores (&players[consoleplayer]);
 	}
 }
 

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1352,3 +1352,17 @@ enum EMonospacing
 	Mono_CellCenter = 2,
 	Mono_CellRight = 3
 };
+
+enum EPrintLevel
+{
+	PRINT_LOW,		// pickup messages
+	PRINT_MEDIUM,	// death messages
+	PRINT_HIGH,		// critical messages
+	PRINT_CHAT,		// chat messages
+	PRINT_TEAMCHAT,	// chat messages from a teammate
+	PRINT_LOG,		// only to logfile
+	PRINT_BOLD = 200,				// What Printf_Bold used
+	PRINT_TYPES = 1023,		// Bitmask.
+	PRINT_NONOTIFY = 1024,	// Flag - do not add to notify buffer
+	PRINT_NOLOG = 2048,		// Flag - do not print to log file
+};

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -334,7 +334,14 @@ class BaseStatusBar native ui
 	virtual void NewGame () { if (CPlayer != null) AttachToPlayer(CPlayer); }
 	virtual void ShowPop (int popnum) { ShowLog = (popnum == POP_Log && !ShowLog); }
 	virtual bool MustDrawLog(int state) { return true; }
-	
+
+	// [MK] let the HUD handle notifications and centered print messages
+	virtual bool ProcessNotify(EPrintLevel printlevel, String outline) { return false; }
+	virtual void FlushNotify() {}
+	virtual bool ProcessMidPrint(Font fnt, String msg, bool bold) { return false; }
+	// [MK] let the HUD handle drawing the chat prompt
+	virtual bool DrawChat(String txt) { return false; }
+
 	native TextureID GetMugshot(int accuracy, int stateflags=MugShot.STANDARD, String default_face = "STF");
 	
 	// These functions are kept native solely for performance reasons. They get called repeatedly and can drag down performance easily if they get too slow.


### PR DESCRIPTION
First of all I'm sorry for how crappy the diff looks. I blame it on my text editor having a habit of automatically clearing all trailing whitespace when saving.

This gives a couple virtual functions to the BaseStatusBar class:

- `virtual bool ProcessNotify(EPrintLevel printlevel, String outline)` : Called for any incoming notification messages. Returning true stops the message from appearing in the usual place, and allows the status bar to handle it instead.
- `virtual void FlushNotify()` : Called when notification messages should be cleared. This is up to the modder to deal with.
- `virtual bool ProcessMidPrint(Font fnt, String msg, bool bold)` : Called for incoming Print/PrintBold types of messages. Same as with notifications, returning true skips the usual behaviour and lets the status bar do it itself.
- `virtual bool DrawChat(String txt)` : Called when the chat prompt should be drawn. The parameter is the input text, without the prompt string. I don't think I need to say what returning true does.

I'm a bit busy with other projects so I couldn't make a grandiose example mod to show this all of this PR's features in action, so instead I made something quick and cheap for the biggest one. This is a modification of the Doom hud that does a couple things differently when it comes to notifications:

1. Separates chat, pickups and obituaries/other, so for example a whole load of pickup messages don't clear out everything else.
2. Gives each message group different durations. Especially noticeable for chat, which lasts much longer.
3. Identical pickup messages are grouped together (will have an "x#" suffix) so they take up less space.
4. In general there's more space for displayed messages (up to 12).

If the function names aren't very convincing I can change them. I kinda cheaped out on that too.