### PR TITLE
Side SetColorization Fix

### DIFF
--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -1769,7 +1769,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, SetXOffset, SetXOffset)
 
  static void SetWallColorization(side_t* self, int pos, int cname)
  {
-	 if (pos >= 0 && pos < 2)
+	 if (pos >= 0 && pos < 3)
 	 {
 		 self->SetTextureFx(pos, TexMan.GetTextureManipulation(ENamedName(cname)));
 	 }


### PR DESCRIPTION
Fixed colorization not being applicable to bottom wall textures. This is because the function internally stopped the bottom texture (2 which is bottom) internally from having any effect, which I assume was an oversight from copying from the sector variant.