### PR TITLE
Wrong offset on Fighter's Fist

### DIFF
--- a/wadsrc/static/zscript/actors/hexen/fighterfist.zs
+++ b/wadsrc/static/zscript/actors/hexen/fighterfist.zs
@@ -38,7 +38,7 @@ class FWeapFist : FighterWeapon
 		FPCH E 1 Offset (35, 70);
 		FPCH E 1 Offset (45, 80);
 		FPCH E 1 Offset (55, 90);
-		FPCH E 1 Offset (65, 90);
+		FPCH E 1 Offset (65, 100);
 		FPCH E 10 Offset (0, 150);
 		Goto Ready;
 	}


### PR DESCRIPTION
A particular frame in the fighter's fist "big punch" has the wrong offset. This is the corresponding frame in [Chocolate Hexen](https://github.com/chocolate-doom/chocolate-doom/blob/master/src/hexen/info.c#L1283).