### PR TITLE
A_StopSounds(min, max)

### DIFF
--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -145,8 +145,16 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_StopSound, NativeStopSound)
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_StopAllSounds, S_StopAllActorSounds)
 {
 	PARAM_SELF_PROLOGUE(AActor);
-
 	S_StopAllActorSounds(self);
+	return 0;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(AActor, A_StopSounds, S_StopActorSounds)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	PARAM_INT(chanmin);
+	PARAM_INT(chanmax);
+	S_StopActorSounds(self, chanmin, chanmax);
 	return 0;
 }
 

--- a/src/sound/s_doomsound.cpp
+++ b/src/sound/s_doomsound.cpp
@@ -513,6 +513,20 @@ void S_StopAllActorSounds(AActor *actor)
 
 //==========================================================================
 //
+// S_StopActorSounds
+//
+// Stops sounds on an actor in a range. 
+// Bear in mind, channels can be negative (-2 or lower).
+//
+//==========================================================================
+
+void S_StopActorSounds(AActor *actor, int chanmin, int chanmax)
+{
+	soundEngine->StopActorSounds(SOURCE_Actor, actor, chanmin, chanmax);
+}
+
+//==========================================================================
+//
 // S_StopSound
 //
 // Stops a sound from a single sector from playing on a specific channel.

--- a/src/sound/s_doomsound.h
+++ b/src/sound/s_doomsound.h
@@ -35,6 +35,7 @@ void S_PlaySound(AActor *a, int chan, EChanFlags flags, FSoundID sid, float vol,
 void S_StopSound (AActor *ent, int channel);
 void S_StopSound (const sector_t *sec, int channel);
 void S_StopSound (const FPolyObj *poly, int channel);
+void S_StopActorSounds(AActor *actor, int chanmin, int chanmax);
 void S_StopAllActorSounds(AActor *actor);
 
 // Moves all sounds from one mobj to another

--- a/src/sound/s_sound.cpp
+++ b/src/sound/s_sound.cpp
@@ -929,6 +929,37 @@ void SoundEngine::StopAllActorSounds(int sourcetype, const void* actor)
 
 //==========================================================================
 //
+// S_StopActorSounds
+//
+// Stops all sounds on an actor within a given range.
+//
+//==========================================================================
+
+void SoundEngine::StopActorSounds(int sourcetype, const void* actor, int chanmin, int chanmax)
+{
+	if (chanmax < chanmin)
+	{
+		int temp = chanmax;
+		chanmax = chanmin;
+		chanmin = temp;
+	}
+
+	FSoundChan* chan = Channels;
+	while (chan != nullptr)
+	{
+		FSoundChan* next = chan->NextChan;
+		if (chan->SourceType == sourcetype &&
+			chan->Source == actor &&
+			chan->EntChannel >= chanmin && chan->EntChannel <= chanmax)
+		{
+			StopChannel(chan);
+		}
+		chan = next;
+	}
+}
+
+//==========================================================================
+//
 // S_StopAllChannels
 //
 //==========================================================================

--- a/src/sound/s_soundinternal.h
+++ b/src/sound/s_soundinternal.h
@@ -308,6 +308,7 @@ public:
 	void StopSound(int channel, int sound_id = -1);
 	void StopSound(int sourcetype, const void* actor, int channel, int sound_id = -1);
 	void StopAllActorSounds(int sourcetype, const void* actor);
+	void StopActorSounds(int sourcetype, const void* actor, int chanmin, int chanmax);
 
 	void RelinkSound(int sourcetype, const void* from, const void* to, const FVector3* optpos);
 	void ChangeSoundVolume(int sourcetype, const void* source, int channel, double dvolume);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1060,6 +1060,7 @@ class Actor : Thinker native
 	native void A_SoundPitch(int slot, double pitch);
 	deprecated("2.3") void A_PlayWeaponSound(sound whattoplay) { A_StartSound(whattoplay, CHAN_WEAPON); }
 	native void A_StopSound(int slot = CHAN_VOICE);	// Bad default but that's what is originally was...
+	native void A_StopSounds(int chanmin, int chanmax);
 	native void A_StopAllSounds();
 	deprecated("2.3") native void A_PlaySoundEx(sound whattoplay, name slot, bool looping = false, int attenuation = 0);
 	deprecated("2.3") native void A_StopSoundEx(name slot);


### PR DESCRIPTION
Added A_StopSounds(int chanmin, int chanmax). Stops all sounds within the defined range.

- Running a for loop with A_StopSound is going to cause issues when there's a large number of sounds involved, and preservation of some sounds is needed.