### PR TITLE
Change IsSourcePlayingSomething to handle overlapping sounds

### DIFF
--- a/src/sound/s_sound.cpp
+++ b/src/sound/s_sound.cpp
@@ -1155,9 +1155,9 @@ bool SoundEngine::IsSourcePlayingSomething (int sourcetype, const void *actor, i
 	{
 		if (chan->SourceType == sourcetype && chan->Source == actor)
 		{
-			if (channel == 0 || chan->EntChannel == channel)
+			if ((channel == 0 || chan->EntChannel == channel) && (sound_id <= 0 || chan->OrgID == sound_id))
 			{
-				return sound_id <= 0 || chan->OrgID == sound_id;
+				return true;
 			}
 		}
 	}


### PR DESCRIPTION
Make sure the loop goes through all matching channels instead of stopping at the first found.

Fixes [this bug](https://forum.zdoom.org/viewtopic.php?f=2&t=66683).