### PR TITLE
Plutonia 2 Compatibility Fixes

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1449,6 +1449,7 @@ class LevelCompatibility : LevelPostProcessor
 			{
 				// Wall behind start creates HOM in software renderer due to weird sector
 				OffsetSectorPlane(236, Sector.Floor, -40);
+				break;
 			}
 
 			case '1C795660D2BA9FC93DA584C593FD1DA3': // Scythe 2 MAP17

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -319,6 +319,14 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case '3B68019EE3154C284B90F0CAEDBD8D8A': // Plutonia 2 MAP05
+			{
+				// Missing texture
+				TextureID step1 = TexMan.CheckForTexture("STEP1", TexMan.Type_Wall);
+				SetWallTextureID(1525, Line.front, Side.bottom, step1);
+				break;
+			}
+
 			case 'FB613B36589FFB09AA2C03633A7D13F4': // Plutonia 2 MAP20
 			{
 				// Remove the pain elementals stuck in the closet boxes that cannot teleport.

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -337,6 +337,15 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case 'A3165C53F9BF0B7D80CDB14665A349EB': // Plutonia 2 MAP23
+			{
+				// Arch-vile in outdoor secret area sometimes don't spawn if revenants
+				// block its one-time teleport. Make this teleport repeatable to ensure
+				// maxkills are always possible.
+				SetLineFlags(756, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+
 			case 'EF251B8F36DE709901B0D32A97F341D7': // Plutonia 2 MAP27
 			{
 				// Remove the monsters stuck in the closet boxes that cannot teleport.

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -329,6 +329,32 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case 'EF251B8F36DE709901B0D32A97F341D7': // Plutonia 2 MAP27
+			{
+				// Remove the monsters stuck in the closet boxes that cannot teleport.
+
+				// Top row, 2nd from left
+				SetThingFlags(156,0);
+				SetThingFlags(210,0);
+				SetThingFlags(211,0);
+
+				// 2nd row, 2nd-5th from left
+				for(int i = 242; i <= 249; i++)
+					SetThingFlags(i,0);
+
+				// 3rd row, rightmost box
+				SetThingFlags(260,0);
+				SetThingFlags(261,0);
+				SetThingFlags(266,0);
+				SetThingFlags(271,0);
+				SetThingFlags(272,0);
+				SetThingFlags(277,0);
+				SetThingFlags(278,0);
+				SetThingFlags(283,0);
+
+				break;
+			}
+
 			case '4CB7AAC5C43CF32BDF05FD36481C1D9F': // Plutonia: Revisited map27
 			{
 				SetLineSpecial(1214, Plat_DownWaitUpStayLip, 20, 64, 150);

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -319,6 +319,16 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case 'FB613B36589FFB09AA2C03633A7D13F4': // Plutonia 2 MAP20
+			{
+				// Remove the pain elementals stuck in the closet boxes that cannot teleport.
+				SetThingFlags(758,0);
+				SetThingFlags(759,0);
+				SetThingFlags(764,0);
+				SetThingFlags(765,0);
+				break;
+			}
+
 			case '4CB7AAC5C43CF32BDF05FD36481C1D9F': // Plutonia: Revisited map27
 			{
 				SetLineSpecial(1214, Plat_DownWaitUpStayLip, 20, 64, 150);

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -346,6 +346,17 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case '9191658A6705B131AB005948E2FDFCE1': // Plutonia 2 MAP24
+			{
+				// Fix improperly pegged blue door
+				for(int i = 957; i <= 958; i++)
+				{
+					SetLineFlags(i, 0, Line.ML_DONTPEGTOP);
+					level.lines[i].sidedef[0].SetTextureYOffset(Side.top,-24);
+				}
+				break;
+			}
+
 			case 'EF251B8F36DE709901B0D32A97F341D7': // Plutonia 2 MAP27
 			{
 				// Remove the monsters stuck in the closet boxes that cannot teleport.


### PR DESCRIPTION
Just finished a playthrough of [Plutonia 2](https://www.doomworld.com/idgames/levels/doom2/megawads/pl2) and found some bugs that I felt needed fixing.

MAP05: Simple missing texture fix on staircase by red key.

MAP20: There are up to 4 pain elementals that are supposed to teleport in after grabbing the BFG, but don't, for reasons I'm not entirely clear on (seems they can't fit between the barrels??), preventing 100% kills. This is a mapping error, the pain elementals don't warp in on PrBoom+ or Chocolate Doom either. To keep consistency with the other ports,  the pain elementals have been removed to allow 100% kills without changing the gameplay.
![MAP20](https://user-images.githubusercontent.com/43163391/72860091-a7f8d280-3c7a-11ea-9c34-d1b219dfffd6.png)

MAP23: Similar to my previous Hell Revealed MAP23 (weird coincidence), the archvile in the secret courtyard near the start may not teleport in if the revenants block its one-time teleport, preventing 100% kills. As before, make the teleport repeatable to fix this.

MAP24: Blue door near entrance is upper unpegged, causing the door texture to not move when the door is fixed. Undo this, and add a texture offset to the linedefs to make the door look the same as before.

MAP27: Up to 17 monsters do not teleport in on this map, preventing 100% kills. Again a mapping error, the closets are missing tags on their sectors/teleport linedefs. Once again, remove these monsters to allow 100% kills, both to keep consistency with other ports, and because it's not evident where/when the author intended these monsters to teleport in.