### PR TITLE
Mixin deep-copy

### DIFF
--- a/src/scripting/zscript/zcc_compile.h
+++ b/src/scripting/zscript/zcc_compile.h
@@ -114,6 +114,7 @@ private:
 
 	int IntConstFromNode(ZCC_TreeNode *node, PContainerType *cls);
 	FString StringConstFromNode(ZCC_TreeNode *node, PContainerType *cls);
+	ZCC_MixinDef *ResolveMixinStmt(ZCC_MixinStmt *mixinStmt, EZCCMixinType type);
 	void ProcessClass(ZCC_Class *node, PSymbolTreeNode *tnode);
 	void ProcessStruct(ZCC_Struct *node, PSymbolTreeNode *tnode, ZCC_Class *outer);
 	void ProcessMixin(ZCC_MixinDef *cnode, PSymbolTreeNode *treenode);

--- a/src/scripting/zscript/zcc_parser.h
+++ b/src/scripting/zscript/zcc_parser.h
@@ -76,6 +76,7 @@ enum
 
 
 // Syntax tree structures.
+// [pbeta] Any changes to AST node structure or new node types require TreeNodeDeepCopy in zcc_parser.cpp to be updated!
 enum EZCCTreeNodeType
 {
 	AST_Identifier,
@@ -386,6 +387,8 @@ struct ZCC_ExprTypeRef : ZCC_Expression
 
 struct ZCC_ExprConstant : ZCC_Expression
 {
+	// [pbeta] The ZCC_ExprConstant case in TreeNodeDeepCopy in zcc_parser.cpp
+	// must be updated if this union is changed!
 	union
 	{
 		FString *StringVal;
@@ -610,5 +613,9 @@ struct ZCCParseState : public ZCC_AST
 
 	FScanner *sc;
 };
+
+const char *GetMixinTypeString(EZCCMixinType type);
+
+ZCC_TreeNode *TreeNodeDeepCopy(ZCC_AST *ast, ZCC_TreeNode *orig, bool copySiblings);
 
 #endif


### PR DESCRIPTION
Required a pretty long deep-copy function. But it seems to work well.
I did attempt to test it by making it always deep copy the "main" AST\*, and that seemed to work. I'd like to see it tested in QZDoom like that, as that would prove the deep copy code is stable.

\* (I did this by adding `ast.TopNode = TreeNodeDeepCopy(&ast, ast.TopNode, true);` right before `ZCC_TreeNode *node = ast.TopNode;` in the `ZCCCompiler::ZCCCompiler` constructor)