### PR TITLE
Attempt to fix keybinds

### DIFF
--- a/src/common/console/c_bind.cpp
+++ b/src/common/console/c_bind.cpp
@@ -59,11 +59,11 @@ const char *KeyNames[NUM_KEYS] =
 	nullptr,	"Escape",	"1",		"2",		"3",		"4",		"5",		"6",		//00
 	"7",		"8",		"9",		"0",		"-",		"=",		"Backspace","Tab",		//08
 	"Q",		"W",		"E",		"R",		"T",		"Y",		"U",		"I",		//10
-	"O",		"P",		"[",		"]",		"Enter",	"LCtrl",		"A",		"S",	//18
+	"O",		"P",		"[",		"]",		"Enter",	"Ctrl",		"A",		"S",	//18
 	"D",		"F",		"G",		"H",		"J",		"K",		"L",		";",		//20
-	"'",		"`",		"LShift",	"\\",		"Z",		"X",		"C",		"V",		//28
+	"'",		"`",		"Shift",	"\\",		"Z",		"X",		"C",		"V",		//28
 	"B",		"N",		"M",		",",		".",		"/",		"RShift",	"KP*",		//30
-	"LAlt",		"Space",	"CapsLock",	"F1",		"F2",		"F3",		"F4",		"F5",		//38
+	"Alt",		"Space",	"CapsLock",	"F1",		"F2",		"F3",		"F4",		"F5",		//38
 	"F6",		"F7",		"F8",		"F9",		"F10",		"NumLock",	"Scroll",	"KP7",		//40
 	"KP8",		"KP9",		"KP-",		"KP4",		"KP5",		"KP6",		"KP+",		"KP1",		//48
 	"KP2",		"KP3",		"KP0",		"KP.",		nullptr,	nullptr,	"OEM102",	"F11",		//50


### PR DESCRIPTION
I compared this to an earlier one that didn't have the bug. I change LCtrl/LAlt/LShift back to Ctrl/Alt/Shift. So now older DEFBINDS work.