### PR TITLE
 SlotNumber and SlotPriority Meta Removal

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -34,8 +34,8 @@ class Weapon : StateProvider
 	bool bAltFire;							// Set when this weapon's alternate fire is used.
 	readonly bool bDehAmmo;					// Uses Doom's original amount of ammo for the respective attack functions so that old DEHACKED patches work as intended.
 											// AmmoUse1 will be set to the first attack's ammo use so that checking for empty weapons still works
-	meta int SlotNumber;
-	meta double SlotPriority;
+	int SlotNumber;
+	double SlotPriority;
 	
 	property AmmoGive: AmmoGive1;
 	property AmmoGive1: AmmoGive1;

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -123,7 +123,7 @@ class Weapon : StateProvider
 	{
 		if (GetReplacement(GetClass()) == GetClass() && !bPowered_Up)
 		{
-			return SlotNumber, int(SlotPriority*65536);
+			return Default.SlotNumber, int(Default.SlotPriority*65536);
 		}
 		return -1, 0;
 	}


### PR DESCRIPTION
- This allows creating customizable weapon selections based on menu options.

I have a system that iterates through the player's inventory live each time the player attempts to switch weapons, which gathers all applicable weaponry and sorts it according to slots and priorities. But I'm also attempting to set up a subsystem where certain weapons can be disabled from selecting if superior versions are found to allow faster weapon cycling. This system ignores weapons that have -1 for SlotNumber or are outside the range [0.0, 1.0] for SlotPriority. Upon picking up a superior weapon and switching to it, the inferior's slot number is set to -1.

To ensure the original behavior is maintained, CheckAddToSlots function now returns the Default of both values so whenever the system is shut off, it behaves as normal and selects them as expected.

Without this change, I'm forced to rely upon inventory hacks that are quite unwieldy with questionable stability.