### PR TITLE
make nosave cvars set their value bypassing network code

### DIFF
--- a/src/console/c_cvars.cpp
+++ b/src/console/c_cvars.cpp
@@ -191,7 +191,14 @@ void FBaseCVar::SetGenericRep (UCVarValue value, ECVarType type)
 			Flags &= ~CVAR_UNSAFECONTEXT;
 			return;
 		}
-		D_SendServerInfoChange (this, value, type);
+		if (Flags & CVAR_NOSAVEGAME)
+		{
+			ForceSet (value, type);
+		}
+		else
+		{
+			D_SendServerInfoChange (this, value, type);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This may look as a workaround, it is not.

nosave cvars are meant to be used as a storage for statistical data that doesn't
affect gameplay. That's why this data isn't saved to the savefile in the first
place. Therefore, there is no point in sending this data over network. It would
have no meaning on machines other than local.