### PR TITLE
Fix single top level filter folder not being read

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -186,7 +186,7 @@ extern bool insave;
 extern TDeletingArray<FLightDefaults *> LightDefaults;
 
 const char* iwad_folders[13] = { "flats/", "textures/", "hires/", "sprites/", "voxels/", "colormaps/", "acs/", "maps/", "voices/", "patches/", "graphics/", "sounds/", "music/" };
-const char* iwad_reserved[12] = { "mapinfo", "zmapinfo", "gameinfo", "sndinfo", "sbarinfo", "menudef", "gldefs", "animdefs", "decorate", "zscript", "iwadinfo" "maps/" };
+const char* iwad_reserved[12] = { "mapinfo", "zmapinfo", "gameinfo", "sndinfo", "sbarinfo", "menudef", "gldefs", "animdefs", "decorate", "zscript", "iwadinfo", "maps/" };
 
 
 CUSTOM_CVAR(Float, i_timescale, 1.0f, CVAR_NOINITCALL)


### PR DESCRIPTION
https://forum.zdoom.org/viewtopic.php?f=2&t=68402&p=1149719#p1149719

This seems to fix the problem that if the only top level thing in a pk3 (in zip format) is the filter folder, the filters are not read correctly. As for why the missing comma broke it in the first place, I'm not really sure why it broke it in this particular way in the first place...