### PR TITLE
- add cvar 'cl_disableinvertedcolormap' - changes the invulnerability…

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -106,6 +106,7 @@
 
 EXTERN_CVAR(Bool, hud_althud)
 EXTERN_CVAR(Int, vr_mode)
+EXTERN_CVAR(Bool, cl_customizeinvulmap)
 void DrawHUD();
 void D_DoAnonStats();
 void I_DetectOS();
@@ -2751,6 +2752,10 @@ static int D_DoomMain_Internal (void)
 		Net_NewMakeTic ();
 		C_RunDelayedCommands();
 		gamestate = GS_STARTUP;
+
+		// enable custom invulnerability map here
+		if (cl_customizeinvulmap)
+			R_InitColormaps(true);
 
 		if (!restart)
 		{

--- a/src/r_data/colormaps.cpp
+++ b/src/r_data/colormaps.cpp
@@ -44,6 +44,11 @@
 #include "colormaps.h"
 #include "templates.h"
 
+CUSTOM_CVAR(Bool, cl_disableinvertedcolormap, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
+{
+	R_InitColormaps();
+}
+
 TArray<FakeCmap> fakecmaps;
 
 TArray<FSpecialColormap> SpecialColormaps;
@@ -241,6 +246,13 @@ void R_InitColormaps ()
 			}
 		}
 	}
+
+	// some of us really don't like Doom's idea of an invulnerability sphere colormap
+	// this hack will override that
+	if (cl_disableinvertedcolormap)
+		SpecialColormapParms[0] = {{0.0, 0.0, 0.2}, { 1.3, 1.3, 0.95}};
+	else
+		SpecialColormapParms[0] = {{1.0, 1.0, 1.0}, { 0.0, 0.0, 0.0}};
 
 	// build default special maps (e.g. invulnerability)
 

--- a/src/r_data/colormaps.cpp
+++ b/src/r_data/colormaps.cpp
@@ -44,10 +44,21 @@
 #include "colormaps.h"
 #include "templates.h"
 
-CUSTOM_CVAR(Bool, cl_disableinvertedcolormap, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINITCALL)
+CUSTOM_CVAR(Bool, cl_customizeinvulmap, false, CVAR_ARCHIVE|CVAR_NOINITCALL)
 {
 	R_InitColormaps();
 }
+CUSTOM_CVAR(Color, cl_custominvulmapcolor1, 0x00001a, CVAR_ARCHIVE|CVAR_NOINITCALL)
+{
+	if (cl_customizeinvulmap)
+		R_InitColormaps();
+}
+CUSTOM_CVAR(Color, cl_custominvulmapcolor2, 0xa6a67a, CVAR_ARCHIVE|CVAR_NOINITCALL)
+{
+	if (cl_customizeinvulmap)
+		R_InitColormaps();
+}
+
 
 TArray<FakeCmap> fakecmaps;
 
@@ -249,10 +260,22 @@ void R_InitColormaps ()
 
 	// some of us really don't like Doom's idea of an invulnerability sphere colormap
 	// this hack will override that
-	if (cl_disableinvertedcolormap)
-		SpecialColormapParms[0] = {{0.0, 0.0, 0.2}, { 1.3, 1.3, 0.95}};
+	if (cl_customizeinvulmap)
+	{
+		uint32_t color1 = cl_custominvulmapcolor1;
+		uint32_t color2 = cl_custominvulmapcolor2;
+		float r1 = (1.f/128.f) * ((color1 & 0xff0000) >> 16);
+		float g1 = (1.f/128.f) * ((color1 & 0x00ff00) >> 8);
+		float b1 = (1.f/128.f) * ((color1 & 0x0000ff) >> 0);
+		float r2 = (1.f/128.f) * ((color2 & 0xff0000) >> 16);
+		float g2 = (1.f/128.f) * ((color2 & 0x00ff00) >> 8);
+		float b2 = (1.f/128.f) * ((color2 & 0x0000ff) >> 0);
+		SpecialColormapParms[0] = {{r1, g1, b1}, {r2, g2, b2}};
+	}
 	else
-		SpecialColormapParms[0] = {{1.0, 1.0, 1.0}, { 0.0, 0.0, 0.0}};
+	{
+		SpecialColormapParms[0] = {{1.0, 1.0, 1.0}, {0.0, 0.0, 0.0}};
+	}
 
 	// build default special maps (e.g. invulnerability)
 

--- a/src/r_data/colormaps.cpp
+++ b/src/r_data/colormaps.cpp
@@ -264,12 +264,12 @@ void R_InitColormaps ()
 	{
 		uint32_t color1 = cl_custominvulmapcolor1;
 		uint32_t color2 = cl_custominvulmapcolor2;
-		float r1 = (1.f/128.f) * ((color1 & 0xff0000) >> 16);
-		float g1 = (1.f/128.f) * ((color1 & 0x00ff00) >> 8);
-		float b1 = (1.f/128.f) * ((color1 & 0x0000ff) >> 0);
-		float r2 = (1.f/128.f) * ((color2 & 0xff0000) >> 16);
-		float g2 = (1.f/128.f) * ((color2 & 0x00ff00) >> 8);
-		float b2 = (1.f/128.f) * ((color2 & 0x0000ff) >> 0);
+		float r1 = (float)((color1 & 0xff0000) >> 16) / 128.f;
+		float g1 = (float)((color1 & 0x00ff00) >> 8) / 128.f;
+		float b1 = (float)((color1 & 0x0000ff) >> 0) / 128.f;
+		float r2 = (float)((color2 & 0xff0000) >> 16) / 128.f;
+		float g2 = (float)((color2 & 0x00ff00) >> 8) / 128.f;
+		float b2 = (float)((color2 & 0x0000ff) >> 0) / 128.f;
 		SpecialColormapParms[0] = {{r1, g1, b1}, {r2, g2, b2}};
 	}
 	else

--- a/src/r_data/colormaps.cpp
+++ b/src/r_data/colormaps.cpp
@@ -46,17 +46,17 @@
 
 CUSTOM_CVAR(Bool, cl_customizeinvulmap, false, CVAR_ARCHIVE|CVAR_NOINITCALL)
 {
-	R_InitColormaps();
+	R_InitColormaps(true);
 }
 CUSTOM_CVAR(Color, cl_custominvulmapcolor1, 0x00001a, CVAR_ARCHIVE|CVAR_NOINITCALL)
 {
 	if (cl_customizeinvulmap)
-		R_InitColormaps();
+		R_InitColormaps(true);
 }
 CUSTOM_CVAR(Color, cl_custominvulmapcolor2, 0xa6a67a, CVAR_ARCHIVE|CVAR_NOINITCALL)
 {
 	if (cl_customizeinvulmap)
-		R_InitColormaps();
+		R_InitColormaps(true);
 }
 
 
@@ -180,7 +180,7 @@ void R_DeinitColormaps ()
 //
 //==========================================================================
 
-void R_InitColormaps ()
+void R_InitColormaps (bool allowCustomColormap)
 {
 	// [RH] Try and convert BOOM colormaps into blending values.
 	//		This is a really rough hack, but it's better than
@@ -260,7 +260,7 @@ void R_InitColormaps ()
 
 	// some of us really don't like Doom's idea of an invulnerability sphere colormap
 	// this hack will override that
-	if (cl_customizeinvulmap)
+	if (allowCustomColormap && cl_customizeinvulmap)
 	{
 		uint32_t color1 = cl_custominvulmapcolor1;
 		uint32_t color2 = cl_custominvulmapcolor2;

--- a/src/r_data/colormaps.h
+++ b/src/r_data/colormaps.h
@@ -5,7 +5,7 @@
 
 struct lightlist_t;
 
-void R_InitColormaps ();
+void R_InitColormaps (bool allowCustomColormap = false);
 void R_DeinitColormaps ();
 
 uint32_t R_ColormapNumForName(const char *name);	// killough 4/4/98

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -925,6 +925,7 @@ OptionMenu "VideoOptions" protected
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
 	StaticText " "
+	Option "$DSPLYMNU_NOINVERTMAP",				"cl_disableinvertedcolormap", "OnOff"
 	Option "$DSPLYMNU_WIPETYPE",				"wipetype", "Wipes"
 	Option "$DSPLYMNU_DRAWFUZZ",				"r_drawfuzz", "Fuzziness"
 	Option "$DSPLYMNU_OLDTRANS",				"r_vanillatrans", "VanillaTrans"

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -925,7 +925,9 @@ OptionMenu "VideoOptions" protected
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
 	StaticText " "
-	Option "$DSPLYMNU_NOINVERTMAP",				"cl_disableinvertedcolormap", "OnOff"
+	Option "$DSPLYMNU_CUSTOMINVERTMAP",			"cl_customizeinvulmap", "OnOff"
+	ColorPicker "$DSPLYMNU_CUSTOMINVERTC1",		"cl_custominvulmapcolor1"
+	ColorPicker "$DSPLYMNU_CUSTOMINVERTC2",		"cl_custominvulmapcolor2"
 	Option "$DSPLYMNU_WIPETYPE",				"wipetype", "Wipes"
 	Option "$DSPLYMNU_DRAWFUZZ",				"r_drawfuzz", "Fuzziness"
 	Option "$DSPLYMNU_OLDTRANS",				"r_vanillatrans", "VanillaTrans"


### PR DESCRIPTION
… sphere to instead be a regular desaturated colormap that transitions from deep blue to pale yellow

Language entry name is DSPLYMNU_NOINVERTMAP

![How it looks](https://cdn.discordapp.com/attachments/340199158772269056/644643275453759498/unknown.png)

https://forum.zdoom.org/viewtopic.php?f=59&t=66386