### PR TITLE
autosave and make screenshot only if there is no other game actions

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1811,8 +1811,11 @@ void G_DoPlayerPop(int playernum)
 
 void G_ScreenShot (const char *filename)
 {
-	shotfile = filename;
-	gameaction = ga_screenshot;
+	if (gameaction == ga_nothing)
+	{
+		shotfile = filename;
+		gameaction = ga_screenshot;
+	}
 }
 
 
@@ -3072,7 +3075,10 @@ DEFINE_ACTION_FUNCTION(FLevelLocals, MakeScreenShot)
 
 void G_MakeAutoSave()
 {
-	gameaction = ga_autosave;
+	if (gameaction == ga_nothing)
+	{
+		gameaction = ga_autosave;
+	}
 }
 
 DEFINE_ACTION_FUNCTION(FLevelLocals, MakeAutoSave)


### PR DESCRIPTION
In-game fix for this bug: https://forum.zdoom.org/viewtopic.php?f=43&t=59889&start=60#p1121698
because it may be also caused by other scripts or even manually.