### PR TITLE
add m_quickexit option for quick exit in game menu

### DIFF
--- a/src/menu/messagebox.cpp
+++ b/src/menu/messagebox.cpp
@@ -46,6 +46,8 @@
 EXTERN_CVAR (Bool, saveloadconfirmation) // [mxd]
 EXTERN_CVAR (Bool, quicksaverotation)
 
+CVAR(Bool, m_quickexit, false, CVAR_ARCHIVE)
+
 typedef void(*hfunc)();
 DEFINE_ACTION_FUNCTION(DMessageBoxMenu, CallHandler)
 {
@@ -85,9 +87,14 @@ DMenu *CreateMessageBoxMenu(DMenu *parent, const char *message, int messagemode,
 
 CCMD (menu_quit)
 {	// F10
+	if (m_quickexit)
+	{
+		ST_Endoom();
+	}
+
 	M_StartControlPanel (true);
 
-	int messageindex = gametic % gameinfo.quitmessages.Size();
+	const size_t messageindex = static_cast<size_t>(gametic) % gameinfo.quitmessages.Size();
 	FString EndString;
 	const char *msg = gameinfo.quitmessages[messageindex];
 	if (msg[0] == '$')

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1202,6 +1202,10 @@ OptionMenu "MiscOptions" protected
 	SafeCommand "$MISCMNU_CLEARNODECACHE",		"clearnodecache"
 	StaticText " "
 	Option "$OPTMNU_LANGUAGE", "language", "LanguageOptions"
+
+	StaticText " "
+	Option "$MISCMNU_QUICKEXIT",				"m_quickexit", "OnOff"
+
 	IfOption(Windows)
 	{
 		StaticText " "


### PR DESCRIPTION
Default: off (false)

When this option is enabled (true), then exiting the game from main menu and by menu_quit command doesn't require confirmation and doesn't play sound.

This option requires adding "$MISCMNU_QUICKEXIT" string.

This option can be configured in Miscellaneous Options.