### PR TITLE
Dictionary fixes

### DIFF
--- a/src/serializer.cpp
+++ b/src/serializer.cpp
@@ -2185,6 +2185,11 @@ FString DictionaryToString(const Dictionary &dict)
 
 Dictionary *DictionaryFromString(const FString &string)
 {
+	if (string.IsEmpty())
+	{
+		return nullptr;
+	}
+
 	Dictionary *const dict = new Dictionary;
 
 	rapidjson::Document doc;
@@ -2214,7 +2219,7 @@ template<> FSerializer &Serialize(FSerializer &arc, const char *key, Dictionary 
 {
 	if (arc.isWriting())
 	{
-		FString contents { DictionaryToString(*dict) };
+		FString contents { dict ? DictionaryToString(*dict) : "" };
 		return arc(key, contents);
 	}
 	else

--- a/src/utility/dictionary.cpp
+++ b/src/utility/dictionary.cpp
@@ -68,3 +68,16 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Dictionary, FromString, DictFromString)
 	PARAM_STRING(string);
 	ACTION_RETURN_POINTER(DictFromString(string));
 }
+
+static void DictRemove(Dictionary *dict, const FString &key)
+{
+	dict->Remove(key);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(_Dictionary, Remove, DictRemove)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(Dictionary);
+	PARAM_STRING(key);
+	DictRemove(self, key);
+	return 0;
+}

--- a/wadsrc/static/zscript/dictionary.zs
+++ b/wadsrc/static/zscript/dictionary.zs
@@ -4,6 +4,7 @@ struct Dictionary native
 	native static Dictionary FromString(String s);
 
 	native void Insert(String key, String value);
+	native void Remove(String key);
 	native String At(String key) const;
 
 	native String ToString() const;


### PR DESCRIPTION
1. fix crash with saving null (uninitialized) Dictionary;
2. add Dictionary.Remove(String key) function.