### PR TITLE
remove gl_texture_usehires since it's unused now

### DIFF
--- a/src/rendering/gl/system/gl_framebuffer.cpp
+++ b/src/rendering/gl/system/gl_framebuffer.cpp
@@ -52,7 +52,6 @@
 EXTERN_CVAR (Bool, vid_vsync)
 EXTERN_CVAR(Bool, r_drawvoxels)
 EXTERN_CVAR(Int, gl_tonemap)
-EXTERN_CVAR(Bool, gl_texture_usehires)
 
 void gl_LoadExtensions();
 void gl_PrintStartupLog();

--- a/src/rendering/hwrenderer/textures/hw_material.cpp
+++ b/src/rendering/hwrenderer/textures/hw_material.cpp
@@ -29,8 +29,6 @@
 #include "hw_ihwtexture.h"
 #include "hw_material.h"
 
-EXTERN_CVAR(Bool, gl_texture_usehires)
-
 //===========================================================================
 // 
 //	Quick'n dirty image rescaling.

--- a/src/rendering/hwrenderer/utility/hw_cvars.cpp
+++ b/src/rendering/hwrenderer/utility/hw_cvars.cpp
@@ -80,11 +80,6 @@ CUSTOM_CVAR(Int, gl_texture_filter, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINI
 	screen->TextureFilterChanged();
 }
 
-CUSTOM_CVAR(Bool, gl_texture_usehires, true, CVAR_ARCHIVE|CVAR_NOINITCALL)
-{
-	TexMan.FlushAll();
-}
-
 CVAR(Bool, gl_precache, false, CVAR_ARCHIVE)
 
 //==========================================================================

--- a/src/rendering/hwrenderer/utility/hw_cvars.h
+++ b/src/rendering/hwrenderer/utility/hw_cvars.h
@@ -10,7 +10,6 @@ EXTERN_CVAR(Bool, gl_texture)
 EXTERN_CVAR(Int, gl_texture_filter)
 EXTERN_CVAR(Float, gl_texture_filter_anisotropic)
 EXTERN_CVAR(Int, gl_texture_format)
-EXTERN_CVAR(Bool, gl_texture_usehires)
 EXTERN_CVAR(Bool, gl_usefb)
 
 EXTERN_CVAR(Int, gl_weaponlight)

--- a/src/rendering/swrenderer/textures/r_swtexture.cpp
+++ b/src/rendering/swrenderer/textures/r_swtexture.cpp
@@ -39,8 +39,6 @@
 #include "m_alloc.h"
 #include "imagehelpers.h"
 
-EXTERN_CVAR(Bool, gl_texture_usehires)
-
 
 FSoftwareTexture *FTexture::GetSoftwareTexture()
 {

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2534,7 +2534,6 @@ OptionMenu "GLTextureGLOptions" protected
 	Title "$GLTEXMNU_TITLE"
 	Option "$GLTEXMNU_TEXFILTER",		gl_texture_filter,				"FilterModes"
 	Option "$GLTEXMNU_ANISOTROPIC",		gl_texture_filter_anisotropic,	"Anisotropy"
-	Option "$GLTEXMNU_ENABLEHIRES",		gl_texture_usehires,			"YesNo"
 
 	ifOption(MMX)
 	{


### PR DESCRIPTION
5490ffcd77bab88c7574d93e4dc0e866c9cc15c2 removed uses but not references.