### PR TITLE
Disable JIT VM by default when compiling for DragonFly BSD

### DIFF
--- a/src/common/scripting/vm/vmframe.cpp
+++ b/src/common/scripting/vm/vmframe.cpp
@@ -45,7 +45,11 @@
 #include "version.h"
 
 #ifdef HAVE_VM_JIT
+#ifdef __DragonFly__
+CUSTOM_CVAR(Bool, vm_jit, false, CVAR_NOINITCALL)
+#else
 CUSTOM_CVAR(Bool, vm_jit, true, CVAR_NOINITCALL)
+#endif
 {
 	Printf("You must restart " GAMENAME " for this change to take effect.\n");
 	Printf("This cvar is currently not saved. You must specify it on the command line.");


### PR DESCRIPTION
When JIT is enabled in GZDoom, it causes an exception to be thrown outside the main thread due to the main menu exit function somehow running parallelized from the main thread when exiting the game from the menu when running on DragonFly BSD, crashing the game without saving the config settings.

I haven't been able to find the cause for the issue yet. So this PR disables vm_jit by default on DragonFly BSD. I fully anticipate that this may not be acceptable at all as a temporary workaround, but I got no other choice for now, at least until the newer JIT implementation that dpJudas is working on is complete. I am welcome for other suggestions otherwise.