### PR TITLE
Upstreaming OpenBSD local changes from the port.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,10 +183,7 @@ include( TargetArch )
 target_architecture(ZDOOM_TARGET_ARCH)
 
 if( ${ZDOOM_TARGET_ARCH} MATCHES "x86_64" )
-	# To make the game respecting OpenBSD's W^X policy by default
-	if(NOT CMAKE_PLATFORM_NAME MATCHES "OpenBSD")
-		set( HAVE_VM_JIT ON )
-	endif()
+	set( HAVE_VM_JIT ON )
 	option (HAVE_VULKAN "Enable Vulkan support" ON)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,10 @@ include( TargetArch )
 target_architecture(ZDOOM_TARGET_ARCH)
 
 if( ${ZDOOM_TARGET_ARCH} MATCHES "x86_64" )
-	set( HAVE_VM_JIT ON )
+	# To make the game respecting OpenBSD's W^X policy by default
+	if(NOT CMAKE_PLATFORM_NAME MATCHES "OpenBSD")
+		set( HAVE_VM_JIT ON )
+	endif()
 	option (HAVE_VULKAN "Enable Vulkan support" ON)
 endif()
 

--- a/libraries/wildmidi/wildmidi/wildmidi_lib.h
+++ b/libraries/wildmidi/wildmidi/wildmidi_lib.h
@@ -28,6 +28,7 @@
 #define WILDMIDI_LIB_H
 
 #include "../../music_common/fileio.h"
+#include <stdarg.h>
 
 namespace WildMidi
 {

--- a/libraries/zmusic/mididevices/music_fluidsynth_mididevice.cpp
+++ b/libraries/zmusic/mididevices/music_fluidsynth_mididevice.cpp
@@ -140,8 +140,12 @@ protected:
 #define FLUIDSYNTHLIB1	"libfluidsynth.1.dylib"
 #define FLUIDSYNTHLIB2	"libfluidsynth.2.dylib"
 #else // !__APPLE__
+#ifndef FLUIDSYNTHLIB1
 #define FLUIDSYNTHLIB1	"libfluidsynth.so.1"
+#endif
+#ifndef FLUIDSYNTHLIB2
 #define FLUIDSYNTHLIB2	"libfluidsynth.so.2"
+#endif
 #endif // __APPLE__
 #endif
 

--- a/libraries/zmusic/zmusic/mididefs.h
+++ b/libraries/zmusic/zmusic/mididefs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdarg.h>
 
 enum
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -411,8 +411,10 @@ endif()
 if( UNIX )
 	CHECK_LIBRARY_EXISTS( rt clock_gettime "" CLOCK_GETTIME_IN_RT )
 	if( NOT CLOCK_GETTIME_IN_RT )
-		CHECK_FUNCTION_EXISTS( clock_gettime CLOCK_GETTIME_EXISTS )
-		if( NOT CLOCK_GETTIME_EXISTS )
+		CHECK_CXX_SOURCE_COMPILES("#include <time.h>
+			int main() { timespec t; int r = clock_gettime(CLOCK_MONOTONIC, &t); }"
+			HAVE_CLOCK_GETTIME)
+		if( NOT HAVE_CLOCK_GETTIME )
 			message( STATUS "Could not find clock_gettime. Timing statistics will not be available." )
 			add_definitions( -DNO_CLOCK_GETTIME )
 		endif()

--- a/src/scripting/vm/vmframe.cpp
+++ b/src/scripting/vm/vmframe.cpp
@@ -45,7 +45,11 @@
 #include "version.h"
 
 #ifdef HAVE_VM_JIT
+#ifndef __OpenBSD__
 CUSTOM_CVAR(Bool, vm_jit, true, CVAR_NOINITCALL)
+#else
+CUSTOM_CVAR(Bool, vm_jit, false, CVAR_NOINITCALL)
+#endif
 {
 	Printf("You must restart " GAMENAME " for this change to take effect.\n");
 	Printf("This cvar is currently not saved. You must specify it on the command line.");


### PR DESCRIPTION
- By default disabling JIT to please the W^X policy.
- Little missing headers/little code changes.
- In addition, clock_gettime test is somewhat flaky due to
this cmake helper thus checking code-wise instead.