### PR TITLE
CheckBossDeath Fix

### DIFF
--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -3050,15 +3050,24 @@ int CheckBossDeath (AActor *actor)
 	auto iterator = actor->Level->GetThinkerIterator<AActor>();
 	AActor *other;
 
+	PClassActor *cls = actor->GetClass();
+	FName type = cls->GetReplacee(actor->Level)->TypeName;
+
 	while ( (other = iterator.Next ()) )
 	{
-		if (other != actor &&
-			(other->health > 0 || (other->flags & MF_ICECORPSE))
-			&& other->GetClass() == actor->GetClass())
+		if (other == actor)
+			continue;
+
+		PClassActor *ocls = other->GetClass();
+		FName otype = ocls->GetReplacee(other->Level)->TypeName;
+
+		if ((other->health > 0 || (other->flags & MF_ICECORPSE))
+			&& (ocls == cls || otype == type))
 		{ // Found a living boss
 		  // [RH] Frozen bosses don't count as dead until they shatter
 			return false;
 		}
+		
 	}
 	// The boss death is good
 	return true;


### PR DESCRIPTION
Fixed CheckBossDeath not checking for actor replacements.

- A_BossDeath relies upon this function in particular.
- This completes CheckReplacee's purpose, allowing for varied actors to count as one particular actor, such as a Fatso for map07 and avoid lowering the walls until they are all dead.