### PR TITLE
REQUIEM.WAD fixes

### DIFF
--- a/wadsrc/static/compatibility.txt
+++ b/wadsrc/static/compatibility.txt
@@ -162,11 +162,6 @@ AF40D0E49BD1B76D4B1AADD8212ADC46 // MAP01 (the wad that shall not be named =P)
 	limitpain
 }
 
-7C1913DEE396BA26CFF22A0E9369B7D2 // Nuke Mine, e1m2
-{
-	pointonline
-}
-
 920F8D876ECD96D8C2A978FF1AB2B401 // Darken2.wad map01 - Nodes go out of bounds/beyond normal sector boundaries
 CFEDB7FA89885E24856CAC9A2FB3CE58 // Darken2.wad map03 - GZDoomBuilder crashes when displaying Nodes
 8E961FA7029761D5FAB3932C40F10CD2 // Darken2.wad map04 - Nodes go out of bounds/beyond normal sector boundaries
@@ -198,6 +193,7 @@ EDA5CE7C462BD171BF8110AC56B67857 // pl2.wad map11
 A9A9A728E689266939C1B71655F320CA // pl2.wad map25
 62CA74092FC88C1E7FE2D0B1A8034E29 // pl2.wad map29
 19E1CFD717FC6BBA9371F0F529B4CDFF // ur_final.wad map27
+836E09559FF22A7A37C2587F7EAFF1EE // Requiem MAP29 - Incorrect sector lighting and vanishing items
 {
 	rebuildnodes
 }
@@ -255,6 +251,7 @@ D7F6E9F08C39A17026349A04F8C0B0BE // Return to Hadron, e1m9
 19D03FFC875589E21EDBB7AB74EF4AEF // Return to Hadron, e1m9, 2016.01.03 update
 5BDA34DA60C0530794CC1EA2DA017976 // doom2.wad map14
 5B3F118B337BFBFB8D5C81E98AF7B71D // Ancient Aliens map23
+7C1913DEE396BA26CFF22A0E9369B7D2 // Nuke Mine, e1m2
 {
 	pointonline
 }

--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -1778,6 +1778,176 @@ class LevelCompatibility : LevelPostProcessor
 				SetLineSpecial(11518, 9, 0, 0, 0, 0);
 				break;
 			}
+			
+			case 'BA530202AF0BA0C6CBAE6A0C7076FB72': // Requiem MAP04
+			{
+				// Flag deathmatch berserk for 100% items in single-player
+				SetThingFlags(284, 17);
+				// Make Hell Knight trap switch repeatable to prevent softlock
+				SetLineFlags(823, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+			
+			case '104415DDEBCAFB9783CA60807C46B57D': // Requiem MAP05
+			{
+				// Raise spectre pit near soulsphere if player drops into it
+				for(int i = 0; i < 4; i++)
+				{
+					SetLineSpecial(2130+i, Floor_LowerToHighest, 28, 8, 128);
+					SetLineActivation(2130+i, SPAC_Cross);
+				}
+				break;
+			}
+			
+			case '1B0AF5286D4E914C5E903BC505E6A844': // Requiem MAP06
+			{
+				// Flag deathmatch berserks for 100% items in single-player
+				SetThingFlags(103, 17);
+				SetThingFlags(109, 17);
+				// Shooting the cross before all Imps spawn in can make 100%
+				// kills impossible, add line actions and change sector tag
+				for(int i = 0; i < 7; i++)
+				{
+					SetLineSpecial(1788+i, Floor_RaiseToNearest, 100, 32);
+					SetLineActivation(1788+i, SPAC_Cross);
+				}
+				SetLineSpecial(1796, Floor_RaiseToNearest, 100, 32);
+				SetLineActivation(1796, SPAC_Cross);
+				SetLineSpecial(1800, Floor_RaiseToNearest, 100, 32);
+				SetLineActivation(1800, SPAC_Cross);
+				SetLineSpecial(1802, Floor_RaiseToNearest, 100, 32);
+				SetLineActivation(1802, SPAC_Cross);
+				ClearSectorTags(412);
+				AddSectorTag(412, 100);
+				// Shootable cross at demon-faced floor changed to repeatable
+				// action to prevent softlock if "spikes" are raised again
+				SetLineFlags(2600, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+			
+			case '3C10B1B017E902BE7CDBF2436DF56973': // Requiem MAP08
+			{
+				// Flag deathmatch soulsphere for 100% items in single-player
+				SetThingFlags(48, 17);
+				// Allow player to leave inescapable lift using the walls
+				for(int i = 0; i < 3; i++)
+				{
+					SetLineSpecial(2485+i, Plat_DownWaitUpStayLip, 68, 64, 105, 0);
+					SetLineActivation(2485+i, SPAC_Use);
+					SetLineFlags(2485+i, Line.ML_REPEAT_SPECIAL);
+				}
+				SetLineSpecial(848, Plat_DownWaitUpStayLip, 68, 64, 105, 0);
+				SetLineActivation(848, SPAC_UseBack);
+				SetLineFlags(848, Line.ML_REPEAT_SPECIAL);
+				SetLineSpecial(895, Plat_DownWaitUpStayLip, 68, 64, 105, 0);
+				SetLineActivation(895, SPAC_UseBack);
+				SetLineFlags(895, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+			
+			case '14FE46ED0458979118007E1906A0C9BC': // Requiem MAP09
+			{
+				// Flag deathmatch items for 100% items in single-player
+				for(int i = 0; i < 6; i++)
+					SetThingFlags(371+i, 17);
+				
+				for(int i = 0; i < 19; i++)
+					SetThingFlags(402+i, 17);
+				
+				SetThingFlags(359, 17);
+				SetThingFlags(389, 17);
+				SetThingFlags(390, 17);
+				// Change sides of blue skull platform to be repeatable
+				for(int i = 0; i < 4; i++)
+					SetLineFlags(873+i, Line.ML_REPEAT_SPECIAL);
+				// Make switch that raises bars near yellow skull repeatable
+				SetLineFlags(2719, Line.ML_REPEAT_SPECIAL);
+				break;
+			}
+			
+			case '53A6369C3C8DA4E7AC443A8F8684E38E': // Requiem MAP12
+			{
+				// Remove unreachable secrets
+				SetSectorSpecial(352, 0);
+				SetSectorSpecial(503, 0);
+				// Change action of eastern switch at pool of water so that it
+				// lowers the floor properly, making the secret accessible
+				SetLineSpecial(4873, Floor_LowerToLowest, 62, 8);
+				break;
+			}
+			
+			case '2DAB6E4B19B4F2763695267D39CD0275': // Requiem MAP13
+			{
+				// Fix missing nukage at starting bridge on hardware renderer
+				for(int i = 0; i < 4; i++)
+					SetLineSectorRef(2152+i, Line.back, 8);
+				break;
+			}
+			
+			case 'F55FB2A8DC68CFC75E4340EF4ED7A8BF': // Requiem MAP21
+			{
+				// Fix self-referencing floor hack
+				for(int i = 0; i < 4; i++)
+					SetLineSectorRef(3+i, Line.back, 219);
+					
+				SetLineSpecial(8, Transfer_Heights, 80);
+				// Fix south side of pit hack so textures don't bleed through
+				// the fake floor on hardware renderer
+				SetLineSectorRef(267, Line.back, 63);
+				SetLineSectorRef(268, Line.back, 63);
+				SetLineSectorRef(270, Line.back, 63);
+				SetLineSectorRef(271, Line.back, 63);
+				SetLineSectorRef(274, Line.back, 63);
+				SetLineSectorRef(275, Line.back, 63);
+				SetLineSectorRef(3989, Line.back, 63);
+				SetLineSectorRef(3994, Line.back, 63);
+				// Fix fake 3D bridge on hardware renderer
+				SetLineSectorRef(506, Line.back, 841);
+				SetLineSectorRef(507, Line.back, 841);
+				SetLineSectorRef(536, Line.back, 841);
+				SetLineSectorRef(537, Line.back, 841);
+				SetLineSectorRef(541, Line.back, 841);
+				SetLineSectorRef(547, Line.back, 841);
+				AddSectorTag(90, 1000);
+				AddSectorTag(91, 1000);
+				SetSectorTexture(90, Sector.floor, "MFLR8_4");
+				SetSectorTexture(91, Sector.floor, "MFLR8_4");
+				
+				SetLineSectorRef(553, Line.back, 841);
+				SetLineSectorRef(554, Line.back, 841);
+				SetLineSectorRef(559, Line.back, 841);
+				SetLineSectorRef(560, Line.back, 841);
+				SetLineSectorRef(562, Line.back, 841);
+				SetLineSectorRef(568, Line.back, 841);
+				AddSectorTag(96, 1000);
+				AddSectorTag(97, 1000);
+				SetSectorTexture(96, Sector.floor, "MFLR8_4");
+				SetSectorTexture(97, Sector.floor, "MFLR8_4");
+				SetLineSpecial(505, Transfer_Heights, 1000);
+				// Fix randomly appearing ceiling at deep water
+				SetLineSectorRef(1219, Line.front, 233);
+				SetLineSectorRef(1222, Line.front, 233);
+				SetLineSectorRef(1223, Line.front, 233);
+				SetLineSectorRef(1228, Line.front, 233);
+				// Make switch in sky room repeatable so player does not get
+				// trapped at red cross if returning a second time
+				SetLineFlags(3870, Line.ML_REPEAT_SPECIAL);
+				// Move unreachable item bonuses
+				SetThingXY(412, -112, 6768);
+				SetThingXY(413, -112, 6928);
+				SetThingXY(414, -96, 6928);
+				SetThingXY(415, -96, 6768);
+				// Remove unreachable secret at exit megasphere
+				SetSectorSpecial(123, 0);
+				break;
+			}
+			
+			case '2499CF9A9351BE9BC4E9C66FC9F291A7': // Requiem MAP23
+			{
+				// Remove secret at switch that can only be scored by crouching
+				SetSectorSpecial(240, 0);
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Various map fixes for the Requiem megawad. The maps changes includes:

-MAP04: Remove a deathmatch only berserk when playing single-player. Make the switch at the Hell Knight closet repeatable to prevent a softlock.

-MAP05: Since many players don't play with infinitely tall actors, it can be possible to fall into a small put with a spectre. The pit should raise if a player walks over it.

-MAP06: Remove deathmatch berserks when playing single-player. Fix an issue where getting 100% kills can be impossible because the sector that allows Imps to teleport into the map can raise all the way to the ceiling if a cross has been shot at. Cleared the sector's tag and added new line actions with a new tag to go with it. Also make the shootable cross repeatable to prevent softlock.

-MAP08: Removed deathmatch soulsphere when playing single-player. Made it possible to leave a lift that can prevent someone from finishing the map if they somehow get stuck.

-MAP09: Removed many deathmatch only items when playing single-player. Made some switches repeatable in case of softlocks.

-MAP12: Removed unreachable secrets. Make one switch that is supposed to reveal a secret actually lower the sector it's tagged to. These mapping tricks are leaving too many errors.

-MAP13: Fix an issue with the hardware renderer not rendering the bridge at the start of the map correctly.
![bridge](https://user-images.githubusercontent.com/35357202/76459514-57644280-63aa-11ea-8415-a038071fba94.png)

-MAP21: Many hardware renderer fixes. The fake floor with the four switches should no longer show the skybox when the floor is raised. The voodoo player trap room should no longer bleed floor textures. The fake 3D bridge has been edited to match how it looks in vanilla Doom's software renderer. Fixes an odd visual glitch where a ceiling appears randomly in the "deep water" room. Softlocks, unreachable items and secrets are also addressed.
![fake_3d_bridge](https://user-images.githubusercontent.com/35357202/76460206-9f379980-63ab-11ea-90eb-6790428db176.png)

-MAP23: Removed the one switch secret that can only be scored by crouching.

-MAP29: Rebuild nodes so any areas with strange lighting or vanishing items can be fixed. This includes the wall at the start of the map, which is the most notable.
![map29_nodes](https://user-images.githubusercontent.com/35357202/76460676-6fd55c80-63ac-11ea-9bfe-1a0414770e50.png)

I tried my hand at MAP31 but the hacks it done in the room where you drop down made it difficult for it to look right with the hardware renderer, more so than MAP21. Besides that, MAP31 can be finished with 100% stats at least. Small note, I moved the mapchecksum of Nuke Mine E1M2 as it is alone with a duplicate pointonline compatibility settings. Don't think issues should come with that.