### PR TITLE
Option to disable merging of identical pickup messages on same tic

### DIFF
--- a/src/gamedata/gi.cpp
+++ b/src/gamedata/gi.cpp
@@ -440,6 +440,7 @@ void FMapInfoParser::ParseGameInfo()
 			GAMEINFOKEY_STRING(statusscreen_dm, "statscreen_dm")
 			GAMEINFOKEY_TWODOUBLES(normforwardmove, "normforwardmove")
 			GAMEINFOKEY_TWODOUBLES(normsidemove, "normsidemove")
+			GAMEINFOKEY_BOOL(nomergepickupmsg, "nomergepickupmsg")
 
 		else
 		{

--- a/src/gamedata/gi.h
+++ b/src/gamedata/gi.h
@@ -206,6 +206,7 @@ struct gameinfo_t
 	double normforwardmove[2];
 	double normsidemove[2];
 	int fullscreenautoaspect = 0;
+	bool nomergepickupmsg;
 
 	const char *GetFinalePage(unsigned int num) const;
 };

--- a/src/playsim/a_pickups.cpp
+++ b/src/playsim/a_pickups.cpp
@@ -41,6 +41,7 @@
 #include "d_player.h"
 #include "vm.h"
 #include "g_levellocals.h"
+#include "gi.h"
 
 EXTERN_CVAR(Bool, sv_unlimited_pickup)
 
@@ -55,7 +56,8 @@ static FString StaticLastMessage;
 
 void PrintPickupMessage(bool localview, const FString &str)
 {
-	if (str.IsNotEmpty() && localview && (StaticLastMessageTic != gametic || StaticLastMessage.Compare(str)))
+	// [MK] merge identical messages on same tic unless disabled in gameinfo
+	if (str.IsNotEmpty() && localview && (gameinfo.nomergepickupmsg || StaticLastMessageTic != gametic || StaticLastMessage.Compare(str)))
 	{
 		StaticLastMessageTic = gametic;
 		StaticLastMessage = str;


### PR DESCRIPTION
I didn't know this was a thing until I started to notice that very often in one of my mods where I merge pickups myself with a little "times" suffix in the hud, very often the amount picked up would not match the suffix.

Well, found the culprit, and I really want an option to get rid of it.

This can be tested easily by loading [this single mapinfo file](https://github.com/coelckers/gzdoom/files/4671407/zmapinfo.txt), warping to Doom 2 MAP07 and picking up the "backpack" (which is actually ten backpacks overlapping). With this flag it should result in ten messages.