### PR TITLE
preliminary "fix" for 10bit/channel colour

### DIFF
--- a/src/posix/sdl/sdlglvideo.cpp
+++ b/src/posix/sdl/sdlglvideo.cpp
@@ -190,10 +190,6 @@ namespace Priv
 
 	void SetupPixelFormat(int multisample, const int *glver)
 	{
-		SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-		SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
 		SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 		SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8);
 		SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);


### PR DESCRIPTION
current master does not start on my linux/xorg machine that is configured to run at 30bit colour depth (i.e. A2R10G10B10). the fix is straight forward and simple, see commit (similar for the vulkan case but i couldn't trigger the vulkan code path so i left it at that for now).

the problem with the commit is the detection of the correct bit depth. whatever i tried here returns SDL_PIXELFORMAT_UNKNOWN and is not very helpful (works here (tm)). this may be the case in std 24-bit configurations, too, which would render the PR useless.

thus i don't actually want to merge at this point but make the fix public, maybe someone else has a better idea how to detect the screen format.