### PR TITLE
- make SDL mouse scaling match that of Windows for consistency.

### DIFF
--- a/src/common/platform/posix/sdl/i_input.cpp
+++ b/src/common/platform/posix/sdl/i_input.cpp
@@ -225,14 +225,10 @@ static void MouseRead ()
 	}
 
 	SDL_GetRelativeMouseState (&x, &y);
-	if (!m_noprescale)
-	{
-		x *= 3;
-		y *= 2;
-	}
+
 	if (x | y)
 	{
-		PostMouseMove (x, -y);
+		PostMouseMove (m_noprescale ? x : x << 2, -y);
 	}
 }
 


### PR DESCRIPTION
Under Windows, when `m_noprescale` is false, the x value is bit shifted by 2 (4x original) and the y value is never touched. Under SDL, when `m_noprescale` is false, the x value is 3x original and the y value is 2x original.

This fits in perfectly with how I'd always set in_mousescaley to 0.5 and then set in_mousesensitivity to 1.25 when playing under Linux. With these changes, the mouse feels 1:1.