### PR TITLE
Fixed tall skies in software

### DIFF
--- a/src/rendering/r_sky.cpp
+++ b/src/rendering/r_sky.cpp
@@ -104,14 +104,10 @@ void InitSkyMap(FLevelLocals *Level)
 	//                  of the texture is at the top of the screen when looking fully up.
 	skyheight = skytex1->GetDisplayHeight();
 
-	if (skyheight >= 128 && skyheight < 200)
-	{
-		Level->skystretch = (r_skymode == 1
-			&& skyheight >= 128
-			&& Level->IsFreelookAllowed()
-			&& !(Level->flags & LEVEL_FORCETILEDSKY)) ? 1 : 0;
-	}
-	else Level->skystretch = false;
+	Level->skystretch = (r_skymode == 1
+		&& skyheight >= 128 && skyheight < 310
+		&& Level->IsFreelookAllowed()
+		&& !(Level->flags & LEVEL_FORCETILEDSKY)) ? 1 : 0;
 }
 
 void R_InitSkyMap()

--- a/src/rendering/swrenderer/plane/r_skyplane.cpp
+++ b/src/rendering/swrenderer/plane/r_skyplane.cpp
@@ -56,6 +56,7 @@
 
 CVAR(Bool, r_linearsky, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 EXTERN_CVAR(Int, r_skymode)
+EXTERN_CVAR(Bool, cl_oldfreelooklimit)
 
 namespace swrenderer
 {
@@ -82,11 +83,12 @@ namespace swrenderer
 		FSoftwareTexture *sskytex2 = skytex2->GetSoftwareTexture();
 		skytexturemid = 0;
 		int skyheight = skytex1->GetDisplayHeight();
+		skyoffset = cl_oldfreelooklimit? 0 : skyheight >= 200? 110 : 138;
 		if (skyheight >= 128 && skyheight < 200)
 		{
 			skytexturemid = -28;
 		}
-		else if (skyheight > 200)
+		else if (skyheight >= 200)
 		{
 			skytexturemid = (200 - skyheight) * sskytex1->GetScale().Y + ((r_skymode == 2 && !(Level->flags & LEVEL_FORCETILEDSKY)) ? skytex1->GetSkyOffset() : 0);
 		}
@@ -102,9 +104,9 @@ namespace swrenderer
 
 		if (Level->skystretch)
 		{
-			skyscale *= (double)SKYSTRETCH_HEIGHT / skyheight;
-			skyiscale *= skyheight / (float)SKYSTRETCH_HEIGHT;
-			skytexturemid *= skyheight / (double)SKYSTRETCH_HEIGHT;
+			skyscale *= (double)(SKYSTRETCH_HEIGHT + skyoffset) / skyheight;
+			skyiscale *= skyheight / (float)(SKYSTRETCH_HEIGHT + skyoffset);
+			skytexturemid *= skyheight / (double)(SKYSTRETCH_HEIGHT + skyoffset);
 		}
 
 		// The standard Doom sky texture is 256 pixels wide, repeated 4 times over 360 degrees,
@@ -204,7 +206,7 @@ namespace swrenderer
 				frontcyl = MAX(frontskytex->GetWidth(), frontxscale);
 				if (Level->skystretch)
 				{
-					skymid = skymid * frontskytex->GetScaledHeightDouble() / SKYSTRETCH_HEIGHT;
+					skymid = skymid * frontskytex->GetScaledHeightDouble() / (SKYSTRETCH_HEIGHT + skyoffset);
 				}
 			}
 		}
@@ -274,7 +276,7 @@ namespace swrenderer
 
 	void RenderSkyPlane::DrawSkyColumn(int start_x, int y1, int y2)
 	{
-		if (1 << frontskytex->GetHeightBits() == frontskytex->GetPhysicalHeight())
+		if (1 << frontskytex->GetHeightBits() >= frontskytex->GetPhysicalHeight())
 		{
 			double texturemid = skymid * frontskytex->GetScale().Y + frontskytex->GetHeight();
 			DrawSkyColumnStripe(start_x, y1, y2, frontskytex->GetScale().Y, texturemid, frontskytex->GetScale().Y);

--- a/src/rendering/swrenderer/plane/r_skyplane.h
+++ b/src/rendering/swrenderer/plane/r_skyplane.h
@@ -55,6 +55,7 @@ namespace swrenderer
 		fixed_t backcyl = 0;
 		double skymid = 0.0;
 		angle_t skyangle = 0;
+		int skyoffset = 0;
 
 		SkyDrawerArgs drawerargs;
 	};


### PR DESCRIPTION
- Fixed capped tall skies not working (Heretic and Hexen).
- Fixed sky stretching for the new freelook limit.