### PR TITLE
- use GAMENAMELOWERCASE macro for music config defaults

### DIFF
--- a/src/sound/music/music_config.cpp
+++ b/src/sound/music/music_config.cpp
@@ -38,6 +38,7 @@
 #include <string>
 #include "c_cvars.h"
 #include "s_music.h"
+#include "version.h"
 #include <zmusic.h>
 
 //==========================================================================
@@ -114,7 +115,7 @@ CUSTOM_CVAR(String, fluid_lib, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTU
 	FORWARD_STRING_CVAR(fluid_lib);
 }
 
-CUSTOM_CVAR(String, fluid_patchset, "gzdoom", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
+CUSTOM_CVAR(String, fluid_patchset, GAMENAMELOWERCASE, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
 {
 	FORWARD_STRING_CVAR(fluid_patchset);
 }
@@ -266,7 +267,7 @@ CUSTOM_CVAR(String, opn_custom_bank, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR
 //==========================================================================
 
 
-CUSTOM_CVAR(String, midi_config, "gzdoom", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
+CUSTOM_CVAR(String, midi_config, GAMENAMELOWERCASE, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
 {
 	FORWARD_STRING_CVAR(gus_config);
 }
@@ -382,7 +383,7 @@ CUSTOM_CVAR(Float, timidity_min_sustain_time, 5000, CVAR_ARCHIVE | CVAR_GLOBALCO
 	FORWARD_CVAR(timidity_min_sustain_time);
 }
 
-CUSTOM_CVAR(String, timidity_config, "gzdoom", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
+CUSTOM_CVAR(String, timidity_config, GAMENAMELOWERCASE, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
 {
 	FORWARD_STRING_CVAR(timidity_config);
 }


### PR DESCRIPTION
I noticed when going through Raze's music_config.cpp (for my own personal purposes, obviously) that Raze uses the GAMENAMELOWERCASE macro for the CVAR defaults. Wouldn't it make sense for GZDoom to do this, too?