### PR TITLE
fix bug when down arrow gave no result after mouse move in main menu

### DIFF
--- a/wadsrc/static/zscript/ui/menu/listmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/listmenu.zs
@@ -144,7 +144,6 @@ class ListMenu : Menu
 	{
 		int oldSelect = mDesc.mSelectedItem;
 		int startedAt = mDesc.mSelectedItem;
-		if (startedAt < 0) startedAt = 0;
 
 		switch (mkey)
 		{


### PR DESCRIPTION
Steps to reproduce:
1. Load game.
2. Press any key to bring up the main menu.
3. Move the mouse anywhere out of the menu entries.
4. Press Down arrow.

Expected result: the menu cursor sound is played, the first menu element is selected.
Actual result: the menu cursor sound is played, no menu element is selected.

Repeated Down arrow pressing doesn't give any result, either.

If on step 4 Up arrow is pressed, the last element in the menu is selected.