### PR TITLE
add empty line after standard options

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -385,6 +385,7 @@ OptionMenu "OptionsMenu" protected
 	SafeCommand "$OPTMNU_DEFAULTS",	"reset2defaults"
 	SafeCommand	"$OPTMNU_RESETTOSAVED",	"reset2saved"
 	Command "$OPTMNU_CONSOLE",			"menuconsole"
+	StaticText " "
 }
 
 //-------------------------------------------------------------------------------------------

--- a/wadsrc/static/zscript/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/optionmenu.zs
@@ -106,6 +106,19 @@ class OptionMenu : Menu
 		mParentMenu = parent;
 		mDesc = desc;
 		DontDim = desc.mDontDim;
+
+		let last = mDesc.mItems[mDesc.mItems.size() - 1];
+		bool lastIsText = (last is "OptionMenuItemStaticText");
+		if (lastIsText)
+		{
+			String text = last.mLabel;
+			bool lastIsSpace = (text == "" || text == " ");
+			if (lastIsSpace)
+			{
+				mDesc.mItems.Pop();
+			}
+		}
+
 		if (mDesc != NULL && mDesc.mSelectedItem == -1) mDesc.mSelectedItem = FirstSelectable();
 		mDesc.CalcIndent();
 


### PR DESCRIPTION
Rationale:
When a mod adds a custom option menu, it adds a space before it, like this:
```
AddOptionMenu OptionsMenu
{
  StaticText ""
  Submenu "$MYTITLE", MyOptions
}
```
to prevent custom option menu being in the same block as the last entries in the
standard options list. It's okay.

But when more than one such mod is loaded, each one of them adds a space before
their option menu entry, and Options Menu becomes unnecessary bloated.

This simple edit allows mods to not add a space, and still be separated from
standard options.