### PR TITLE
STOPRAILS Actor Flag + Rail Invulnerable Check Fix

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -411,6 +411,7 @@ enum ActorFlag8
 	MF8_NOFRICTIONBOUNCE	= 0x00000040,	// don't bounce off walls when on icy floors
 	MF8_RETARGETAFTERSLAM	= 0x00000080,	// Forces jumping to the idle state after slamming into something
 	MF8_RECREATELIGHTS	= 0x00000100,	// Internal flag that signifies that the light attachments need to be recreated at the
+	MF8_STOPRAILS		= 0x00000200,	// [MC] Prevent rails from going further if an actor has this flag.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5127,7 +5127,8 @@ static ETraceStatus ProcessRailHit(FTraceResults &res, void *userdata)
 	{
 		data->count++;
 	}
-	return (data->StopAtOne || (data->limit && (data->count >= data->limit))) ? TRACE_Stop : TRACE_Continue;
+	return (data->StopAtOne || (data->limit && (data->count >= data->limit)) || (res.Actor->flags8 & MF8_STOPRAILS)) 
+			? TRACE_Stop : TRACE_Continue;
 }
 
 //==========================================================================

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5089,12 +5089,6 @@ static ETraceStatus ProcessRailHit(FTraceResults &res, void *userdata)
 		return TRACE_Stop;
 	}
 
-	// Invulnerable things completely block the shot
-	if (data->StopAtInvul && res.Actor->flags2 & MF2_INVULNERABLE)
-	{
-		return TRACE_Stop;
-	}
-
 	// Skip actors if the puff has:
 	// 1. THRUACTORS (This one did NOT include a check for spectral)
 	// 2. MTHRUSPECIES on puff and the shooter has same species as the hit actor
@@ -5107,6 +5101,12 @@ static ETraceStatus ProcessRailHit(FTraceResults &res, void *userdata)
 		(data->ThruGhosts && res.Actor->flags3 & MF3_GHOST))
 	{
 		return TRACE_Skip;
+	}
+
+	// Invulnerable things completely block the shot
+	if (data->StopAtInvul && res.Actor->flags2 & MF2_INVULNERABLE)
+	{
+		return TRACE_Stop;
 	}
 
 	// Save this thing for damaging later, and continue the trace

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -322,6 +322,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, NOFRICTION, AActor, flags8),
 	DEFINE_FLAG(MF8, NOFRICTIONBOUNCE, AActor, flags8),
 	DEFINE_FLAG(MF8, RETARGETAFTERSLAM, AActor, flags8),
+	DEFINE_FLAG(MF8, STOPRAILS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
This PR does 2 things:

1. Adds an actor flag which stops rail attacks from proceeding past the actor it hits.
2. Fixes a bug where the invulnerability check came before the various thru flags, which means rails could not pass invulnerable actors that were meant to be skipped under the right conditions.

I can separate the second change into its own PR if desired, but seeing how simple this PR is, I thought it would be passable.