### PR TITLE
export TMap<FString, FString> to ZScript

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1171,6 +1171,7 @@ add_executable( zdoom WIN32 MACOSX_BUNDLE
 	utility/x86.cpp
 	utility/strnatcmp.c
 	utility/zstring.cpp
+	utility/dictionary.cpp
 	utility/math/asin.c
 	utility/math/atan.c
 	utility/math/const.c

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -55,6 +55,7 @@
 #include "wi_stuff.h"
 #include "a_dynlight.h"
 #include "types.h"
+#include "utility/dictionary.h"
 
 static TArray<FPropertyInfo*> properties;
 static TArray<AFuncDesc> AFTable;
@@ -840,6 +841,21 @@ void InitThingdef()
 	auto wbplayerstruct = NewStruct("WBPlayerStruct", nullptr, true);
 	wbplayerstruct->Size = sizeof(wbplayerstruct_t);
 	wbplayerstruct->Align = alignof(wbplayerstruct_t);
+
+	auto dictionarystruct = NewStruct("Dictionary", nullptr, true);
+	dictionarystruct->Size = sizeof(Dictionary);
+	dictionarystruct->Align = alignof(Dictionary);
+	NewPointer(dictionarystruct, false)->InstallHandlers(
+		[](FSerializer &ar, const char *key, const void *addr)
+		{
+			ar(key, *(Dictionary **)addr);
+		},
+		[](FSerializer &ar, const char *key, void *addr)
+		{
+			Serialize<Dictionary>(ar, key, *(Dictionary **)addr, nullptr);
+			return true;
+		}
+	);
 
 	FAutoSegIterator probe(CRegHead, CRegTail);
 

--- a/src/serializer.h
+++ b/src/serializer.h
@@ -7,6 +7,7 @@
 #include "r_defs.h"
 #include "resourcefiles/file_zip.h"
 #include "tflags.h"
+#include "utility/dictionary.h"
 
 extern bool save_full;
 
@@ -270,6 +271,7 @@ template<> FSerializer &Serialize(FSerializer &arc, const char *key, FDoorAnimat
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, char *&pstr, char **def);
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, FFont *&font, FFont **def);
 template<> FSerializer &Serialize(FSerializer &arc, const char *key, FLevelLocals *&font, FLevelLocals **def);
+template<> FSerializer &Serialize(FSerializer &arc, const char *key, Dictionary *&dict, Dictionary **def);
 
 FSerializer &Serialize(FSerializer &arc, const char *key, FState *&state, FState **def, bool *retcode);
 template<> inline FSerializer &Serialize(FSerializer &arc, const char *key, FState *&state, FState **def)
@@ -311,5 +313,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, TFlags<T, TT> &flags, 
 	return Serialize(arc, key, flags.Value, def? &def->Value : nullptr);
 }
 
+FString DictionaryToString(const Dictionary &dict);
+Dictionary *DictionaryFromString(const FString &string);
 
 #endif

--- a/src/utility/dictionary.cpp
+++ b/src/utility/dictionary.cpp
@@ -1,0 +1,70 @@
+#include "utility/dictionary.h"
+
+#include "scripting/vm/vm.h"
+#include "serializer.h"
+
+//=====================================================================================
+//
+// Dictionary exports
+//
+//=====================================================================================
+
+DEFINE_ACTION_FUNCTION(_Dictionary, Create)
+{
+	PARAM_PROLOGUE;
+	ACTION_RETURN_POINTER(new Dictionary);
+}
+
+static void DictInsert(Dictionary *dict, const FString &key, const FString &value)
+{
+	dict->Insert(key, value);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(_Dictionary, Insert, DictInsert)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(Dictionary);
+	PARAM_STRING(key);
+	PARAM_STRING(value);
+	DictInsert(self, key, value);
+	return 0;
+}
+
+static void DictAt(const Dictionary *dict, const FString &key, FString *result)
+{
+	const FString *value = dict->CheckKey(key);
+	*result = value ? *value : "";
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(_Dictionary, At, DictAt)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(Dictionary);
+	PARAM_STRING(key);
+	FString result;
+	DictAt(self, key, &result);
+	ACTION_RETURN_STRING(result);
+}
+
+static void DictToString(const Dictionary *dict, FString *result)
+{
+	*result = DictionaryToString(*dict);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(_Dictionary, ToString, DictToString)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(Dictionary);
+	FString result;
+	DictToString(self, &result);
+	ACTION_RETURN_STRING(result);
+}
+
+static Dictionary *DictFromString(const FString& string)
+{
+	return DictionaryFromString(string);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(_Dictionary, FromString, DictFromString)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(string);
+	ACTION_RETURN_POINTER(DictFromString(string));
+}

--- a/src/utility/dictionary.h
+++ b/src/utility/dictionary.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "tarray.h"
+#include "zstring.h"
+
+using Dictionary = TMap<FString, FString>;

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -8,6 +8,7 @@ version "4.2"
 #include "zscript/destructible.zs"
 #include "zscript/level_postprocessor.zs"
 #include "zscript/level_compatibility.zs"
+#include "zscript/dictionary.zs"
 
 #include "zscript/actors/actor.zs"
 #include "zscript/actors/checks.zs"

--- a/wadsrc/static/zscript/dictionary.zs
+++ b/wadsrc/static/zscript/dictionary.zs
@@ -1,0 +1,10 @@
+struct Dictionary native
+{
+	native static Dictionary Create();
+	native static Dictionary FromString(String s);
+
+	native void Insert(String key, String value);
+	native String At(String key) const;
+
+	native String ToString() const;
+}


### PR DESCRIPTION
Simple string-to-string map (dictionary) allows to store and retrieve key-value string pairs.

Extra feature: get serialized dictionary as a string, so the user can store it in a CVar. So this Dictionary can be used between games.

There are several mods in need of this data structure (Weapon Menu, Lazy Points, Target Spy). Maybe FragTrak could use it too.

Test PK3: [stringmap-test.zip](https://github.com/coelckers/gzdoom/files/4007969/stringmap-test.zip)

Forum topic: https://forum.zdoom.org/viewtopic.php?f=59&t=66788#p1129689

PS. It's no way I got everything right in unfamiliar code, so I'm ready to fix any issues.