### PR TITLE
Localize level/author strings on intermission startup

### DIFF
--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -862,10 +862,10 @@ class StatusScreen abstract play version("2.5")
 		enteringPatch = TexMan.CheckForTexture("WIENTER", TexMan.Type_MiscPatch);	// "entering"
 		finishedPatch = TexMan.CheckForTexture("WIF", TexMan.Type_MiscPatch);			// "finished"
 
-		lnametexts[0] = wbstartstruct.thisname;		
-		lnametexts[1] = wbstartstruct.nextname;
-		authortexts[0] = wbstartstruct.thisauthor;
-		authortexts[1] = wbstartstruct.nextauthor;
+		lnametexts[0] = StringTable.Localize(wbstartstruct.thisname);		
+		lnametexts[1] = StringTable.Localize(wbstartstruct.nextname);
+		authortexts[0] = StringTable.Localize(wbstartstruct.thisauthor);
+		authortexts[1] = StringTable.Localize(wbstartstruct.nextauthor);
 
 		bg = InterBackground.Create(wbs);
 		noautostartmap = bg.LoadBackground(false);


### PR DESCRIPTION
Fixes misalignments (especially noticeable with wadsmoosh).

Before:
![Screenshot_Doom_20191110_180538](https://user-images.githubusercontent.com/2286785/68547730-20265a80-03e5-11ea-8682-ed4322c151c0.png)
After:
![Screenshot_Doom_20191110_180804](https://user-images.githubusercontent.com/2286785/68547731-23214b00-03e5-11ea-86ae-29c1bb54eb4f.png)
