### PR TITLE
- fix nullptr crash in player.camera reference

### DIFF
--- a/src/rendering/gl/renderer/gl_renderer.cpp
+++ b/src/rendering/gl/renderer/gl_renderer.cpp
@@ -256,7 +256,8 @@ sector_t *FGLRenderer::RenderView(player_t* player)
 		NoInterpolateView = false;
 
 		// Shader start time does not need to be handled per level. Just use the one from the camera to render from.
-		gl_RenderState.CheckTimer(player->camera->Level->ShaderStartTime);
+		if (player->camera)
+			gl_RenderState.CheckTimer(player->camera->Level->ShaderStartTime);
 		// prepare all camera textures that have been used in the last frame.
 		// This must be done for all levels, not just the primary one!
 		for (auto Level : AllLevels())

--- a/src/rendering/polyrenderer/backend/poly_framebuffer.cpp
+++ b/src/rendering/polyrenderer/backend/poly_framebuffer.cpp
@@ -267,7 +267,8 @@ sector_t *PolyFrameBuffer::RenderView(player_t *player)
 		NoInterpolateView = false;
 
 		// Shader start time does not need to be handled per level. Just use the one from the camera to render from.
-		GetRenderState()->CheckTimer(player->camera->Level->ShaderStartTime);
+		if (player->camera)
+			GetRenderState()->CheckTimer(player->camera->Level->ShaderStartTime);
 		// prepare all camera textures that have been used in the last frame.
 		// This must be done for all levels, not just the primary one!
 		for (auto Level : AllLevels())

--- a/src/rendering/vulkan/system/vk_framebuffer.cpp
+++ b/src/rendering/vulkan/system/vk_framebuffer.cpp
@@ -404,7 +404,8 @@ sector_t *VulkanFrameBuffer::RenderView(player_t *player)
 		NoInterpolateView = false;
 
 		// Shader start time does not need to be handled per level. Just use the one from the camera to render from.
-		GetRenderState()->CheckTimer(player->camera->Level->ShaderStartTime);
+		if (player->camera)
+			GetRenderState()->CheckTimer(player->camera->Level->ShaderStartTime);
 		// prepare all camera textures that have been used in the last frame.
 		// This must be done for all levels, not just the primary one!
 		for (auto Level : AllLevels())


### PR DESCRIPTION
Creating this bug fix pull request, because I've been burned for "doing it wrong" before. If this isn't the right fix, then I don't know what is.

Theory and justification: If a player destroys itself (i.e. in a death state) by terminating at a "Stop", then the VM itself should crash to the console - but instead, the game crashes in the render loop.