### PR TITLE
Add current, max and average velocity as stat

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -617,6 +617,9 @@ public:
 	int			total_monsters;
 	int			killed_monsters;
 
+	double      max_velocity;
+	double      sum_velocity;
+
 	double		gravity;
 	double		aircontrol;
 	double		airfriction;

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -618,7 +618,7 @@ public:
 	int			killed_monsters;
 
 	double      max_velocity;
-	double      sum_velocity;
+	double      avg_velocity;
 
 	double		gravity;
 	double		aircontrol;

--- a/src/gamedata/statistics.cpp
+++ b/src/gamedata/statistics.cpp
@@ -605,7 +605,7 @@ ADD_STAT(velocity)
 	FString compose;
 	if (players[consoleplayer].mo != NULL && gamestate == GS_LEVEL) {
 		compose.AppendFormat("Current velocity: %.2f\n", players[consoleplayer].mo->Vel.Length());
-		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", primaryLevel->MapName, primaryLevel->max_velocity, primaryLevel->sum_velocity / primaryLevel->maptime);
+		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", primaryLevel->MapName.GetChars(), primaryLevel->max_velocity, primaryLevel->sum_velocity / primaryLevel->maptime);
 	}
 	return compose;
 }

--- a/src/gamedata/statistics.cpp
+++ b/src/gamedata/statistics.cpp
@@ -605,7 +605,7 @@ ADD_STAT(velocity)
 	FString compose;
 	if (players[consoleplayer].mo != NULL && gamestate == GS_LEVEL) {
 		compose.AppendFormat("Current velocity: %.2f\n", players[consoleplayer].mo->Vel.Length());
-		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", primaryLevel->MapName.GetChars(), primaryLevel->max_velocity, primaryLevel->sum_velocity / primaryLevel->maptime);
+		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", primaryLevel->MapName.GetChars(), primaryLevel->max_velocity, primaryLevel->avg_velocity);
 	}
 	return compose;
 }

--- a/src/gamedata/statistics.cpp
+++ b/src/gamedata/statistics.cpp
@@ -599,3 +599,13 @@ ADD_STAT(statistics)
 	StoreLevelStats(primaryLevel);	// Refresh the current level's results.
 	return GetStatString();
 }
+
+ADD_STAT(velocity)
+{
+	FString compose;
+	if (players[consoleplayer].mo != NULL && gamestate == GS_LEVEL) {
+		compose.AppendFormat("Current velocity: %.2f\n", players[consoleplayer].mo->Vel.Length());
+		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", primaryLevel->MapName, primaryLevel->max_velocity, primaryLevel->sum_velocity / primaryLevel->maptime);
+	}
+	return compose;
+}

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -263,7 +263,7 @@ void FLevelLocals::ClearLevelData()
 	total_monsters = total_items = total_secrets =
 	killed_monsters = found_items = found_secrets = 0;
 
-	max_velocity = sum_velocity = 0;
+	max_velocity = avg_velocity = 0;
 
 	for (int i = 0; i < 4; i++)
 	{

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -263,6 +263,8 @@ void FLevelLocals::ClearLevelData()
 	total_monsters = total_items = total_secrets =
 	killed_monsters = found_items = found_secrets = 0;
 
+	max_velocity = sum_velocity = 0;
+
 	for (int i = 0; i < 4; i++)
 	{
 		UDMFKeys[i].Clear();

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -182,7 +182,7 @@ void P_Ticker (void)
 	}
 	if (players[consoleplayer].mo != NULL) {
 		if (players[consoleplayer].mo->Vel.Length() > primaryLevel->max_velocity) { primaryLevel->max_velocity = players[consoleplayer].mo->Vel.Length(); }
-		primaryLevel->sum_velocity += players[consoleplayer].mo->Vel.Length();
+		primaryLevel->avg_velocity += (players[consoleplayer].mo->Vel.Length() - primaryLevel->avg_velocity) / primaryLevel->maptime;
 	}
 	StatusBar->CallTick();		// Status bar should tick AFTER the thinkers to properly reflect the level's state at this time.
 }

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -180,5 +180,9 @@ void P_Ticker (void)
 		Level->maptime++;
 		Level->totaltime++;
 	}
+	if (players[consoleplayer].mo != NULL) {
+		if (players[consoleplayer].mo->Vel.Length() > primaryLevel->max_velocity) { primaryLevel->max_velocity = players[consoleplayer].mo->Vel.Length(); }
+		primaryLevel->sum_velocity += players[consoleplayer].mo->Vel.Length();
+	}
 	StatusBar->CallTick();		// Status bar should tick AFTER the thinkers to properly reflect the level's state at this time.
 }


### PR DESCRIPTION
When i was learning the sr50 movement in doom, i was looking for a way to display the movement speed on the screen. I found that you can view your current speed/velocity with info or myinfo console commands,  but not display it on the screen real time, so i decided to look into it, open source and all. Similar feature exists in quake3 mods for example, turning on a cvar would make your movement speed displayed on screen.

I noticed there is already a stats system in place, which can display interesting information on screen, so i decided to create a new "stat velocity" which displays current velocity, and i also added max and average velocity to make it a little bit more interesting and stat-like.

Not much else to say, my main goal was to get faster feedback about sr50 movement, not super useful i suppose :). maybe it can provide interesting information about speedrun demos as well.

Let me know what you think.