### PR TITLE
More Morph Virtuals

### DIFF
--- a/wadsrc/static/zscript/actors/morph.zs
+++ b/wadsrc/static/zscript/actors/morph.zs
@@ -28,6 +28,12 @@ extend class Actor
 		return null, 0, 0;
 	}
 
+	// [MC] Called when an actor morphs, on both the previous form (passive) and present form (!passive).
+	// 'cls' points to the other class they transitioned from/to.
+	virtual void PreMorph(Class<Actor> cls) {}
+	virtual void PostMorph(Class<Actor> cls) {}
+	virtual void PreUnmorph(Class<Actor> cls) {}
+	virtual void PostUnmorph(Class<Actor> cls) {}
 	
 	//===========================================================================
 	//
@@ -105,6 +111,11 @@ extend class Actor
 		}
 
 		let morphed = MorphedMonster(Spawn (spawntype, Pos, NO_REPLACE));
+
+		// Use GetClass in the event someone actually allows replacements.
+		PreMorph(morphed.GetClass());
+		morphed.PreMorph(GetClass());
+
 		Substitute (morphed);
 		if ((style & MRF_TRANSFERTRANSLATION) && !morphed.bDontTranslate)
 		{
@@ -140,6 +151,8 @@ extend class Actor
 		let eflash = Spawn(enter_flash ? enter_flash : (class<Actor>)("TeleportFog"), Pos + (0, 0, gameinfo.TELEFOGHEIGHT), ALLOW_REPLACE);
 		if (eflash)
 			eflash.target = morphed;
+		PostMorph(morphed.GetClass());
+		morphed.PostMorph(GetClass());
 		return true;
 	}
 }

--- a/wadsrc/static/zscript/actors/morph.zs
+++ b/wadsrc/static/zscript/actors/morph.zs
@@ -28,12 +28,11 @@ extend class Actor
 		return null, 0, 0;
 	}
 
-	// [MC] Called when an actor morphs, on both the previous form (passive) and present form (!passive).
-	// 'cls' points to the other class they transitioned from/to.
-	virtual void PreMorph(Class<Actor> cls) {}
-	virtual void PostMorph(Class<Actor> cls) {}
-	virtual void PreUnmorph(Class<Actor> cls) {}
-	virtual void PostUnmorph(Class<Actor> cls) {}
+	// [MC] Called when an actor morphs, on both the previous form (!current) and present form (current).
+	virtual void PreMorph(Actor mo, bool current) {}
+	virtual void PostMorph(Actor mo, bool current) {}
+	virtual void PreUnmorph(Actor mo, bool current) {}
+	virtual void PostUnmorph(Actor mo, bool current) {}
 	
 	//===========================================================================
 	//
@@ -112,9 +111,9 @@ extend class Actor
 
 		let morphed = MorphedMonster(Spawn (spawntype, Pos, NO_REPLACE));
 
-		// Use GetClass in the event someone actually allows replacements.
-		PreMorph(morphed.GetClass());
-		morphed.PreMorph(GetClass());
+		// [MC] Notify that we're just about to start the transfer.
+		PreMorph(morphed, false);		// False: No longer the current.
+		morphed.PreMorph(self, true);	// True: Becoming this actor.
 
 		Substitute (morphed);
 		if ((style & MRF_TRANSFERTRANSLATION) && !morphed.bDontTranslate)
@@ -151,8 +150,8 @@ extend class Actor
 		let eflash = Spawn(enter_flash ? enter_flash : (class<Actor>)("TeleportFog"), Pos + (0, 0, gameinfo.TELEFOGHEIGHT), ALLOW_REPLACE);
 		if (eflash)
 			eflash.target = morphed;
-		PostMorph(morphed.GetClass());
-		morphed.PostMorph(GetClass());
+		PostMorph(morphed, false);
+		morphed.PostMorph(self, true);
 		return true;
 	}
 }

--- a/wadsrc/static/zscript/actors/player/player_morph.zs
+++ b/wadsrc/static/zscript/actors/player/player_morph.zs
@@ -138,6 +138,11 @@ extend class PlayerPawn
 		}
 
 		let morphed = PlayerPawn(Spawn (spawntype, Pos, NO_REPLACE));
+
+		// Use GetClass in the event someone actually allows replacements.
+		PreMorph(morphed.GetClass());
+		morphed.PreMorph(GetClass());
+
 		EndAllPowerupEffects();
 		Substitute(morphed);
 		if ((style & MRF_TRANSFERTRANSLATION) && !morphed.bDontTranslate)
@@ -211,6 +216,8 @@ extend class PlayerPawn
 		morphed.ScoreIcon = ScoreIcon;	// [GRB]
 		if (eflash)	
 			eflash.target = morphed;
+		PostMorph(morphed.GetClass());
+		morphed.PostMorph(GetClass());
 		return true;
 	}
 	
@@ -249,6 +256,9 @@ extend class PlayerPawn
 			player.morphTics = 2*TICRATE;
 			return false;
 		}
+		PreUnmorph(altmo.GetClass());
+		altmo.PreUnmorph(GetClass());
+
 		// No longer using tracer as morph storage. That is what 'alternative' is for. 
 		// If the tracer has changed on the morph, change the original too.
 		altmo.target = target;
@@ -395,6 +405,8 @@ extend class PlayerPawn
 				beastweap.Destroy ();
 			}
 		}
+		PostUnmorph(altmo.GetClass());
+		altmo.PostUnmorph(GetClass());
 		Destroy ();
 		// Restore playerclass armor to its normal amount.
 		let hxarmor = HexenArmor(altmo.FindInventory('HexenArmor'));
@@ -544,6 +556,8 @@ class MorphedMonster : Actor
 			UnmorphTime = level.time + 5*TICRATE; // Next try in 5 seconds
 			return false;
 		}
+		PreUnmorph(unmorphed.GetClass());
+		unmorphed.PreUnmorph(GetClass());
 		unmorphed.Angle = Angle;
 		unmorphed.target = target;
 		unmorphed.bShadow = bShadow;
@@ -563,6 +577,8 @@ class MorphedMonster : Actor
 		unmorphed.args[4] = args[4];
 		unmorphed.CopyFriendliness (self, true);
 		unmorphed.bUnmorphed = false;
+		PostUnmorph(unmorphed.GetClass());
+		unmorphed.PostUnmorph(GetClass());
 		UnmorphedMe = NULL;
 		Substitute(unmorphed);
 		Destroy ();

--- a/wadsrc/static/zscript/actors/player/player_morph.zs
+++ b/wadsrc/static/zscript/actors/player/player_morph.zs
@@ -140,8 +140,8 @@ extend class PlayerPawn
 		let morphed = PlayerPawn(Spawn (spawntype, Pos, NO_REPLACE));
 
 		// Use GetClass in the event someone actually allows replacements.
-		PreMorph(morphed.GetClass());
-		morphed.PreMorph(GetClass());
+		PreMorph(morphed, false);
+		morphed.PreMorph(self, true);
 
 		EndAllPowerupEffects();
 		Substitute(morphed);
@@ -216,8 +216,8 @@ extend class PlayerPawn
 		morphed.ScoreIcon = ScoreIcon;	// [GRB]
 		if (eflash)	
 			eflash.target = morphed;
-		PostMorph(morphed.GetClass());
-		morphed.PostMorph(GetClass());
+		PostMorph(morphed, false);		// No longer the current body
+		morphed.PostMorph(self, true);	// This is the current body
 		return true;
 	}
 	
@@ -256,8 +256,9 @@ extend class PlayerPawn
 			player.morphTics = 2*TICRATE;
 			return false;
 		}
-		PreUnmorph(altmo.GetClass());
-		altmo.PreUnmorph(GetClass());
+
+		PreUnmorph(altmo, false);		// This body's about to be left.
+		altmo.PreUnmorph(self, true);	// This one's about to become current.
 
 		// No longer using tracer as morph storage. That is what 'alternative' is for. 
 		// If the tracer has changed on the morph, change the original too.
@@ -405,8 +406,8 @@ extend class PlayerPawn
 				beastweap.Destroy ();
 			}
 		}
-		PostUnmorph(altmo.GetClass());
-		altmo.PostUnmorph(GetClass());
+		PostUnmorph(altmo, false);		// This body is no longer current.
+		altmo.PostUnmorph(self, true);	// altmo body is current.
 		Destroy ();
 		// Restore playerclass armor to its normal amount.
 		let hxarmor = HexenArmor(altmo.FindInventory('HexenArmor'));
@@ -556,8 +557,8 @@ class MorphedMonster : Actor
 			UnmorphTime = level.time + 5*TICRATE; // Next try in 5 seconds
 			return false;
 		}
-		PreUnmorph(unmorphed.GetClass());
-		unmorphed.PreUnmorph(GetClass());
+		PreUnmorph(unmorphed, false);
+		unmorphed.PreUnmorph(self, true);
 		unmorphed.Angle = Angle;
 		unmorphed.target = target;
 		unmorphed.bShadow = bShadow;
@@ -577,8 +578,8 @@ class MorphedMonster : Actor
 		unmorphed.args[4] = args[4];
 		unmorphed.CopyFriendliness (self, true);
 		unmorphed.bUnmorphed = false;
-		PostUnmorph(unmorphed.GetClass());
-		unmorphed.PostUnmorph(GetClass());
+		PostUnmorph(unmorphed, false);		// From is false here: Leaving the caller's body.
+		unmorphed.PostUnmorph(self, true);	// True here: Entering this body from here.
 		UnmorphedMe = NULL;
 		Substitute(unmorphed);
 		Destroy ();


### PR DESCRIPTION
Added Pre(Un)Morph and Post(Un)Morph functions.
- mo: The other actor that is being exchanged between. Always points to the other actor involved.
- current: If true, the actor calling the function is the resulting body of the (un)morph. False means the calling actor is (about to be) transitioned from to mo.