### PR TITLE
do not expect user input if stdin is redirected

### DIFF
--- a/src/posix/sdl/i_system.cpp
+++ b/src/posix/sdl/i_system.cpp
@@ -260,6 +260,11 @@ int I_PickIWad (WadStuff *wads, int numwads, bool showwin, int defaultiwad)
 	return I_PickIWad_Cocoa (wads, numwads, showwin, defaultiwad);
 #endif
 	
+	if (!isatty(fileno(stdin)))
+	{
+		return defaultiwad;
+	}
+
 	printf ("Please select a game wad (or 0 to exit):\n");
 	for (i = 0; i < numwads; ++i)
 	{


### PR DESCRIPTION
If GZDoom is built on a POSIX system without the GTK frontend and not
run from a KDE session, an IWAD picker is presented on the terminal
and expects the user to select a game wad. However, if stdin is
redirected, this won't work, so start with the default IWAD instead.