### PR TITLE
add "nosave" cvar token

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1477,6 +1477,10 @@ void ParseCVarInfo()
 				{
 					cvarflags |= CVAR_LATCH;
 				}
+				else if (stricmp(sc.String, "nosave") == 0)
+				{
+					cvarflags |= CVAR_NOSAVE;
+				}
 				else
 				{
 					sc.ScriptError("Unknown cvar attribute '%s'", sc.String);


### PR DESCRIPTION
It makes a cvar value not be saved in a save file.

Use case: saving global gameplay statistics. If it's saved into a savefile, loading this savefile will overwrite the updated statistics.

[cvarinfo.txt](https://github.com/coelckers/gzdoom/files/4023631/cvarinfo.txt)
