### PR TITLE
fix "'ictionary' is freed outside the GC process" warning

### DIFF
--- a/src/common/scripting/core/dictionary.cpp
+++ b/src/common/scripting/core/dictionary.cpp
@@ -43,7 +43,7 @@ void Dictionary::Serialize(FSerializer &arc)
 		Dictionary *pointerToDeserializedDictionary;
 		arc(key, pointerToDeserializedDictionary);
 		Map.TransferFrom(pointerToDeserializedDictionary->Map);
-		delete pointerToDeserializedDictionary;
+		pointerToDeserializedDictionary->Destroy();
 	}
 }
 


### PR DESCRIPTION
Fixes https://forum.zdoom.org/viewtopic.php?f=2&t=68603#p1151561.