### PR TITLE
Fix for a little typo/oversight

### DIFF
--- a/src/console/c_console.cpp
+++ b/src/console/c_console.cpp
@@ -1763,7 +1763,7 @@ void C_MidPrint (FFont *font, const char *msg, bool bold)
 	IFVIRTUALPTR(StatusBar, DBaseStatusBar, ProcessMidPrint)
 	{
 		FString msgstr = msg;
-		VMValue params[] = { (DObject*)StatusBar, font, &msg, bold };
+		VMValue params[] = { (DObject*)StatusBar, font, &msgstr, bold };
 		int rv;
 		VMReturn ret(&rv);
 		VMCall(func, params, countof(params), &ret, 1);


### PR DESCRIPTION
The wrong pointer was passed to ProcessMidPrint, which resulted in a crash.