### PR TITLE
TICRATE Conversion

### DIFF
--- a/src/g_statusbar/sbarinfo.cpp
+++ b/src/g_statusbar/sbarinfo.cpp
@@ -722,10 +722,10 @@ void SBarInfo::ParseSBarInfo(int lump)
 						popup.transition = Popup::TRANSITION_FADE;
 						sc.MustGetToken(',');
 						sc.MustGetToken(TK_FloatConst);
-						popup.speed = 1.0 / (35.0 * sc.Float);
+						popup.speed = 1.0 / (TICRATE * sc.Float);
 						sc.MustGetToken(',');
 						sc.MustGetToken(TK_FloatConst);
-						popup.speed2 = 1.0 / (35.0 * sc.Float);
+						popup.speed2 = 1.0 / (TICRATE * sc.Float);
 					}
 					else
 						sc.ScriptError("Unkown transition type: '%s'", sc.String);

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -977,7 +977,7 @@ DEFINE_MAP_OPTION(sky1, true)
 		{
 			parse.sc.Float /= 256;
 		}
-		info->skyspeed1 = float(parse.sc.Float * (35. / 1000.));
+		info->skyspeed1 = float(parse.sc.Float * (TICRATE / 1000.));
 	}
 }
 
@@ -991,7 +991,7 @@ DEFINE_MAP_OPTION(sky2, true)
 		{
 			parse.sc.Float /= 256;
 		}
-		info->skyspeed2 = float(parse.sc.Float * (35. / 1000.));
+		info->skyspeed2 = float(parse.sc.Float * (TICRATE / 1000.));
 	}
 }
 

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -297,7 +297,7 @@ void FTextureAnimator::InitAnimated (void)
 				}
 
 				// Speed is stored as tics, but we want ms so scale accordingly.
-				FAnimDef *adef = AddSimpleAnim (pic1, pic2 - pic1 + 1, Scale (animspeed, 1000, 35));
+				FAnimDef *adef = AddSimpleAnim (pic1, pic2 - pic1 + 1, Scale (animspeed, 1000, TICRATE));
 				if (adef != NULL) adef->AnimType = animtype;
 			}
 		}
@@ -601,14 +601,14 @@ void FTextureAnimator::ParseTime (FScanner &sc, uint32_t &min, uint32_t &max)
 	if (sc.Compare ("tics"))
 	{
 		sc.MustGetFloat ();
-		min = max = uint32_t(sc.Float * 1000 / 35);
+		min = max = uint32_t(sc.Float * 1000 / TICRATE);
 	}
 	else if (sc.Compare ("rand"))
 	{
 		sc.MustGetFloat ();
-		min = uint32_t(sc.Float * 1000 / 35);
+		min = uint32_t(sc.Float * 1000 / TICRATE);
 		sc.MustGetFloat ();
-		max = uint32_t(sc.Float * 1000 / 35);
+		max = uint32_t(sc.Float * 1000 / TICRATE);
 	}
 	else
 	{

--- a/src/playsim/mapthinkers/a_lightning.cpp
+++ b/src/playsim/mapthinkers/a_lightning.cpp
@@ -51,7 +51,7 @@ void DLightningThinker::Construct()
 {
 	Stopped = false;
 	LightningFlashCount = 0;
-	NextLightningFlash = ((pr_lightning()&15)+5)*35; // don't flash at level start
+	NextLightningFlash = ((pr_lightning()&15)+5)*TICRATE; // don't flash at level start
 
 	LightningLightLevels.Resize(Level->sectors.Size());
 	fillshort(&LightningLightLevels[0], LightningLightLevels.Size(), SHRT_MAX);
@@ -193,11 +193,11 @@ void DLightningThinker::LightningFlash ()
 		{
 			if (pr_lightning() < 128 && !(Level->time&32))
 			{
-				NextLightningFlash = ((pr_lightning()&7)+2)*35;
+				NextLightningFlash = ((pr_lightning()&7)+2)*TICRATE;
 			}
 			else
 			{
-				NextLightningFlash = ((pr_lightning()&15)+5)*35;
+				NextLightningFlash = ((pr_lightning()&15)+5)*TICRATE;
 			}
 		}
 	}

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -6443,7 +6443,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 		{
 			PalEntry color = args[0];
 			bool fullbright = argCount > 1 ? !!args[1] : false;
-			int lifetime = argCount > 2 ? args[2] : 35;
+			int lifetime = argCount > 2 ? args[2] : TICRATE;
 			double size = argCount > 3 ? args[3] : 1.;
 			int x = argCount > 4 ? args[4] : 0;
 			int y = argCount > 5 ? args[5] : 0;

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -695,7 +695,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 			if (!p)
 				return;
 
-			int spiralduration = (duration == 0) ? 35 : duration;
+			int spiralduration = (duration == 0) ? TICRATE : duration;
 
 			p->alpha = 1.f;
 			p->ttl = spiralduration;

--- a/src/playsim/p_effect.h
+++ b/src/playsim/p_effect.h
@@ -34,6 +34,7 @@
 #pragma once
 
 #include "vectors.h"
+#include "doomdef.h"
 
 #define FX_ROCKET			0x00000001
 #define FX_GRENADE			0x00000002
@@ -88,7 +89,7 @@ struct SPortalHit
 	DVector3 OutDir;
 };
 
-void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1, int color2, double maxdiff = 0, int flags = 0, PClassActor *spawnclass = NULL, DAngle angle = 0., int duration = 35, double sparsity = 1.0, double drift = 1.0, int SpiralOffset = 270, DAngle pitch = 0.);
+void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1, int color2, double maxdiff = 0, int flags = 0, PClassActor *spawnclass = NULL, DAngle angle = 0., int duration = TICRATE, double sparsity = 1.0, double drift = 1.0, int SpiralOffset = 270, DAngle pitch = 0.);
 void P_DrawSplash (FLevelLocals *Level, int count, const DVector3 &pos, DAngle angle, int kind);
 void P_DrawSplash2 (FLevelLocals *Level, int count, const DVector3 &pos, DAngle angle, int updown, int kind);
 void P_DisconnectEffect (AActor *actor);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1080,7 +1080,7 @@ class Actor : Thinker native
 	native void A_FadeOut(double reduce = 0.1, int flags = 1); //bool remove == true
 	native void A_FadeTo(double target, double amount = 0.1, int flags = 0);
 	native void A_SpawnDebris(class<Actor> spawntype, bool transfer_translation = false, double mult_h = 1, double mult_v = 1);
-	native void A_SpawnParticle(color color1, int flags = 0, int lifetime = 35, double size = 1, double angle = 0, double xoff = 0, double yoff = 0, double zoff = 0, double velx = 0, double vely = 0, double velz = 0, double accelx = 0, double accely = 0, double accelz = 0, double startalphaf = 1, double fadestepf = -1, double sizestep = 0);
+	native void A_SpawnParticle(color color1, int flags = 0, int lifetime = TICRATE, double size = 1, double angle = 0, double xoff = 0, double yoff = 0, double zoff = 0, double velx = 0, double vely = 0, double velz = 0, double accelx = 0, double accely = 0, double accelz = 0, double startalphaf = 1, double fadestepf = -1, double sizestep = 0);
 	native void A_ExtChase(bool usemelee, bool usemissile, bool playactive = true, bool nightmarefast = false);
 	native void A_DropInventory(class<Inventory> itemtype, int amount = -1);
 	native void A_SetBlend(color color1, double alpha, int tics, color color2 = 0, double alpha2 = 0.);

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -422,6 +422,7 @@ struct GameInfoStruct native
 
 class Object native
 {
+	const TICRATE = 35;
 	native bool bDestroyed;
 
 	// These must be defined in some class, so that the compiler can find them. Object is just fine, as long as they are private to external code.
@@ -509,7 +510,6 @@ class Thinker : Object native play
 		MAX_STATNUM = 127
 	}
 
-	const TICRATE = 35;
 
 	native LevelLocals Level;
 	

--- a/wadsrc/static/zscript/ui/statusbar/strife_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/strife_sbar.zs
@@ -318,10 +318,10 @@ class StrifeStatusBar : BaseStatusBar
 			int flags = item.Amount <= 0? DI_ITEM_OFFSETS|DI_DIM : DI_ITEM_OFFSETS;
 			if (item == CPlayer.mo.InvSel)
 			{
-				DrawTexture (Images[CursorImage], (42 + 35*i, 180), flags, 1. - itemflashFade);
+				DrawTexture (Images[CursorImage], (42 + TICRATE*i, 180), flags, 1. - itemflashFade);
 			}
-			DrawInventoryIcon (item, (48 + 35*i, 182), flags);
-			DrawString(mYelFont, FormatNumber(item.Amount, 3, 5), (75 + 35*i, 191), DI_TEXT_ALIGN_RIGHT);
+			DrawInventoryIcon (item, (48 + TICRATE*i, 182), flags);
+			DrawString(mYelFont, FormatNumber(item.Amount, 3, 5), (75 + TICRATE*i, 191), DI_TEXT_ALIGN_RIGHT);
 			i++;
 		}
 	}
@@ -388,13 +388,13 @@ class StrifeStatusBar : BaseStatusBar
 				{
 					if (item == CPlayer.mo.InvSel)
 					{
-						DrawTexture(Images[CursorImage], (-90+i*35, -3), DI_SCREEN_CENTER_BOTTOM, 0.75);
+						DrawTexture(Images[CursorImage], (-90+i*TICRATE, -3), DI_SCREEN_CENTER_BOTTOM, 0.75);
 					}
 					if (item.Icon.isValid())
 					{
-						DrawInventoryIcon(item, (-90+i*35, -5), DI_SCREEN_CENTER_BOTTOM|DI_DIMDEPLETED, 0.75);
+						DrawInventoryIcon(item, (-90+i*TICRATE, -5), DI_SCREEN_CENTER_BOTTOM|DI_DIMDEPLETED, 0.75);
 					}
-					DrawString(mYelFont, FormatNumber(item.Amount, 3, 5), (-72 + i*35, -8), DI_TEXT_ALIGN_RIGHT|DI_SCREEN_CENTER_BOTTOM);
+					DrawString(mYelFont, FormatNumber(item.Amount, 3, 5), (-72 + i*TICRATE, -8), DI_TEXT_ALIGN_RIGHT|DI_SCREEN_CENTER_BOTTOM);
 					++i;
 				}
 			}


### PR DESCRIPTION
This converts a bunch of 35s to TICRATE constant.

Moved TICRATE from Thinker to Object in ZScript so status bars have access to it.

NOTE: Some places have purposefully remain untouched. The most notable are: 
- Fuzz shader for ZDoom 
- **d_main.cpp** line 1082: `diff = (nowtime - wipestart) * 40 / 1000;	// Using 35 here feels too slow.`
- Gameplay options menu with the CleanFac * 35, because that doesn't appear to have anything to do with ticrate.