### PR TITLE
Exported MD5 to ZScript

### DIFF
--- a/src/utility/md5.cpp
+++ b/src/utility/md5.cpp
@@ -293,3 +293,41 @@ CCMD (md5sum)
 		}
 	}
 }
+
+//==========================================================================
+//
+// MD5
+//
+// Expose the MD5 hashing to ZScript
+//
+//==========================================================================
+
+#include "vm.h"
+
+static void MD5String(const FString& str, FString* result)
+{
+	MD5Context md5;
+	char hash[16];
+
+	uint8_t* buf = (uint8_t*)M_Malloc(str.Len() * sizeof(uint8_t));
+	memcpy(buf, str.GetChars(), str.Len() * sizeof(uint8_t));
+
+	md5.Update(buf, (unsigned int)str.Len());
+	md5.Final(buf);
+
+	int offset = 0;
+	for (unsigned int j = 0; j < 16; ++j)
+	{
+		offset += snprintf(hash + offset, 16, "%02x", buf[j]);
+	}
+	*result = hash;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, MD5, MD5String)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(str);
+	FString result;
+	MD5String(str, &result);
+	ACTION_RETURN_STRING(result);
+}

--- a/src/utility/md5.cpp
+++ b/src/utility/md5.cpp
@@ -307,20 +307,15 @@ CCMD (md5sum)
 static void MD5String(const FString& str, FString* result)
 {
 	MD5Context md5;
-	char hash[16];
+	uint8_t hash[16];
 
-	uint8_t* buf = (uint8_t*)M_Malloc(str.Len() * sizeof(uint8_t));
-	memcpy(buf, str.GetChars(), str.Len() * sizeof(uint8_t));
+	md5.Update((uint8_t *)str.GetChars(), (unsigned int)str.Len());
+	md5.Final(hash);
 
-	md5.Update(buf, (unsigned int)str.Len());
-	md5.Final(buf);
-
-	int offset = 0;
 	for (unsigned int j = 0; j < 16; ++j)
 	{
-		offset += snprintf(hash + offset, 16, "%02x", buf[j]);
+		result->AppendFormat("%02x", hash[j]);
 	}
-	*result = hash;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, MD5, MD5String)

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -945,6 +945,8 @@ struct StringStruct native
 	native void DeleteLastCharacter();
 	native int CodePointCount() const;
 	native int, int GetNextCodePoint(int position) const;
+
+	native static String MD5(String bytes);
 }
 
 class SectorEffect : Thinker native


### PR DESCRIPTION
Exported the MD5 hashing algorithm to ZScript, so that mods don't need [to](https://github.com/3saster/fullscrn_huds/blob/af9374f337081c86d91b7ae200a56f37814c1eea/zscript/compat/compat_functions.zs#L61) [reimplement](https://github.com/Doom2fan/Se7evidas/blob/662df772dde522643176ff63343eeba9a5744e7a/PK3%20Source/S7ZScript/MD5.ZS) a hashing algorithm. It returns the MD5 of a string, since I imagine the main use case of this would be for hashing [data-lumps](https://github.com/3saster/fullscrn_huds/blob/af9374f337081c86d91b7ae200a56f37814c1eea/filter/game-doomchex/zscript/statusbars/main.zs#L100-L109), but if there is a better place/way this should be done, I can edit as necessary.