### PR TITLE
Rename MAP31 and MAP32 back in Doom 2: Unity Edition

### DIFF
--- a/wadsrc/static/mapinfo/doom2unity.txt
+++ b/wadsrc/static/mapinfo/doom2unity.txt
@@ -20,27 +20,3 @@ episode level01
 	key = "n"
 	optional
 }
-
-// Wolfenstein 3D censorship
-map MAP31 lookup "HUSTR_31B"
-{
-	titlepatch = "CWILV30"
-	next = "MAP16"
-	secretnext = "MAP32"
-	sky1 = "SKY3"
-	cluster = 9
-	par = 120
-	music = "$MUSIC_EVIL"
-	needclustertext
-}
-
-map MAP32 lookup "HUSTR_32B"
-{
-	titlepatch = "CWILV31"
-	next = "MAP16"
-	secretnext = "MAP16"
-	sky1 = "SKY3"
-	cluster = 10
-	par = 30
-	music = "$MUSIC_ULTIMA"
-}


### PR DESCRIPTION
Quoting [Doom Wiki](https://doomwiki.org/wiki/Doom_Classic_Unity_port#Doom_II_specific):

> BFG Edition's MAP31: IDKFA and MAP32: Keen has been reverted back to MAP31: Wolfenstein and MAP32: Grosse