### PR TITLE
Added Armor to Hexen fullscreen display

### DIFF
--- a/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
@@ -65,8 +65,12 @@ class HexenStatusBar : BaseStatusBar
 	protected void DrawFullScreenStuff ()
 	{
 		//health
-		DrawImage("PTN1A0", (51, -3));
+		DrawImage("PTN1A0", (60, -3));
 		DrawString(mBigFont, FormatNumber(mHealthInterpolator.GetValue()), (41, -21), DI_TEXT_ALIGN_RIGHT);
+
+		//armor
+		DrawImage("AR_1A0", (60, -23));
+		DrawString(mBigFont, FormatNumber(GetArmorSavePercent() / 5, 2), (41, -41), DI_TEXT_ALIGN_RIGHT);
 
 		//frags/keys
 		if (deathmatch)


### PR DESCRIPTION
The hexen fullscreen HUD lacks an armor display. It has been added above it, like in heretic. Because the armor icon is much larger than the flask icon, both icons have been shifted a bit to the right.