### PR TITLE
Fix sounds not playing most of the time for actors / ui

### DIFF
--- a/src/sound/s_doomsound.cpp
+++ b/src/sound/s_doomsound.cpp
@@ -450,7 +450,7 @@ void S_PlaySoundPitch(AActor *a, int chan, EChanFlags flags, FSoundID sid, float
 
 	if (!(flags & CHANF_LOCAL))
 	{
-		if (!(flags & (CHANF_NOSTOP) || !S_IsActorPlayingSomething(a, chan, sid)))
+		if (!(flags & CHANF_NOSTOP) || !S_IsActorPlayingSomething(a, chan, sid))
 		{
 			S_SoundPitchActor(a, chan, flags, sid, vol, atten, pitch);
 		}
@@ -459,7 +459,7 @@ void S_PlaySoundPitch(AActor *a, int chan, EChanFlags flags, FSoundID sid, float
 	{
 		if (a->CheckLocalView())
 		{
-			if (!(flags & (CHANF_NOSTOP) || !soundEngine->IsSourcePlayingSomething(SOURCE_None, nullptr, chan, sid)))
+			if (!(flags & CHANF_NOSTOP) || !soundEngine->IsSourcePlayingSomething(SOURCE_None, nullptr, chan, sid))
 			{
 				S_SoundPitch(chan, flags, sid, vol, ATTN_NONE, pitch);
 			}

--- a/wadsrc/static/zscript/ui/menu/menu.zs
+++ b/wadsrc/static/zscript/ui/menu/menu.zs
@@ -284,7 +284,7 @@ class Menu : Object native ui version("2.4")
 
 	static void MenuSound(Sound snd)
 	{
-		S_StartSound (snd, CHAN_VOICE, CHANF_MAYBE_LOCAL, snd_menuvolume, ATTN_NONE);
+		S_StartSound (snd, CHAN_VOICE, CHANF_UI, snd_menuvolume, ATTN_NONE);
 	}
 	
 	deprecated("4.0") static void DrawConText (int color, int x, int y, String str)

--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -715,7 +715,7 @@ class StatusScreen abstract play version("2.5")
 
 	static void PlaySound(Sound snd)
 	{
-		S_StartSound(snd, CHAN_VOICE, CHANF_MAYBE_LOCAL, 1, ATTN_NONE);
+		S_StartSound(snd, CHAN_VOICE, CHANF_UI, 1, ATTN_NONE);
 	}
 	
 	


### PR DESCRIPTION
Beta, me and a couple others noticed something went terribly wrong, and lo and behold, here's the source of it all. Looks like not only there were some typos in S_PlaySoundPitch, but for some reason  on menus and stat screens you switched CHANF_UI for CHANF_MAYBE_LOCAL (which made ui sounds not play while menus were open).