### PR TITLE
Replacing of "get distance" to "get distance squared"

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1469,13 +1469,13 @@ double FLevelLocals::PlayersRangeFromSpot (FPlayerStart *spot)
 		if (!playeringame[i] || !players[i].mo || players[i].health <= 0)
 			continue;
 
-		distance = players[i].mo->Distance2D(spot->pos.X, spot->pos.Y);
+		distance = players[i].mo->Distance2DSquared(spot->pos.X, spot->pos.Y);
 
 		if (distance < closest)
 			closest = distance;
 	}
 
-	return closest;
+	return sqrt(closest);
 }
 
 // [RH] Select the deathmatch spawn spot farthest from everyone.

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -857,6 +857,11 @@ public:
 		return (Pos().XY() - otherpos).LengthSquared();
 	}
 
+	double Distance2DSquared(double x, double y) const
+	{
+		return DVector2(X() - x, Y() - y).LengthSquared();
+	}
+
 	double Distance2D(AActor *other, bool absolute = false)
 	{
 		DVector2 otherpos = absolute ? other->Pos() : other->PosRelative(this);

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -2461,12 +2461,12 @@ DEFINE_ACTION_FUNCTION(AActor, CheckIfTargetInLOS)
 	}
 	double distance_squared = self->Distance3DSquared(target);
 
-	if (dist_max && (distance_squared > (dist_max * dist_max) ) )
+	if (dist_max && (dist_max >= 0 && distance_squared > (dist_max * dist_max) ) )
 	{
 		ACTION_RETURN_BOOL(false);
 	}
 
-	if (dist_close && (distance_squared < (dist_close * dist_close) ) )
+	if (dist_close && (dist_close >= 0 && distance_squared < (dist_close * dist_close) ) )
 	{
 		if (flags & JLOSF_CLOSENOJUMP)
 		{

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -2241,8 +2241,9 @@ DEFINE_ACTION_FUNCTION(AActor, CheckLOF)
 		{
 			if (range > 0 && !(flags & CLOFF_CHECKPARTIAL))
 			{
-				double distance = self->Distance3D(target);
-				if (distance > range)
+				double distance_squared = self->Distance3DSquared(target);
+
+				if (distance_squared > (range * range) )
 				{
 					ACTION_RETURN_BOOL(false);
 				}
@@ -2458,13 +2459,14 @@ DEFINE_ACTION_FUNCTION(AActor, CheckIfTargetInLOS)
 	{
 		ACTION_RETURN_BOOL(false);
 	}
-	double distance = self->Distance3D(target);
+	double distance_squared = self->Distance3DSquared(target);
 
-	if (dist_max && (distance > dist_max))
+	if (dist_max && (distance_squared > (dist_max * dist_max) ) )
 	{
 		ACTION_RETURN_BOOL(false);
 	}
-	if (dist_close && (distance < dist_close))
+
+	if (dist_close && (distance_squared < (dist_close * dist_close) ) )
 	{
 		if (flags & JLOSF_CLOSENOJUMP)
 		{
@@ -2549,16 +2551,16 @@ DEFINE_ACTION_FUNCTION(AActor, CheckIfInTargetLOS)
 		ACTION_RETURN_BOOL(false);
 	}
 
-	double distance = self->Distance3D(target);
+	double distance_squared = self->Distance3DSquared(target);
 
-	if (dist_max && (distance > dist_max))
+	if (dist_max && dist_max >= 0 && (distance_squared > (dist_max * dist_max) ) )
 	{
 		ACTION_RETURN_BOOL(false);
 	}
 
 	bool doCheckSight = !(flags & JLOSF_NOSIGHT);
 
-	if (dist_close && (distance < dist_close))
+	if (dist_close && dist_close >= 0 && (distance_squared < (dist_close * dist_close) ) )
 	{
 		if (flags & JLOSF_CLOSENOJUMP)
 		{
@@ -3349,7 +3351,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_WolfAttack)
 
 	// Target can dodge if it can see enemy
 	DAngle angle = absangle(self->target->Angles.Yaw, self->target->AngleTo(self));
-	bool dodge = (P_CheckSight(self->target, self) && angle < 30. * 256. / 360.);	// 30 byteangles ~ 21°
+	bool dodge = (P_CheckSight(self->target, self) && angle < 30. * 256. / 360.);	// 30 byteangles ~ 21ï¿½
 
 	// Distance check is simplistic
 	DVector2 vec = self->Vec2To(self->target);

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -2070,11 +2070,11 @@ void P_FakeZMovement(AActor *mo)
 			//and square of a real number always positive
 			double delta = mo->target->Center() - mo->Z();
 			//why it multiplies by 3 in original function?
-			double delta_squared = delta * delta * 3 * 3;
-			if (delta < 0 && dist_squared < -(delta_squared) )
+			double delta_squared = delta * abs(delta) * 3 * 3;
+			if (delta_squared < 0 && dist_squared < -(delta_squared) )
 				mo->AddZ(-mo->FloatSpeed);
 
-			else if (delta > 0 && dist_squared < (delta_squared) )
+			else if (delta_squared > 0 && dist_squared < (delta_squared) )
 				mo->AddZ(mo->FloatSpeed);
 		}
 	}

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -1354,10 +1354,10 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 				fabs(thing->Y() - oldpos.Y) < (thing->radius + tm.thing->radius))
 
 			{
-				double newdist = thing->Distance2D(cres.Position.X, cres.Position.Y);
-				double olddist = thing->Distance2D(oldpos.X, oldpos.Y);
+				double newdist_squared = thing->Distance2DSquared(cres.Position.X, cres.Position.Y);
+				double olddist_squared = thing->Distance2DSquared(oldpos.X, oldpos.Y);
 
-				if (newdist > olddist)
+				if (newdist_squared > olddist_squared)
 				{
 					// unblock only if there's already a vertical overlap (or both actors are flagged not to overlap)
 					unblocking = (tm.thing->Top() > thing->Z() && tm.thing->Z() < topz) || (tm.thing->flags3 & thing->flags3 & MF3_DONTOVERLAP);
@@ -2065,15 +2065,20 @@ void P_FakeZMovement(AActor *mo)
 	{ // float down towards target if too close
 		if (!(mo->flags & MF_SKULLFLY) && !(mo->flags & MF_INFLOAT))
 		{
-			double dist = mo->Distance2D(mo->target);
+			double dist_squared = mo->Distance2DSquared(mo->target);
+			//still need delta intact, because it can be negative
+			//and square of a real number always positive
 			double delta = mo->target->Center() - mo->Z();
-			if (delta < 0 && dist < -(delta * 3))
+			//why it multiplies by 3 in original function?
+			double delta_squared = delta * delta * 3 * 3;
+			if (delta < 0 && dist_squared < -(delta_squared) )
 				mo->AddZ(-mo->FloatSpeed);
-			else if (delta > 0 && dist < (delta * 3))
+
+			else if (delta > 0 && dist_squared < (delta_squared) )
 				mo->AddZ(mo->FloatSpeed);
 		}
 	}
-	if (mo->player && mo->flags&MF_NOGRAVITY && (mo->Z() > mo->floorz) && !mo->IsNoClip2())
+	if (mo->player && mo->flags & MF_NOGRAVITY && (mo->Z() > mo->floorz) && !mo->IsNoClip2())
 	{
 		mo->AddZ(DAngle(4.5 * mo->Level->maptime).Sin());
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -2367,7 +2367,7 @@ void P_MonsterFallingDamage (AActor *mo)
 
 void P_ZMovement (AActor *mo, double oldfloorz)
 {
-	double dist;
+	double distance_squared;//not used anywhere except height adjusting block
 	double delta;
 	double oldz = mo->Z();
 	double grav = mo->GetGravity();
@@ -2479,11 +2479,17 @@ void P_ZMovement (AActor *mo, double oldfloorz)
 	{	// float down towards target if too close
 		if (!(mo->flags & (MF_SKULLFLY | MF_INFLOAT)))
 		{
-			dist = mo->Distance2D (mo->target);
-			delta = (mo->target->Center()) - mo->Z();
-			if (delta < 0 && dist < -(delta*3))
+			//same code block from P_FakeZMovement/vice versa???
+			double dist_squared = mo->Distance2DSquared(mo->target);
+			//still need delta intact, because it can be negative
+			//and square of a real number always positive
+			double delta = mo->target->Center() - mo->Z();
+			//why it multiplies by 3 in original function?
+			double delta_squared = delta * delta * 3 * 3;
+			if (delta < 0 && dist_squared < -(delta_squared) )
 				mo->AddZ(-mo->FloatSpeed);
-			else if (delta > 0 && dist < (delta*3))
+
+			else if (delta > 0 && dist_squared < (delta_squared) )
 				mo->AddZ(mo->FloatSpeed);
 		}
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -2480,16 +2480,16 @@ void P_ZMovement (AActor *mo, double oldfloorz)
 		if (!(mo->flags & (MF_SKULLFLY | MF_INFLOAT)))
 		{
 			//same code block from P_FakeZMovement/vice versa???
-			double dist_squared = mo->Distance2DSquared(mo->target);
+			distance_squared = mo->Distance2DSquared(mo->target);
 			//still need delta intact, because it can be negative
 			//and square of a real number always positive
-			double delta = mo->target->Center() - mo->Z();
+			delta = mo->target->Center() - mo->Z();
 			//why it multiplies by 3 in original function?
-			double delta_squared = delta * delta * 3 * 3;
-			if (delta < 0 && dist_squared < -(delta_squared) )
+			double delta_squared = delta * abs(delta) * 3 * 3;
+			if (delta_squared < 0 && distance_squared < -(delta_squared) )
 				mo->AddZ(-mo->FloatSpeed);
 
-			else if (delta > 0 && dist_squared < (delta_squared) )
+			else if (delta_squared > 0 && distance_squared < (delta_squared) )
 				mo->AddZ(mo->FloatSpeed);
 		}
 	}

--- a/src/playsim/p_things.cpp
+++ b/src/playsim/p_things.cpp
@@ -613,7 +613,7 @@ int P_Thing_CheckProximity(FLevelLocals *Level, AActor *self, PClass *classname,
 		// [MC]Make sure it's in range and respect the desire for Z or not. The function forces it to use
 		// Z later for ensuring CLOSEST and FARTHEST flags are respected perfectly.
 		// Ripped from sphere checking in A_RadiusGive (along with a number of things).
-		if ((ref->Distance2D(mo) < distance &&
+		if ((ref->Distance2DSquared(mo) < (distance * distance) &&
 			((flags & CPXF_NOZ) ||
 			((ref->Z() > mo->Z() && ref->Z() - mo->Top() < distance) ||
 			(ref->Z() <= mo->Z() && mo->Z() - ref->Top() < distance)))))


### PR DESCRIPTION
Slightly misleading title.
What it actually do, is replaced most checks, which involves distance measurement to check is actor closer/further than some specific distance, to use distance squared instead which increase performance. Especially for "NoiseMarkSector" function with non zero "hear distance" argument.