### PR TITLE
- autoload nerveunity.wad to doom2unity.wad

### DIFF
--- a/wadsrc_extra/static/iwadinfo.txt
+++ b/wadsrc_extra/static/iwadinfo.txt
@@ -507,6 +507,7 @@ IWad
 	MustContain = "MAP01", "DMENUPIC"
 	BannerColors = "00 7c 00", "a8 a8 a8"
 	IgnoreTitlePatches = 1
+	Load = "nerveunity.wad"
 }
 
 IWad
@@ -521,7 +522,7 @@ IWad
 	MustContain = "MAP01", "MAP33", "CWILV32"
 	BannerColors = "18 18 18", "a8 a8 a8"
 	IgnoreTitlePatches = 1
-	Load = "NERVE.WAD"
+	Load = "nerve.wad"
 	DeleteLumps = "M_EPI1", "M_EPI2", "M_EPISOD"
 }
 


### PR DESCRIPTION
refers to https://github.com/Doom-Utils/iwad-patches/commit/0b38c442e0fab07e3b88cc541730b508393d7926