### PR TITLE
- Fixed OpenAL regression with looping sounds with playing length 0.

### DIFF
--- a/src/common/audio/sound/oalsound.cpp
+++ b/src/common/audio/sound/oalsound.cpp
@@ -1420,7 +1420,10 @@ FISoundChannel *OpenALSoundRenderer::StartSound3D(SoundHandle sfx, SoundListener
 
 	if(!reuse_chan || reuse_chan->StartTime == 0)
 	{
-		float st = (chanflags & SNDF_LOOP) ? fmod(startTime, (float)GetMSLength(sfx) / 1000.f) : clamp<float>(startTime, 0.f, (float)GetMSLength(sfx) / 1000.f);
+		float sfxlength = (float)GetMSLength(sfx) / 1000.f;
+		float st = (chanflags & SNDF_LOOP)
+				? (sfxlength > 0 ? fmod(startTime, sfxlength) : 0)
+				: clamp<float>(startTime, 0.f, sfxlength);
 		alSourcef(source, AL_SEC_OFFSET, st);
 	}
 	else

--- a/src/common/audio/sound/s_sound.cpp
+++ b/src/common/audio/sound/s_sound.cpp
@@ -547,9 +547,10 @@ FSoundChan *SoundEngine::StartSound(int type, const void *source,
 		if (chanflags & (CHANF_UI|CHANF_NOPAUSE)) startflags |= SNDF_NOPAUSE;
 		if (chanflags & CHANF_UI) startflags |= SNDF_NOREVERB;
 
+		float sfxlength = (float)GSnd->GetMSLength(sfx->data) / 1000.f;
 		startTime = (startflags & SNDF_LOOP)
-			? fmod(startTime, (float)GSnd->GetMSLength(sfx->data) / 1000.f)
-			: clamp<float>(startTime, 0.f, (float)GSnd->GetMSLength(sfx->data) / 1000.f);
+				? (sfxlength > 0 ? fmod(startTime, sfxlength) : 0)
+				: clamp<float>(startTime, 0.f, sfxlength);
 
 		if (attenuation > 0 && type != SOURCE_None)
 		{


### PR DESCRIPTION
If such case occurs, the starttime parameter passed to the sound functions is ignored and truncated to 0.

Fixes https://forum.zdoom.org/viewtopic.php?f=104&t=68780 .