### PR TITLE
Fix ILLUSORY/ilusory1 E3M7 some more

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1379,6 +1379,16 @@ class LevelCompatibility native play
 				SetLineSpecial(203, Door_Open, 0, 16);
 				break;
 			}
+			case 'D8AB5E8EF9CFD153B146DD7E5B3208CF': // Illusions of Home e1m7
+			{
+				// Fix yellow key door
+				SetLineActivation(407, SPAC_Use);
+				SetLineSpecial(407, Door_Raise, 0, 16, 150, 0);
+				SetLineFlags(407, Line.ML_REPEAT_SPECIAL);
+				SetLineActivation(413, SPAC_Use);
+				SetLineSpecial(413, Door_Raise, 0, 16, 150, 0);
+				SetLineFlags(413, Line.ML_REPEAT_SPECIAL);
+			}
 			case '5084755C29FB0A1912113E36F37C958A': // Illusions of Home e3m4
 			{
 				// Fix action of final switch

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1388,11 +1388,13 @@ class LevelCompatibility native play
 			case '0EF86635676FD512CE0E962040125553': // Illusions of Home e3m7
 			{
 				// Fix red key and red key area door
+				// Also fix missing texture in red key area
 				SetThingFlags(247, 2016);
 				SetThingSkills(247, 31);
 				SetLineActivation(49, SPAC_Use);
 				SetLineSpecial(49, Door_Raise, 0, 16, 150, 0);
 				SetLineFlags(49, Line.ML_REPEAT_SPECIAL);
+				SetWallTexture(608, Line.back, Side.bottom, "GRAY5");
 				break;
 			}
 		}

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1388,6 +1388,7 @@ class LevelCompatibility native play
 				SetLineActivation(413, SPAC_Use);
 				SetLineSpecial(413, Door_Raise, 0, 16, 150, 0);
 				SetLineFlags(413, Line.ML_REPEAT_SPECIAL);
+				break;
 			}
 			case '5084755C29FB0A1912113E36F37C958A': // Illusions of Home e3m4
 			{

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1389,6 +1389,7 @@ class LevelCompatibility native play
 			{
 				// Fix red key and red key area door
 				SetThingFlags(247, 2016);
+				SetThingSkills(247, 31);
 				SetLineActivation(49, SPAC_Use);
 				SetLineSpecial(49, Door_Raise, 0, 16, 150, 0);
 				SetLineFlags(49, Line.ML_REPEAT_SPECIAL);

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1389,8 +1389,9 @@ class LevelCompatibility native play
 			{
 				// Fix red key and red key area door
 				SetThingFlags(247, 2016);
-				SetLineActivation(49, SPAC_Use);
+				SetLineActivation(49, SPAC_Use | SPAC_MUse);
 				SetLineSpecial(49, Door_Raise, 0, 16, 150, 0);
+				SetLineFlags(49, Line.ML_REPEAT_SPECIAL);
 				break;
 			}
 		}

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1379,17 +1379,6 @@ class LevelCompatibility native play
 				SetLineSpecial(203, Door_Open, 0, 16);
 				break;
 			}
-			case 'D8AB5E8EF9CFD153B146DD7E5B3208CF': // Illusions of Home e1m7
-			{
-				// Fix yellow key door
-				SetLineActivation(407, SPAC_Use);
-				SetLineSpecial(407, Door_Raise, 0, 16, 150, 0);
-				SetLineFlags(407, Line.ML_REPEAT_SPECIAL);
-				SetLineActivation(413, SPAC_Use);
-				SetLineSpecial(413, Door_Raise, 0, 16, 150, 0);
-				SetLineFlags(413, Line.ML_REPEAT_SPECIAL);
-				break;
-			}
 			case '5084755C29FB0A1912113E36F37C958A': // Illusions of Home e3m4
 			{
 				// Fix action of final switch

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1387,8 +1387,10 @@ class LevelCompatibility native play
 			}
 			case '0EF86635676FD512CE0E962040125553': // Illusions of Home e3m7
 			{
-				// Fix red key
+				// Fix red key and red key area door
 				SetThingFlags(247, 2016);
+				SetLineActivation(49, SPAC_Use);
+				SetLineSpecial(49, Door_Raise, 0, 16, 150, 0);
 				break;
 			}
 		}

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1389,7 +1389,7 @@ class LevelCompatibility native play
 			{
 				// Fix red key and red key area door
 				SetThingFlags(247, 2016);
-				SetLineActivation(49, SPAC_Use | SPAC_MUse);
+				SetLineActivation(49, SPAC_Use);
 				SetLineSpecial(49, Door_Raise, 0, 16, 150, 0);
 				SetLineFlags(49, Line.ML_REPEAT_SPECIAL);
 				break;


### PR DESCRIPTION
Illusions of Home, even after all that patching, still has one minor fault in E3M7. The door to the red key area is inaccessible without patching, making this patch a requirement to beat the level. Ties into both #916 and #917.