### PR TITLE
Fixed player sprites not being affected by sector light level in the classic software renderer

### DIFF
--- a/src/rendering/swrenderer/scene/r_light.cpp
+++ b/src/rendering/swrenderer/scene/r_light.cpp
@@ -205,7 +205,10 @@ namespace swrenderer
 
 			int shade = LightVisibility::LightLevelToShade(lightlevel, foggy, thread->Viewport.get());
 			if (psprite)
+			{
+				visibility = 0;
 				shade -= 24 * FRACUNIT;
+			}
 
 			BaseColormap = basecolormap;
 			ColormapNum = GETPALOOKUP(visibility, shade);


### PR DESCRIPTION
https://forum.zdoom.org/viewtopic.php?f=56&t=65826