### PR TITLE
Fix issues in ILLUSORY/ilusory1

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1370,6 +1370,28 @@ class LevelCompatibility native play
 				SetWallTexture(1926, Line.back, Side.bottom, "MARBLE3");
 				break;
 			}
+			case 'A7C4FC8CAEB3E375B7214E35C6298B03': // Illusions of Home e1m6
+			{
+				// Convert zero-tagged GR door into regular open-stay door to fix map
+				SetLineActivation (37, SPAC_Use);
+				SetLineSpecial (37, Door_Open, 0, 16);
+				SetLineActivation (203, SPAC_Use);
+				SetLineSpecial (203, Door_Open, 0, 16);
+				break;
+			}
+			case '5084755C29FB0A1912113E36F37C958A': // Illusions of Home e3m4
+			{
+				// Fix action of final switch
+				SetLineActivation (765, SPAC_Use);
+				SetLineSpecial (765, Door_Open, 0, 16);
+				break;
+			}
+			case '0EF86635676FD512CE0E962040125553': // Illusions of Home e3m7
+			{
+				// Fix red key
+				SetThingFlags(247, 2016);
+				break;
+			}
 		}
 	}
 

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1373,16 +1373,16 @@ class LevelCompatibility native play
 			case 'A7C4FC8CAEB3E375B7214E35C6298B03': // Illusions of Home e1m6
 			{
 				// Convert zero-tagged GR door into regular open-stay door to fix map
-				SetLineActivation (37, SPAC_Use);
-				SetLineSpecial (37, Door_Open, 0, 16);
-				SetLineActivation (203, SPAC_Use);
-				SetLineSpecial (203, Door_Open, 0, 16);
+				SetLineActivation(37, SPAC_Use);
+				SetLineSpecial(37, Door_Open, 0, 16);
+				SetLineActivation(203, SPAC_Use);
+				SetLineSpecial(203, Door_Open, 0, 16);
 				break;
 			}
 			case '5084755C29FB0A1912113E36F37C958A': // Illusions of Home e3m4
 			{
 				// Fix action of final switch
-				SetLineSpecial (765, Door_Open, 0, 16);
+				SetLineSpecial(765, Door_Open, 0, 16);
 				break;
 			}
 			case '0EF86635676FD512CE0E962040125553': // Illusions of Home e3m7

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1382,7 +1382,6 @@ class LevelCompatibility native play
 			case '5084755C29FB0A1912113E36F37C958A': // Illusions of Home e3m4
 			{
 				// Fix action of final switch
-				SetLineActivation (765, SPAC_Use);
 				SetLineSpecial (765, Door_Open, 0, 16);
 				break;
 			}


### PR DESCRIPTION
Added some compatibility patches for Illusions of Home E1M6, E3M4, and E3M7 (this fixes minor issues to all of these maps)
E1M8 requires a MAPINFO of some sort to have work correctly in the state it's in, unfortunately.
You can use this to check it over for yourself: https://www.doomworld.com/idgames/levels/doom/g-i/ilusory1