### PR TITLE
Let Hexen Cleric and Mage use unique health chains

### DIFF
--- a/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
@@ -105,13 +105,13 @@ class HexenStatusBar : BaseStatusBar
 	{
 		DrawImage("H2BAR", (0, 134), DI_ITEM_OFFSETS);
 		
-		String Gem;
-		if (CPlayer.mo is "ClericPlayer") Gem = "LIFEGMC2";
-		else if (CPlayer.mo is "MagePlayer") Gem = "LIFEGMM2";
-		else Gem = "LIFEGMF2";
+		String Gem, Chain;
+		if (CPlayer.mo is "ClericPlayer")    { Gem = "LIFEGMC2"; Chain = "CHAIN2"; }
+		else if (CPlayer.mo is "MagePlayer") { Gem = "LIFEGMM2"; Chain = "CHAIN3"; }
+		else                                 { Gem = "LIFEGMF2"; Chain = "CHAIN";  }
 
 		int inthealth =  mHealthInterpolator2.GetValue();
-		DrawGem("CHAIN", "LIFEGMF2", inthealth, CPlayer.mo.GetMaxHealth(true), (30, 193), -23, 49, 15, (multiplayer? DI_TRANSLATABLE : 0) | DI_ITEM_LEFT_TOP); 
+		DrawGem(Chain, Gem, inthealth, CPlayer.mo.GetMaxHealth(true), (30, 193), -23, 49, 15, (multiplayer? DI_TRANSLATABLE : 0) | DI_ITEM_LEFT_TOP); 
 		
 		DrawImage("LFEDGE", (0, 192), DI_ITEM_OFFSETS);
 		DrawImage("RTEDGE", (277, 192), DI_ITEM_OFFSETS);


### PR DESCRIPTION
Hexen's characters incorrectly only used the Fighter's health chain previously.