### PR TITLE
Disables AO for sky portals

### DIFF
--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1644,6 +1644,7 @@ MapFlagHandlers[] =
 	{ "nolightfade",					MITYPE_SETFLAG3,	LEVEL3_NOLIGHTFADE, 0 },
 	{ "nocoloredspritelighting",		MITYPE_SETFLAG3,	LEVEL3_NOCOLOREDSPRITELIGHTING, 0 },
 	{ "forceworldpanning",				MITYPE_SETFLAG3,	LEVEL3_FORCEWORLDPANNING, 0 },
+	{ "enableskyboxao",				MITYPE_SETFLAG3,	LEVEL3_SKYBOXAO, 0 },
 	{ "nobotnodes",						MITYPE_IGNORE,	0, 0 },		// Skulltag option: nobotnodes
 	{ "compat_shorttex",				MITYPE_COMPATFLAG, COMPATF_SHORTTEX, 0 },
 	{ "compat_stairs",					MITYPE_COMPATFLAG, COMPATF_STAIRINDEX, 0 },

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -249,6 +249,7 @@ enum ELevelFlags : unsigned int
 	LEVEL3_EXITSECRETUSED		= 0x00000040,
 	LEVEL3_FORCEWORLDPANNING	= 0x00000080,	// Forces the world panning flag for all textures, even those without it explicitly set.
 	LEVEL3_HIDEAUTHORNAME		= 0x00000100,
+	LEVEL3_SKYBOXAO	= 0x00000200,	// Apply SSAO to sector skies
 };
 
 

--- a/src/rendering/gl/renderer/gl_scene.cpp
+++ b/src/rendering/gl/renderer/gl_scene.cpp
@@ -105,7 +105,7 @@ void FGLRenderer::DrawScene(HWDrawInfo *di, int drawmode)
 	}
 	else if (drawmode == DM_PORTAL && ssao_portals_available > 0)
 	{
-		applySSAO = true;
+		applySSAO = (strcmp(di->mCurrentPortal->GetName(),"Skybox") || di->Level->flags3&LEVEL3_SKYBOXAO);
 		ssao_portals_available--;
 	}
 

--- a/src/rendering/polyrenderer/backend/poly_framebuffer.cpp
+++ b/src/rendering/polyrenderer/backend/poly_framebuffer.cpp
@@ -380,7 +380,7 @@ void PolyFrameBuffer::DrawScene(HWDrawInfo *di, int drawmode)
 	}
 	else if (drawmode == DM_PORTAL && ssao_portals_available > 0)
 	{
-		applySSAO = true;
+		applySSAO = (strcmp(di->mCurrentPortal->GetName(),"Skybox") || di->Level->flags3&LEVEL3_SKYBOXAO);
 		ssao_portals_available--;
 	}
 

--- a/src/rendering/vulkan/system/vk_framebuffer.cpp
+++ b/src/rendering/vulkan/system/vk_framebuffer.cpp
@@ -570,7 +570,7 @@ void VulkanFrameBuffer::DrawScene(HWDrawInfo *di, int drawmode)
 	}
 	else if (drawmode == DM_PORTAL && ssao_portals_available > 0)
 	{
-		applySSAO = true;
+		applySSAO = (strcmp(di->mCurrentPortal->GetName(),"Skybox") || di->Level->flags3&LEVEL3_SKYBOXAO);
 		ssao_portals_available--;
 	}
 


### PR DESCRIPTION
Can be re-enabled with MAPINFO flag (enableskyboxao).

Since it uses the IsSky() virtual to check, it also affects stacked sectors due to them technically reporting themselves as skies. I have not found a way around this.

As usual, here is an example showing that it works: [skyboxao_m.zip](https://github.com/coelckers/gzdoom/files/4001871/skyboxao_m.zip)
This contains two identical maps with a sector sky. In MAPINFO one of them has the flag to re-enable AO.