### PR TITLE
Allow user to -warp to a map's literal name in case of custom filenam…

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2220,11 +2220,24 @@ static void CheckCmdLine()
 	if (p && p < Args->NumArgs() - 1)
 	{
 		int ep, map;
+		bool mapnameliteral = false; // will later be set to true if mapname contains a non-numeric character
+		const char * mapname = Args->GetArg(p+1);
 
 		if (gameinfo.flags & GI_MAPxx)
 		{
 			ep = 1;
-			map = atoi (Args->GetArg(p+1));
+			int mapnamelen = strlen(mapname);
+			for (int i = 0; i < mapnamelen; i++)
+			{
+				// 0x30 is the 0 character in ASCII and 0x39 is the 9 character in ASCII
+				if (mapname[i] < 0x30 || mapname[i] > 0x39)
+				{
+					mapnameliteral = true;
+					break;
+				}
+			}
+
+			map = atoi (mapname);
 		}
 		else 
 		{
@@ -2237,7 +2250,15 @@ static void CheckCmdLine()
 			}
 		}
 
-		startmap = CalcMapName (ep, map);
+		if (mapnameliteral)
+		{
+			startmap = mapname; // will use the literal mapname, ex. CORAX03 if trying to warp to level 3 of SOTNR
+		}
+		else
+		{
+			startmap = CalcMapName (ep, map);
+		}
+
 		autostart = true;
 	}
 


### PR DESCRIPTION
…es in MAPINFO, e.g., CORAX03

Some WADs make custom `MAPINFO` files, like [Shadows of the Nightmare Realm](https://www.doomworld.com/forum/topic/94268-release-shadows-of-the-nightmare-realm/). In it, the map filenames at not `MAP01`, `MAP02`, etc. They are `START`, `CORAX01`, `CORAX02`, etc. They do not follow the normal convention. I wanted to make demo files with these maps, but was having trouble because I could not `-warp` directly into them.

This commit fixes that. You can now `./gzdoom -warp CORAX02` and it will interpret it correctly. The normal approach is still supported, so for example `./gzdoom -warp 3` will take you to `MAP03` by default, and `-warp <e> <m>` will work correctly as well.