### PR TITLE
more descriptive message for server CVAR change attempt in netgame

### DIFF
--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -629,7 +629,7 @@ bool D_SendServerInfoChange (FBaseCVar *cvar, UCVarValue value, ECVarType type)
 	{
 		if (netgame && !players[consoleplayer].settings_controller)
 		{
-			Printf("Only setting controllers can change %s\n", cvar->GetName());
+			Printf("Only setting controllers can change server CVAR %s\n", cvar->GetName());
 			cvar->MarkSafe();
 			return true;
 		}
@@ -659,7 +659,10 @@ bool D_SendServerFlagChange (FBaseCVar *cvar, int bitnum, bool set, bool silent)
 	{
 		if (netgame && !players[consoleplayer].settings_controller)
 		{
-			if (!silent) Printf("Only setting controllers can change %s\n", cvar->GetName());
+			if (!silent)
+			{
+				Printf("Only setting controllers can change server CVAR %s\n", cvar->GetName());
+			}
 			return true;
 		}
 


### PR DESCRIPTION
Rationale: while the previous description contains the name of a CVAR, it doesn't specify that it's a CVAR. Unsuspecting user may be not aware that the engine or a mod contains such a CVAR.