### PR TITLE
Add rt to lib list after others such as libasmjit to fix linking order

### DIFF
--- a/libraries/asmjit/CMakeLists.txt
+++ b/libraries/asmjit/CMakeLists.txt
@@ -101,6 +101,10 @@ add_library(${ASMJITNAME} STATIC ${ASMJIT_SRCS} ${ASMJIT_PUBLIC_HDRS})
 
 set_target_properties(${ASMJITNAME} PROPERTIES OUTPUT_NAME asmjit)
 
+if(UNIX)
+    target_link_libraries(${ASMJITNAME} PRIVATE rt)
+endif()
+
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
     install(TARGETS ${ASMJITNAME}
         RUNTIME DESTINATION bin


### PR DESCRIPTION
I wasn't able to reproduce this personally so it may depend on other
factors but more than one other Gentoo user encountered it. See
https://bugs.gentoo.org/695192.