### PR TITLE
add an option for instant intermission counters

### DIFF
--- a/src/wi_stuff.cpp
+++ b/src/wi_stuff.cpp
@@ -59,6 +59,7 @@ CVAR(Bool, wi_percents, true, CVAR_ARCHIVE)
 CVAR(Bool, wi_showtotaltime, true, CVAR_ARCHIVE)
 CVAR(Bool, wi_noautostartmap, false, CVAR_USERINFO | CVAR_ARCHIVE)
 CVAR(Int, wi_autoadvance, 0, CVAR_SERVERINFO)
+CVAR(Bool, wi_instant, false, CVAR_ARCHIVE)
 
 // States for the intermission
 enum EState

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1196,7 +1196,9 @@ OptionMenu "MiscOptions" protected
 	Slider "$MISCMNU_QUICKSAVECOUNT",			"quicksaverotationcount", 1, 20, 1, 0
 	Option "$MISCMNU_DEHLOAD",					"dehload", "dehopt"
 	Option "$MISCMNU_ENABLESCRIPTSCREENSHOTS",		"enablescriptscreenshot", "OnOff"
+	StaticText " "
 	Option "$MISCMNU_INTERSCROLL",				"nointerscrollabort", "OffOn"
+	Option "$MISCMNU_INSTANT_INTERMISSION",			"wi_instant", "OnOff"
 	StaticText " "
 	Option "$MISCMNU_CACHENODES",				"gl_cachenodes", "OnOff"
 	Slider "$MISCMNU_CACHETIME",				"gl_cachetime", 0.0, 2.0, 0.1

--- a/wadsrc/static/zscript/ui/statscreen/statscreen_sp.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen_sp.zs
@@ -7,7 +7,7 @@ class DoomStatusScreen : StatusScreen
 	{
 		intermissioncounter = gameinfo.intermissioncounter;
 		CurState = StatCount;
-		acceleratestage = 0;
+		acceleratestage = wi_instant;
 		sp_state = 1;
 		cnt_kills[0] = cnt_items[0] = cnt_secret[0] = -1;
 		cnt_time = cnt_par = -1;
@@ -22,7 +22,10 @@ class DoomStatusScreen : StatusScreen
 		{
 			acceleratestage = 0;
 			sp_state = 10;
-			PlaySound("intermission/nextstage");
+			if (!wi_instant)
+			{
+				PlaySound("intermission/nextstage");
+			}
 
 			cnt_kills[0] = Plrs[me].skills;
 			cnt_items[0] = Plrs[me].sitems;


### PR DESCRIPTION
Changes:

- new CVar: wi_instant, off by default
- wi_instant true: intsant intermission counter results
- wi_instant true: no sound on intermission counter results
- menu entry in Miscellaneous menu

This change requires MISCMNU_INSTANT_INTERMISSION string to be added. Suggested string in English: "Instant intermission counters"