### PR TITLE
Force STATIC for internal GZDoom SPIRV library

### DIFF
--- a/libraries/glslang/spirv/CMakeLists.txt
+++ b/libraries/glslang/spirv/CMakeLists.txt
@@ -49,7 +49,7 @@ set(SPVREMAP_HEADERS
     SPVRemapper.h
     doc.h)
 
-add_library(SPIRV ${LIB_TYPE} ${SOURCES} ${HEADERS})
+add_library(SPIRV STATIC ${LIB_TYPE} ${SOURCES} ${HEADERS})
 set_property(TARGET SPIRV PROPERTY FOLDER glslang)
 set_property(TARGET SPIRV PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(SPIRV PUBLIC


### PR DESCRIPTION
This makes sure the internal version of this library bundled with the
GZDoom source code is used. This prevents the system from building
GZDoom for dynamic linking with an incompatible external library (see
commit 6fafa297bfe0f82696d898d66e39c50f4f5eef16 and
<https://forum.zdoom.org/viewtopic.php?f=2&t=64633>).