### PR TITLE
Fix for LineTrace not setting its starting sector based on its offset

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -4803,7 +4803,7 @@ int P_LineTrace(AActor *t1, DAngle angle, double distance,
 	if ( flags & TRF_NOSKY ) tflags |= TRACE_NoSky;
 
 	// Do trace
-	bool ret = Trace(startpos, t1->Sector, direction, distance, aflags, lflags, t1, trace, tflags, CheckLineTrace, &TData);
+	bool ret = Trace(startpos, t1->Level->PointInSector(startpos), direction, distance, aflags, lflags, t1, trace, tflags, CheckLineTrace, &TData);
 	if ( outdata )
 	{
 		memset(outdata,0,sizeof(*outdata));


### PR DESCRIPTION
LineTrace uses the current sector of the caller, rather than adjusting its sector to wherever the offset makes it start from. This can cause issues, mainly related to floor/ceiling heights.

This is a simple fix for that oversight.