### PR TITLE
save and restore config-only variables from proper sections

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -579,6 +579,12 @@ void FGameConfigFile::DoGameSetup (const char *gamename)
 		ReadCVars (0);
 	}
 
+	strncpy (subsection, "ConfigOnlyVariables", sublen);
+	if (SetSection (section))
+	{
+		ReadCVars (0);
+	}
+
 	strncpy (subsection, "ConsoleVariables", sublen);
 	if (SetSection (section))
 	{
@@ -671,6 +677,11 @@ void FGameConfigFile::DoModSetup(const char *gamename)
 	{
 		ReadCVars (CVAR_MOD|CVAR_SERVERINFO|CVAR_IGNORE);
 	}
+	mysnprintf(section, countof(section), "%s.ConfigOnlyVariables.Mod", gamename);
+	if (SetSection (section))
+	{
+		ReadCVars (CVAR_MOD|CVAR_CONFIG_ONLY|CVAR_IGNORE);
+	}
 	// Signal that these sections should be rewritten when saving the config.
 	bModSetup = true;
 }
@@ -759,7 +770,15 @@ void FGameConfigFile::ArchiveGameData (const char *gamename)
 	strncpy (subsection, "ConfigOnlyVariables", sublen);
 	SetSection (section, true);
 	ClearCurrentSection ();
-	C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_AUTO|CVAR_MOD|CVAR_CONFIG_ONLY);
+	C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_AUTO|CVAR_CONFIG_ONLY);
+
+	if (bModSetup)
+	{
+		strncpy (subsection, "ConfigOnlyVariables.Mod", sublen);
+		SetSection (section, true);
+		ClearCurrentSection ();
+		C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_AUTO|CVAR_MOD|CVAR_CONFIG_ONLY);
+	}
 
 	strncpy (subsection, "UnknownConsoleVariables", sublen);
 	SetSection (section, true);


### PR DESCRIPTION
This commit fixes the following issues with config-only variables:
1. Config-only variables were saved to config file to "ConfigOnlyVariables" category regardless of mod or not.
2. Config-only variables were not restored from config file at all.

The saving and restoring is set up as it's done for server and user cvars.
I'm not sure how the part in `DoGameSetup` works.