### PR TITLE
Remove unused ga_loadlevel gameaction and EGameAction reference

### DIFF
--- a/src/d_event.h
+++ b/src/d_event.h
@@ -59,7 +59,6 @@ struct event_t
 enum gameaction_t : int
 {
 	ga_nothing,
-	ga_loadlevel, // not used.
 	ga_newgame,
 	ga_newgame2,
 	ga_recordgame,

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1102,7 +1102,6 @@ enum EGameState
 enum EGameAction
 {
 	ga_nothing,
-	ga_loadlevel,
 	ga_newgame,
 	ga_newgame2,
 	ga_recordgame,


### PR DESCRIPTION
The title says it all. `ga_loadlevel` is an unused element in the `EGameState` and `gameaction_t` enums. It gets mentioned nowhere in the entire codebase aside from these two places, so the comment stating that it's unused is true. Removing this to remove some minor clutter in the code.