### PR TITLE
Added 'NoKeyboardCheats' option to IWADINFO

### DIFF
--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -128,6 +128,10 @@ void FIWadManager::ParseIWadInfo(const char *fn, const char *data, int datasize,
 					sc.MustGetString();
 					iwad->MapInfo = sc.String;
 				}
+				else if (sc.Compare("NoKeyboardCheats"))
+				{
+					iwad->nokeyboardcheats = true;
+				}
 				else if (sc.Compare("Compatibility"))
 				{
 					sc.MustGetStringName("=");

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2480,6 +2480,7 @@ static int D_DoomMain_Internal (void)
 		if (!iwad_info) return 0;	// user exited the selection popup via cancel button.
 		gameinfo.gametype = iwad_info->gametype;
 		gameinfo.flags = iwad_info->flags;
+		gameinfo.nokeyboardcheats = iwad_info->nokeyboardcheats;
 		gameinfo.ConfigName = iwad_info->Configname;
 		lastIWAD = iwad;
 

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -107,6 +107,7 @@ struct FIWADInfo
 	EGameType gametype = GAME_Doom;		// which game are we playing?
 	int StartupType = FStartupInfo::DefaultStartup;		// alternate startup type
 	FString MapInfo;		// Base mapinfo to load
+	bool nokeyboardcheats = false;		// disable keyboard cheats
 	TArray<FString> Load;	// Wads to be loaded with this one.
 	TArray<FString> Lumps;	// Lump names for identification
 	TArray<FString> DeleteLumps;	// Lumps which must be deleted from the directory.

--- a/src/gamedata/gi.h
+++ b/src/gamedata/gi.h
@@ -111,6 +111,7 @@ struct gameinfo_t
 	FString ConfigName;
 
 	FString TitlePage;
+	bool nokeyboardcheats;
 	bool drawreadthis;
 	bool noloopfinalemusic;
 	bool intermissioncounter;

--- a/src/st_stuff.cpp
+++ b/src/st_stuff.cpp
@@ -309,7 +309,7 @@ bool ST_Responder (event_t *ev)
 {
 	bool eat = false;
 
-	if (nocheats || !!cl_blockcheats)
+	if (nocheats || !!cl_blockcheats || (gameinfo.nokeyboardcheats && !allcheats))
 	{
 		return false;
 	}


### PR DESCRIPTION
The purpose of this option is to disable all hardcoded keyboard cheats (such as `idkfa` for Doom-based IWADs) for a particular IWAD. This allows a TC that is thematically unlike Doom (say, Total Chaos) to not use the thematically inappropriate Doom engine cheats (and possibly implement its own). Turning `allcheats` on, however, allows this setting to be overridden.