### PR TITLE
Hotfix: LineTrace now reports the correct number of portal crossings

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -4866,7 +4866,8 @@ int P_LineTrace(AActor *t1, DAngle angle, double distance,
 		outdata->HitLocation = trace.HitPos;
 		outdata->HitDir = trace.HitVector;
 		outdata->Distance = trace.Distance;
-		outdata->NumPortals = TData.NumPortals;
+		// [MK] Subtract two "bogus" portal crossings used internally by trace code
+		outdata->NumPortals = TData.NumPortals-2;
 		outdata->HitType = trace.HitType;
 	}
 	return ret;


### PR DESCRIPTION
This is in relation to that ["bug" report](https://forum.zdoom.org/viewtopic.php?f=2&t=68852) I made.

Because I actually want NumPortals to have the "expected" result for the end user, here's a tiny change.