### PR TITLE
Reset command buffer in render state before deleting frame objects

### DIFF
--- a/src/rendering/vulkan/renderer/vk_renderstate.h
+++ b/src/rendering/vulkan/renderer/vk_renderstate.h
@@ -49,6 +49,7 @@ public:
 	void Bind(int bindingpoint, uint32_t offset);
 	void EndRenderPass();
 	void EndFrame();
+	void ResetCommandBuffer() { mCommandBuffer = nullptr; }
 
 protected:
 	void Apply(int dt);

--- a/src/rendering/vulkan/system/vk_framebuffer.cpp
+++ b/src/rendering/vulkan/system/vk_framebuffer.cpp
@@ -209,6 +209,7 @@ void VulkanFrameBuffer::Update()
 
 void VulkanFrameBuffer::DeleteFrameObjects()
 {
+	mRenderState->ResetCommandBuffer();
 	FrameDeleteList.Images.clear();
 	FrameDeleteList.ImageViews.clear();
 	FrameDeleteList.Framebuffers.clear();


### PR DESCRIPTION
This fixes potential crash when rendering mirror portals

https://forum.zdoom.org/viewtopic.php?t=65719