### PR TITLE
Revert "add "nosave" cvar token"

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1477,10 +1477,6 @@ void ParseCVarInfo()
 				{
 					cvarflags |= CVAR_LATCH;
 				}
-				else if (stricmp(sc.String, "nosave") == 0)
-				{
-					cvarflags |= CVAR_NOSAVE;
-				}
 				else
 				{
 					sc.ScriptError("Unknown cvar attribute '%s'", sc.String);


### PR DESCRIPTION
This reverts commit b209fd95726ceaabb07bdf0e126e6e329e4e7a24.

1. It turns out that it wasn't even needed. Saving server cvars in the save file can be easily overwritten with the value from ini.
2. nosave cvars are not saved not only to savefile, but to INI too. So such cvars could not be used for the intended purpose in the first place.

Sorry.