### PR TITLE
Adjust collision detection for item pickups

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -1324,8 +1324,14 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 			(thing->flags5 & MF5_DONTRIP) ||
 			((tm.thing->flags6 & MF6_NOBOSSRIP) && (thing->flags2 & MF2_BOSS)))
 		{
+			if (thing->flags & MF_SPECIAL)
+			{
+				// Vanilla condition, i.e. without equality, for item pickups
+				if ((tm.thing->Z() > topz) || (tm.thing->Top() < thing->Z()))
+					return true;
+			}
 			// Some things prefer not to overlap each other, if possible (Q: Is this even needed anymore? It was just for dealing with some deficiencies in the code below in Heretic.)
-			if (!(tm.thing->flags3 & thing->flags3 & MF3_DONTOVERLAP))
+			else if (!(tm.thing->flags3 & thing->flags3 & MF3_DONTOVERLAP))
 			{
 				if ((tm.thing->Z() >= topz) || (tm.thing->Top() <= thing->Z()))
 					return true;


### PR DESCRIPTION
Use vanilla condition for a thing with `MF_SPECIAL` flag to fix inability to grab it when item's top is at the same height as sector's floor from it can be picked up

https://forum.zdoom.org/viewtopic.php?t=60181&start=88#p1122935