### PR TITLE
Fixed broken option

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2687,7 +2687,7 @@ OptionMenu "ReverbSettings" protected
 	SliderReverbEditOption "$REVMNU_Echo_Depth", 0, 1, 0.01, 3, 20
 	SliderReverbEditOption "$REVMNU_Modulation_Time", 0.04, 4, 0.01, 3, 21
 	SliderReverbEditOption "$REVMNU_Modulation_Depth",0, 1, 0.01, 3, 22
-	SliderReverbEditOption "$REVMNU_Air Absorption_HF", -100, 0, 0.01, 3, 23
+	SliderReverbEditOption "$REVMNU_Air_Absorption_HF", -100, 0, 0.01, 3, 23
 	SliderReverbEditOption "$REVMNU_HF_Reference", 10000, 200000, 1, 3, 24
 	SliderReverbEditOption "$REVMNU_LF_Reference",20, 10000, 0.1, 3, 25
 	SliderReverbEditOption "$REVMNU_Room_Rolloff_Factor",0, 10, 0.01, 3, 26


### PR DESCRIPTION
Also, the **REVMNU_ENVIRONMENTSIZE** entry should be changed to **REVMNU_ENVIRONMENT_SIZE** in the Google Docs spreadsheet.