### PR TITLE
Remove the removal of one of Doom 2 MAP15's secrets

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -689,8 +689,6 @@ class LevelCompatibility native play
 			
 			case '1A540BA717BF9EC85F8522594C352F2A': // Doom II, map15
 			{
-				// Remove unreachable secret
-				SetSectorSpecial(147, 0);
 				// Missing textures
 				SetWallTexture(94, Line.back, Side.top, "METAL");
 				SetWallTexture(95, Line.back, Side.top, "METAL");


### PR DESCRIPTION
Removed the ZScript that originally removed the Doom 2 MAP15 secret as Zero Master proved that it is possible to trigger it with a pain elemental. The video that prompted this is: https://www.youtube.com/watch?v=irNoHfnLXRM