### PR TITLE
- Fixed ancient ZDoom savegame slot selection bug

### DIFF
--- a/src/menu/loadsavemenu.cpp
+++ b/src/menu/loadsavemenu.cpp
@@ -361,6 +361,10 @@ void FSavegameManager::NotifyNewSave(const FString &file, const FString &title, 
 		if (quickSaveSlot == nullptr || quickSaveSlot == (FSaveGameNode*)1 || forceQuicksave) quickSaveSlot = node;
 		LastAccessed = LastSaved = index;
 	}
+	else
+	{
+		LastAccessed = ++LastSaved;
+	}
 }
 
 //=============================================================================


### PR DESCRIPTION
When creating new autosaves LastAccessed and LastSaved were not updated accordingly.
https://forum.zdoom.org/viewtopic.php?f=2&t=65592&p=1119034#p1119034