### PR TITLE
Implement return type covariance for ZScript virtual functions

### DIFF
--- a/src/common/objects/dobjtype.cpp
+++ b/src/common/objects/dobjtype.cpp
@@ -51,6 +51,7 @@
 // TYPES -------------------------------------------------------------------
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
+bool AreCompatiblePointerTypes(PType* dest, PType* source, bool forcompare = false);
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
 
@@ -665,7 +666,7 @@ PClass *PClass::FindClassTentative(FName name)
 //
 //==========================================================================
 
-int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction *parentfunc)
+int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction *parentfunc, bool exactReturnType)
 {
 	auto proto = variant->Proto;
 	for (unsigned i = 0; i < Virtuals.Size(); i++)
@@ -693,7 +694,10 @@ int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction 
 
 			for (unsigned a = 0; a < proto->ReturnTypes.Size(); a++)
 			{
-				if (proto->ReturnTypes[a] != vproto->ReturnTypes[a])
+				PType* expected = vproto->ReturnTypes[a];
+				PType* actual = proto->ReturnTypes[a];
+
+				if (expected != actual && (exactReturnType || !AreCompatiblePointerTypes(expected, actual)))
 				{
 					fail = true;
 					break;

--- a/src/common/objects/dobjtype.h
+++ b/src/common/objects/dobjtype.h
@@ -43,7 +43,7 @@ public:
 	void InitializeSpecials(void* addr, void* defaults, TArray<FTypeAndOffset> PClass::* Inits);
 	void WriteAllFields(FSerializer &ar, const void *addr) const;
 	bool ReadAllFields(FSerializer &ar, void *addr) const;
-	int FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction *parentfunc);
+	int FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction *parentfunc, bool exactReturnType);
 	PSymbol *FindSymbol(FName symname, bool searchparents) const;
 	PField *AddField(FName name, PType *type, uint32_t flags);
 	void InitializeDefaults();

--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -81,7 +81,7 @@ static const FLOP FxFlops[] =
 	{ NAME_Round,	FLOP_ROUND,		[](double v) { return round(v);  } },
 };
 
-static bool AreCompatiblePointerTypes(PType* dest, PType* source, bool forcompare = false);
+bool AreCompatiblePointerTypes(PType* dest, PType* source, bool forcompare = false);
 
 //==========================================================================
 //
@@ -271,7 +271,7 @@ PFunction *FindBuiltinFunction(FName funcname)
 //
 //==========================================================================
 
-static bool AreCompatiblePointerTypes(PType *dest, PType *source, bool forcompare)
+bool AreCompatiblePointerTypes(PType *dest, PType *source, bool forcompare)
 {
 	if (dest->isPointer() && source->isPointer())
 	{

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -2352,6 +2352,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 			sym->Variants[0].Implementation->VarFlags = sym->Variants[0].Flags;
 		}
 
+		bool exactReturnType = mVersion < MakeVersion(4, 4);
 		PClass *clstype = forclass? static_cast<PClassType *>(c->Type())->Descriptor : nullptr;
 		if (varflags & VARF_Virtual)
 		{
@@ -2365,7 +2366,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 			{
 				auto parentfunc = clstype->ParentClass? dyn_cast<PFunction>(clstype->ParentClass->VMType->Symbols.FindSymbol(sym->SymbolName, true)) : nullptr;
 
-				int vindex = clstype->FindVirtualIndex(sym->SymbolName, &sym->Variants[0], parentfunc);
+				int vindex = clstype->FindVirtualIndex(sym->SymbolName, &sym->Variants[0], parentfunc, exactReturnType);
 				// specifying 'override' is necessary to prevent one of the biggest problem spots with virtual inheritance: Mismatching argument types.
 				if (varflags & VARF_Override)
 				{
@@ -2445,7 +2446,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 		}
 		else if (forclass)
 		{
-			int vindex = clstype->FindVirtualIndex(sym->SymbolName, &sym->Variants[0], nullptr);
+			int vindex = clstype->FindVirtualIndex(sym->SymbolName, &sym->Variants[0], nullptr, exactReturnType);
 			if (vindex != -1)
 			{
 				Error(f, "Function %s attempts to override parent function without 'override' qualifier", FName(f->Name).GetChars());

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -1,4 +1,4 @@
-version "4.3"
+version "4.4"
 #include "zscript/base.zs"
 #include "zscript/sounddata.zs"
 #include "zscript/mapdata.zs"

--- a/wadsrc_extra/static/filter/harmony/zscript.txt
+++ b/wadsrc_extra/static/filter/harmony/zscript.txt
@@ -1,2 +1,2 @@
-version "4.2"
+version "4.4"
 #include "zscript/harm_sbar.zs"


### PR DESCRIPTION
This PR implements covariant return types for virtual functions as suggested [here](https://forum.zdoom.org/viewtopic.php?f=15&t=66340).

With this new feature, an overridden function's return type can now be either the same as or a subtype of the parent virtual function. The overridden function still fulfills the contract declared by the parent class, as well as enforces the new contract to all subclasses of the declaring class. This can come in handy in a few potential use cases, especially to avoid dangerous type-casting.

This feature requires a ZScript version bump, since it may cause old code to break. Consider the following ZScript:

```
class A
{
    virtual C GetSomething()
    {
        ...
    }
}

class B : A
{
    D GetSomething()
    {
        ...
    }
}

class C
{
}

class D : C
{
}
```

Currently, this code compiles, but if the proposed changes are introduced, the compiler will assume that B tries to override GetSomething without the override qualifier. Therefore, this feature is disabled in all ZScript versions up to and including 4.2.

Technical note: The only change required for this to work is in `PClass::FindVirtualIndex`, which is only called twice in the whole source, and both calls are located in `ZCCCompiler::CompileFunction` and have a similar context to them. Therefore, I believe that the proposed changes will not cause any regressions elsewhere. All existing ZScript code that I've tested so far (with the new feature enabled) did not produce any compile errors or other strange behavior.
