### PR TITLE
Scythe MAP22 Compatibility fix

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1394,6 +1394,12 @@ class LevelCompatibility native play
 				break;
 			}
 
+			case '63BDD083A98A48C04B8CD58AA857F77D': // Scythe MAP22
+			{
+				// Wall behind start creates HOM in software renderer due to weird sector
+				OffsetSectorPlane(236, Sector.Floor, -40);
+			}
+
 			case '1C795660D2BA9FC93DA584C593FD1DA3': // Scythe 2 MAP17
 			{
 				// Texture displays incorrectly in hardware renderer


### PR DESCRIPTION
https://www.doomworld.com/forum/topic/109887-gzdoom-scythe-hom/

Scythe MAP22 has a HOM in software behind the start due to an incorrectly made sector. Why this only occurs in GZDoom software is a good question...