### PR TITLE
Add PlayerSpawned() event

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -1006,6 +1006,18 @@ void DStaticEventHandler::PlayerEntered(int num, bool fromhub)
 	}
 }
 
+void DStaticEventHandler::PlayerSpawned(int num)
+{
+	IFVIRTUAL(DStaticEventHandler, PlayerSpawned)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func)) return;
+		FPlayerEvent e = { num, false };
+		VMValue params[2] = { (DStaticEventHandler*)this, &e };
+		VMCall(func, params, 2, nullptr, 0);
+	}
+}
+
 void DStaticEventHandler::PlayerRespawned(int num)
 {
 	IFVIRTUAL(DStaticEventHandler, PlayerRespawned)

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -418,6 +418,14 @@ void EventManager::PlayerEntered(int num, bool fromhub)
 		handler->PlayerEntered(num, fromhub);
 }
 
+void EventManager::PlayerSpawned(int num)
+{
+	if (ShouldCallStatic(true)) staticEventManager.PlayerSpawned(num);
+
+	for (DStaticEventHandler* handler = FirstEventHandler; handler; handler = handler->next)
+		handler->PlayerSpawned(num);
+}
+
 void EventManager::PlayerRespawned(int num)
 {
 	if (ShouldCallStatic(true)) staticEventManager.PlayerRespawned(num);

--- a/src/events.h
+++ b/src/events.h
@@ -263,6 +263,8 @@ struct EventManager
 	void RenderUnderlay(EHudState state);
 	// this executes when a player enters the level (once). PlayerEnter+inhub = RETURN
 	void PlayerEntered(int num, bool fromhub);
+	// this executes at the same time as ENTER scripts
+	void PlayerSpawned(int num);
 	// this executes when a player respawns. includes resurrect cheat.
 	void PlayerRespawned(int num);
 	// this executes when a player dies (partially duplicating worldthingdied, but whatever)

--- a/src/events.h
+++ b/src/events.h
@@ -97,6 +97,7 @@ public:
 
 	//
 	void PlayerEntered(int num, bool fromhub);
+	void PlayerSpawned(int num);
 	void PlayerRespawned(int num);
 	void PlayerDied(int num);
 	void PlayerDisconnected(int num);

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5260,6 +5260,7 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 		if (state == PST_ENTER || (state == PST_LIVE && !savegamerestore))
 		{
 			Behaviors.StartTypedScripts (SCRIPT_Enter, p->mo, true);
+			localEventManager->PlayerSpawned(PlayerNum(p));
 		}
 		else if (state == PST_REBORN)
 		{

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -340,6 +340,7 @@ class StaticEventHandler : Object native play version("2.4")
     
     //
     virtual void PlayerEntered(PlayerEvent e) {}
+    virtual void PlayerSpawned(PlayerEvent e) {}
     virtual void PlayerRespawned(PlayerEvent e) {}
     virtual void PlayerDied(PlayerEvent e) {}
     virtual void PlayerDisconnected(PlayerEvent e) {}


### PR DESCRIPTION
I fully anticipate this is not merge-able. However I wanted to try my hand at some minor contribution instead of just nagging others to do it for me.

- I added a new event in `events.cpp` that looks basically like `PlayerRespawned()`.
- I added this to the `events.h` header as well.
- in `p_mobj.cpp` I added a call to this handler at the same place the ACS `ENTER` scripts start (since that's the functionality I want to replicate)
- I added the event virtual to `events.zs`

This is a fairly rudimentary attempt and I did it late at night on a whim. Feedback and/or guidance appreciated and I can make changes if this is even remotely close to the correct implementation.