### PR TITLE
Added 'nocheats' CVAR

### DIFF
--- a/src/st_stuff.cpp
+++ b/src/st_stuff.cpp
@@ -300,6 +300,7 @@ static cheatseq_t SpecialCheats[] =
 
 
 CVAR(Bool, allcheats, false, CVAR_ARCHIVE)
+CVAR(Bool, nocheats, false, CVAR_ARCHIVE)
 
 // Respond to keyboard input events, intercept cheats.
 // [RH] Cheats eat the last keypress used to trigger them
@@ -307,7 +308,11 @@ bool ST_Responder (event_t *ev)
 {
 	bool eat = false;
 
-	if (!allcheats)
+	if (nocheats)
+	{
+		return false;
+	}
+	else if (!allcheats)
 	{
 		cheatseq_t *cheats;
 		int numcheats;

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1187,6 +1187,7 @@ OptionMenu "MiscOptions" protected
 	}
 	Option "$MISCMNU_QUERYIWAD",				"queryiwad", "OnOff"
 	StaticText " "
+	Option "$MISCMNU_NOCHEATS",				"nocheats", "OnOff"
 	Option "$MISCMNU_ALLCHEATS",				"allcheats", "OnOff"
 	Option "$MISCMNU_ENABLEAUTOSAVES",			"disableautosave", "Autosave"
 	Option "$MISCMNU_SAVELOADCONFIRMATION",			"saveloadconfirmation", "OnOff"


### PR DESCRIPTION
After discussing with DabbingSquidward and looking at the source, it turns out that classic keyboard cheats (iddqd, etc.) eat key inputs after the second character. This can cause problems with certain cheat codes (like mASSAcre) even with standard WASD controls, and potentially more problems with non-standard controls. GZDoom can also emulate any cheat from the console or with an alias, so cheats are somewhat superfluous. As such, I've added a CVAR in the miscellaneous options that simply disables all keyboard cheats (keyboard cheats are enabled by default).

This will require a `MISCMNU_NOCHEATS` language string to be added. It should read something like "Disable keyboard cheats", or something to that effect.

