### PR TITLE
AbsorbDamage Extension + DamageFactor Property Inclusion

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -675,7 +675,7 @@ public:
 	// Adjusts the angle for deflection/reflection of incoming missiles
 	// Returns true if the missile should be allowed to explode anyway
 	bool AdjustReflectionAngle (AActor *thing, DAngle &angle);
-	int AbsorbDamage(int damage, FName dmgtype);
+	int AbsorbDamage(int damage, FName dmgtype, AActor *inflictor, AActor *source, int flags);
 	void AlterWeaponSprite(visstyle_t *vis);
 
 	// Returns true if this actor is within melee range of its target

--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -1301,7 +1301,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 				int newdam = damage;
 				if (damage > 0)
 				{
-					newdam = player->mo->AbsorbDamage(damage, mod);
+					newdam = player->mo->AbsorbDamage(damage, mod, inflictor, source, flags);
 				}
 				if (!telefragDamage || (player->mo->flags7 & MF7_LAXTELEFRAGDMG)) //rawdamage is never modified.
 				{
@@ -1371,7 +1371,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 		if (!(flags & (DMG_NO_ARMOR|DMG_FORCED)) && target->Inventory != NULL && damage > 0)
 		{
 			int newdam = damage;
-			newdam = target->AbsorbDamage(damage, mod);
+			newdam = target->AbsorbDamage(damage, mod, inflictor, source, flags);
 			damage = newdam;
 			if (damage <= 0)
 			{

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3231,14 +3231,14 @@ bool AActor::AdjustReflectionAngle (AActor *thing, DAngle &angle)
 	return false;
 }
 
-int AActor::AbsorbDamage(int damage, FName dmgtype)
+int AActor::AbsorbDamage(int damage, FName dmgtype, AActor *inflictor, AActor *source, int flags)
 {
 	for (AActor *item = Inventory; item != nullptr; item = item->Inventory)
 	{
 		IFVIRTUALPTRNAME(item, NAME_Inventory, AbsorbDamage)
 		{
-			VMValue params[4] = { item, damage, dmgtype.GetIndex(), &damage };
-			VMCall(func, params, 4, nullptr, 0);
+			VMValue params[7] = { item, damage, dmgtype.GetIndex(), &damage, inflictor, source, flags };
+			VMCall(func, params, 7, nullptr, 0);
 		}
 	}
 	return damage;

--- a/wadsrc/static/zscript/actors/inventory/armor.zs
+++ b/wadsrc/static/zscript/actors/inventory/armor.zs
@@ -141,7 +141,7 @@ class BasicArmor : Armor
 	//
 	//===========================================================================
 
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
 	{
 		int saved;
 
@@ -552,7 +552,7 @@ class HexenArmor : Armor
 	//
 	//===========================================================================
 
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
 	{
 		if (!DamageTypeDefinition.IgnoreArmor(damageType))
 		{

--- a/wadsrc/static/zscript/actors/inventory/armor.zs
+++ b/wadsrc/static/zscript/actors/inventory/armor.zs
@@ -201,7 +201,8 @@ class BasicArmor : Armor
 		// Once the armor has absorbed its part of the damage, then apply its damage factor, if any, to the player
 		if ((damage > 0) && (ArmorType != 'None')) // BasicArmor is not going to have any damage factor, so skip it.
 		{
-			newdamage = ApplyDamageFactors(ArmorType, damageType, damage, damage);
+			damage = int(damage * DamageFactor);
+			newdamage = (damage < 1) ? 0 : ApplyDamageFactors(ArmorType, damageType, damage, damage);
 		}
 	}
 }

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -1099,7 +1099,7 @@ class Inventory : Actor
 	//
 	//===========================================================================
 
-	virtual void AbsorbDamage (int damage, Name damageType, out int newdamage) {}
+	virtual void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor = null, Actor source = null, int flags = 0) {}
 	
 	//===========================================================================
 	//

--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -761,7 +761,7 @@ class PowerIronFeet : Powerup
 		Powerup.Color "00 ff 00", 0.125;
 	}
 	
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
 	{
 		if (damageType == 'Drowning')
 		{
@@ -795,7 +795,7 @@ class PowerMask : PowerIronFeet
 		Inventory.Icon "I_MASK";
 	}
 	
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
 	{
 		if (damageType == 'Fire' || damageType == 'Drowning')
 		{

--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -1659,7 +1659,8 @@ class PowerDamage : Powerup
 	{
 		if (!passive && damage > 0)
 		{
-			newdamage = max(1, ApplyDamageFactors(GetClass(), damageType, damage, damage * 4));
+			damage = int(damage * DamageFactor);
+			newdamage = (damage < 1) ? 0 : max(1, ApplyDamageFactors(GetClass(), damageType, damage, damage * 4));
 			if (Owner != null && newdamage > damage) Owner.A_StartSound(ActiveSound, CHAN_AUTO, CHANF_DEFAULT, 1.0, ATTN_NONE);
 		}
 	}
@@ -1753,7 +1754,8 @@ class PowerProtection : Powerup
 	{
 		if (passive && damage > 0)
 		{
-			newdamage = max(0, ApplyDamageFactors(GetClass(), damageType, damage, damage / 4));
+			damage = int(damage * DamageFactor);
+			newdamage = (damage < 1) ? 0 : max(0, ApplyDamageFactors(GetClass(), damageType, damage, damage / 4));
 			if (Owner != null && newdamage < damage) Owner.A_StartSound(ActiveSound, CHAN_AUTO, CHANF_DEFAULT, 1.0, ATTN_NONE);
 		}
 	}


### PR DESCRIPTION
Adds inflictor, source and flags to AbsorbDamage, much like ModifyDamage.

Also, DamageFactor property (the adjustable one) was never taken into account via PowerDamage + Protection's ModifyDamage function, or BasicArmor's AbsorbDamage function. This fixes that issue.