### PR TITLE
- fixed initial setup for dynamic light actors

### DIFF
--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -122,6 +122,9 @@ void AttachLight(AActor *self)
 	light->visibletoplayer = true;
 	light->lighttype = (uint8_t)self->IntVar(NAME_lighttype);
 	self->AttachedLights.Push(light);
+
+	// Disable postponed processing of dynamic light because its setup has been completed by this function
+	self->flags8 &= ~MF8_RECREATELIGHTS;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(ADynamicLight, AttachLight, AttachLight)

--- a/wadsrc/static/zscript/actors/shared/dynlights.zs
+++ b/wadsrc/static/zscript/actors/shared/dynlights.zs
@@ -84,12 +84,12 @@ class DynamicLight : Actor
 	override void BeginPlay()
 	{
 		ChangeStatNum(STAT_DLIGHT);
-		AttachLight();
 	}
 
 	override void PostBeginPlay()
 	{
 		Super.PostBeginPlay();
+		AttachLight();
 		
 		if (!(SpawnFlags & MTF_DORMANT))
 		{


### PR DESCRIPTION
They are attached and actived explicitly during usual actor initialization sequence
Postponed processing applicable to so called user dynamic lights must be skipped for them
RECREATELIGHTS flag handling for dynamic light actors had the opposite effect of deactivating them

https://forum.zdoom.org/viewtopic.php?t=65683