### PR TITLE
Remove ga_loadlevel in a way that does NOT rearrange the order of the…

### DIFF
--- a/src/d_event.h
+++ b/src/d_event.h
@@ -58,9 +58,8 @@ struct event_t
  
 enum gameaction_t : int
 {
-	ga_nothing,
-	ga_loadlevel, // not used.
-	ga_newgame,
+	ga_nothing = 0x00,
+	ga_newgame = 0x02,
 	ga_newgame2,
 	ga_recordgame,
 	ga_loadgame,

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1101,9 +1101,8 @@ enum EGameState
 
 enum EGameAction
 {
-	ga_nothing,
-	ga_loadlevel,
-	ga_newgame,
+	ga_nothing = 0x00,
+	ga_newgame = 0x02,
 	ga_newgame2,
 	ga_recordgame,
 	ga_loadgame,


### PR DESCRIPTION
… other enum elements

Second attempt at removing `ga_loadlevel`. The first attempt was [here](https://github.com/coelckers/gzdoom/pull/993). The reason for rejecting it was that it rearranges the other values. This will no longer do that; it starts at `0x00`, then goes to `0x02`, skipping `0x01`. The other constants retain their numeric value while getting rid of this unused value in the enum list.