### PR TITLE
Fix crash on vulkan with a large number of texture shaders

### DIFF
--- a/src/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/rendering/vulkan/shaders/vk_shader.cpp
@@ -38,7 +38,7 @@ VkShaderManager::VkShaderManager(VulkanDevice *device) : device(device)
 			FString defines = defaultshaders[usershaders[i].shaderType].Defines + usershaders[i].defines;
 
 			VkShaderProgram prog;
-			prog.vert = LoadVertShader(name, mainvp, defaultshaders[i].Defines);
+			prog.vert = LoadVertShader(name, mainvp, defines);
 			prog.frag = LoadFragShader(name, mainfp, usershaders[i].shader, defaultshaders[usershaders[i].shaderType].lightfunc, defines, true, gbufferpass);
 			mMaterialShaders[j].push_back(std::move(prog));
 		}


### PR DESCRIPTION
Just a quick patch for the bug I reported.

If a mod uses a large number of unique texture shaders, it will crash with a SIGSEGV. This is because it is using the incorrect array index for shader defines when compiling.