### PR TITLE
Smarter DEFBINDS fix, checks if the file is loaded from an IWAD/IPK3/IPK7

### DIFF
--- a/src/common/console/c_bind.cpp
+++ b/src/common/console/c_bind.cpp
@@ -723,7 +723,13 @@ void C_SetDefaultKeys(const char* baseconfig)
 	lastlump = 0;
 	while ((lump = fileSystem.FindLump("DEFBINDS", &lastlump)) != -1)
 	{
-		ReadBindings(lump, false);
+		// [SW] - We need to check to see the origin of the DEFBINDS... if it
+		// Comes from an IWAD/IPK3/IPK7 allow it to override the users settings...
+		// If it comes from a user mod however, don't.
+		if (fileSystem.GetFileContainer(lump) > fileSystem.GetMaxIwadNum())
+			ReadBindings(lump, false);
+		else
+			ReadBindings(lump, true);
 	}
 }
 

--- a/src/common/console/c_bind.cpp
+++ b/src/common/console/c_bind.cpp
@@ -717,7 +717,13 @@ void C_SetDefaultKeys(const char* baseconfig)
 	while ((lump = fileSystem.FindLumpFullName(baseconfig, &lastlump)) != -1)
 	{
 		if (fileSystem.GetFileContainer(lump) > 0) break;
-		ReadBindings(lump, true);
+		// [SW] - We need to check to see the origin of the DEFBINDS... if it
+		// Comes from an IWAD/IPK3/IPK7 allow it to override the users settings...
+		// If it comes from a user mod however, don't.
+		if (fileSystem.GetFileContainer(lump) > fileSystem.GetMaxIwadNum())
+			ReadBindings(lump, false);
+		else
+			ReadBindings(lump, true);
 	}
 
 	lastlump = 0;


### PR DESCRIPTION
A much smarter DEFBINDS fix. Check if the lump is in the range of an IWAD, if so, override the settings... if not, don't override the settings.

https://forum.zdoom.org/viewtopic.php?f=2&t=68292