### PR TITLE
Implemented scale parameter for BaseStatusBar::DrawString

### DIFF
--- a/src/g_statusbar/sbar.h
+++ b/src/g_statusbar/sbar.h
@@ -437,7 +437,7 @@ public:
 	void DrawAltHUD();
 
 	void DrawGraphic(FTextureID texture, double x, double y, int flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY);
-	void DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY);
+	void DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY, double scaleX, double scaleY);
 	void TransformRect(double &x, double &y, double &w, double &h, int flags = 0);
 	void Fill(PalEntry color, double x, double y, double w, double h, int flags = 0);
 	void SetClipRect(double x, double y, double w, double h, int flags = 0);

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -1675,27 +1675,29 @@ void DBaseStatusBar::DrawGraphic(FTextureID texture, double x, double y, int fla
 //
 //============================================================================
 
-void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY)
+void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY, double scaleX, double scaleY)
 {
 	bool monospaced = monospacing != EMonospacing::Off;
+	double dx = 0;
 
 	switch (flags & DI_TEXT_ALIGN)
 	{
 	default:
 		break;
 	case DI_TEXT_ALIGN_RIGHT:
-		if (!monospaced)
-			x -= static_cast<int> (font->StringWidth(cstring) + (spacing * cstring.CharacterCount()));
-		else //monospaced, so just multiply the character size
-			x -= static_cast<int> ((spacing) * cstring.CharacterCount());
+		dx = monospaced
+			? static_cast<int> ((spacing)*cstring.CharacterCount()) //monospaced, so just multiply the character size
+			: static_cast<int> (font->StringWidth(cstring) + (spacing * cstring.CharacterCount()));
 		break;
 	case DI_TEXT_ALIGN_CENTER:
-		if (!monospaced)
-			x -= static_cast<int> (font->StringWidth(cstring) + (spacing * cstring.CharacterCount())) / 2;
-		else //monospaced, so just multiply the character size
-			x -= static_cast<int> ((spacing)* cstring.CharacterCount()) / 2;
+		dx = monospaced
+			? static_cast<int> ((spacing)*cstring.CharacterCount()) / 2 //monospaced, so just multiply the character size
+			: static_cast<int> (font->StringWidth(cstring) + (spacing * cstring.CharacterCount())) / 2;
 		break;
 	}
+
+	// Take text scale into account
+	x -= dx * scaleX;
 
 	const uint8_t* str = (const uint8_t*)cstring.GetChars();
 	const EColorRange boldTranslation = EColorRange(translation ? translation - 1 : NumTextColors - 1);
@@ -1781,6 +1783,11 @@ void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, d
 			rx += orgx;
 			ry += orgy;
 		}
+
+		// Apply text scale
+		rw *= scaleX;
+		rh *= scaleY;
+
 		// This is not really such a great way to draw shadows because they can overlap with previously drawn characters.
 		// This may have to be changed to draw the shadow text up front separately.
 		if ((shadowX != 0 || shadowY != 0) && !(flags & DI_NOSHADOW))
@@ -1798,14 +1805,16 @@ void DBaseStatusBar::DrawString(FFont *font, const FString &cstring, double x, d
 			DTA_Alpha, Alpha,
 			TAG_DONE);
 
-		if (!monospaced)
-			x += width + spacing - (c->GetDisplayLeftOffsetDouble() + 1);
-		else
-			x += spacing;
+		dx = monospaced 
+			? spacing
+			: width + spacing - (c->GetDisplayLeftOffsetDouble() + 1);
+
+		// Take text scale into account
+		x += dx * scaleX;
 	}
 }
 
-void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string, double x, double y, int flags, int trans, double alpha, int wrapwidth, int linespacing)
+void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string, double x, double y, int flags, int trans, double alpha, int wrapwidth, int linespacing, double scaleX, double scaleY)
 {
 	if (font == nullptr) ThrowAbortException(X_READ_NIL, nullptr);
 	if (!screen->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
@@ -1821,16 +1830,16 @@ void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string
 
 	if (wrapwidth > 0)
 	{
-		auto brk = V_BreakLines(font->mFont, wrapwidth, string, true);
+		auto brk = V_BreakLines(font->mFont, int(wrapwidth * scaleX), string, true);
 		for (auto &line : brk)
 		{
-			self->DrawString(font->mFont, line.Text, x, y, flags, alpha, trans, font->mSpacing, font->mMonospacing, font->mShadowX, font->mShadowY);
-			y += font->mFont->GetHeight() + linespacing;
+			self->DrawString(font->mFont, line.Text, x, y, flags, alpha, trans, font->mSpacing, font->mMonospacing, font->mShadowX, font->mShadowY, scaleX, scaleY);
+			y += (font->mFont->GetHeight() + linespacing) * scaleY;
 		}
 	}
 	else
 	{
-		self->DrawString(font->mFont, string, x, y, flags, alpha, trans, font->mSpacing, font->mMonospacing, font->mShadowX, font->mShadowY);
+		self->DrawString(font->mFont, string, x, y, flags, alpha, trans, font->mSpacing, font->mMonospacing, font->mShadowX, font->mShadowY, scaleX, scaleY);
 	}
 }
 

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2541,7 +2541,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DBaseStatusBar, DrawImage, SBar_DrawImage)
 	return 0;
 }
 
-void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string, double x, double y, int flags, int trans, double alpha, int wrapwidth, int linespacing);
+void SBar_DrawString(DBaseStatusBar *self, DHUDFont *font, const FString &string, double x, double y, int flags, int trans, double alpha, int wrapwidth, int linespacing, double scaleX, double scaleY);
 
 DEFINE_ACTION_FUNCTION_NATIVE(DBaseStatusBar, DrawString, SBar_DrawString)
 {
@@ -2555,7 +2555,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(DBaseStatusBar, DrawString, SBar_DrawString)
 	PARAM_FLOAT(alpha);
 	PARAM_INT(wrapwidth);
 	PARAM_INT(linespacing);
-	SBar_DrawString(self, font, string, x, y, flags, trans, alpha, wrapwidth, linespacing);
+	PARAM_FLOAT(scaleX);
+	PARAM_FLOAT(scaleY);
+	SBar_DrawString(self, font, string, x, y, flags, trans, alpha, wrapwidth, linespacing, scaleX, scaleY);
 	return 0;
 }
 

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -349,7 +349,7 @@ class BaseStatusBar native ui
 	native static TextureID, bool GetInventoryIcon(Inventory item, int flags);
 	native void DrawTexture(TextureID texture, Vector2 pos, int flags = 0, double Alpha = 1., Vector2 box = (-1, -1), Vector2 scale = (1, 1));
 	native void DrawImage(String texture, Vector2 pos, int flags = 0, double Alpha = 1., Vector2 box = (-1, -1), Vector2 scale = (1, 1));
-	native void DrawString(HUDFont font, String string, Vector2 pos, int flags = 0, int translation = Font.CR_UNTRANSLATED, double Alpha = 1., int wrapwidth = -1, int linespacing = 4);
+	native void DrawString(HUDFont font, String string, Vector2 pos, int flags = 0, int translation = Font.CR_UNTRANSLATED, double Alpha = 1., int wrapwidth = -1, int linespacing = 4, Vector2 scale = (1, 1));
 	native double, double, double, double TransformRect(double x, double y, double w, double h, int flags = 0);
 	native void Fill(Color col, double x, double y, double w, double h, int flags = 0);
 	native static String FormatNumber(int number, int minsize = 0, int maxsize = 0, int format = 0, String prefix = "");


### PR DESCRIPTION
This PR adds a scale argument to ```BaseStatusBar::DrawString```, allowing for the size of the resulting string to be easily altered.

So far, I've found only two methods to draw scaled strings on the screen with the current feature set. Let me explain why I think they are not sufficient.

#### 1. Using ```Screen::DrawText```

With ```Screen::DrawText```, it is possible to render text of any size by passing the corresponding ```DTA_VirtualWidth``` and ```DTA_VirtualHeight``` values to the function. Example code has been provided [here](https://forum.zdoom.org/viewtopic.php?p=1076520#p1076520) by m8f. Unfortunately, this method is not suitable for use in the HUD context, because:

* It does not take into account the HUD scale and knows nothing about the status bar coordinate system. All coordinate conversions must be taken care of in user code, breaking the HUD abstraction entirely. There is ```DTA_HudRules```, but it only works with the fullscreen HUD and has been [declared deprecated](https://github.com/coelckers/gzdoom/blob/8f7e902875aa7d5dca1634dbd353f32efac5f9bd/src/rendering/2d/v_draw.cpp#L384) in the source code.
* All text rendering in HUDs is usually done with the help of the ```HUDFont``` class. However, ```Screen::DrawText``` does not work with it. This calls for a need of a special ```HUDFont``` wrapper class that stores all the parameters passed to ```HUDFont::Create``` just so that they can also be passed to ```Screen::DrawText``` when necessary. Additionally, it should be noted that ```Screen::DrawText``` does not support shadows, and thus the algorithm to draw them has to be re-implemented in user code.

#### 2. ```SetSize``` hack

This method can be used to draw scaled strings in a status bar context. Example code has been provided [here](https://forum.zdoom.org/viewtopic.php?p=1076821#p1076821) by Major Cooke. There are several issues with this method:

* Only uniform scaling is possible, i.e. horizontal and vertical scaling factors are always the same.
* It requires the original HUD size to be stored somewhere purely for the purposes of reverting to it after the text has been drawn.
* It might be relying on undefined behavior, because ```BaseStatusBar::SetSize``` is intended to be called only once during initialization.
* It is primarily meant for use in a statur bar context. It can be used with fullscreen HUDs as well, but there is a serious flaw: complete disregard for the fullscreen HUD coordinate system. Not only this means the resulting text will not scale correctly when the HUD scale is changed in GZDoom options (unless it has been manually accounted for in the code), it can also lead to all sorts of confusions and bad design as a result of mixing two completely different coordinate systems. In the end, the code will be harder to maintain and refactor.

After a thorough forum search, I've been unable to find a way to solve the problem without any of the above shortcomings. If such a way exists, then this PR should probably be closed, but then I kindly ask the developers to give us some pointers in [this thread](https://forum.zdoom.org/viewtopic.php?f=18&t=62299) so that people can finally stop using hacks.

However, if I'm correct, and there is indeed no better way to change the scale of strings in HUDs at the moment, then you should look no further than this proposed addition. There are obvious advantages to integrating the proposed changes compared to the previous two methods - no need to use any dubious (and potentially problematic) hacks, native awareness of the HUD coordinate system, and native support for ```HUDFont```. Honestly, I don't think it can get any better than this, and I have no idea why it hasn't been there from the start.

#### Technical details

This feature, as currently implemented, affects line spacing but doesn't affect shadow. The latter is intentional, since it is assumed that the shadow represents the "elevation" of the text, which the scale, being 2D, does not affect at all. Line spacing, on the other hand, should probably be relative to text size, or multi-line text will not scale linearly.
