### PR TITLE
Continue dpJudas' work on directional contrast.

### DIFF
--- a/src/common/models/modelrenderer.h
+++ b/src/common/models/modelrenderer.h
@@ -17,7 +17,7 @@ public:
 
 	virtual VSMatrix GetViewToWorldMatrix() = 0;
 
-	virtual void BeginDrawHUDModel(FRenderStyle style, const VSMatrix &objectToWorldMatrix, bool mirrored) = 0;
+	virtual void BeginDrawHUDModel(FRenderStyle style, FSpriteModelFrame *smf, const VSMatrix &objectToWorldMatrix, bool mirrored) = 0;
 	virtual void EndDrawHUDModel(FRenderStyle style) = 0;
 
 	virtual void SetInterpolation(double interpolation) = 0;

--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -283,6 +283,9 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 		uniform mat4 NormalModelMatrix;
 		uniform mat4 TextureMatrix;
 
+		// directional light
+		uniform vec4 uDirectionalContrast;
+
 		// light buffers
 		#ifdef SHADER_STORAGE_LIGHTS
 		layout(std430, binding = 1) buffer LightBufferSSO
@@ -597,6 +600,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 	muTextureModulateColor.Init(hShader, "uTextureModulateColor");
 	muTextureBlendColor.Init(hShader, "uTextureBlendColor");
 	muTimer.Init(hShader, "timer");
+	muDirectionalContrast.Init(hShader, "uDirectionalContrast");
 
 	lights_index = glGetUniformLocation(hShader, "lights");
 	modelmatrix_index = glGetUniformLocation(hShader, "ModelMatrix");

--- a/src/common/rendering/gl/gl_shader.h
+++ b/src/common/rendering/gl/gl_shader.h
@@ -265,6 +265,7 @@ class FShader
 #ifdef NPOT_EMULATION
 	FBufferedUniform2f muNpotEmulation;
 #endif
+	FUniform4f muDirectionalContrast;
 
 	int lights_index;
 	int modelmatrix_index;

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -201,6 +201,8 @@ struct StreamData
 #ifdef NPOT_EMULATION
 	FVector2 uNpotEmulation;
 #endif
+
+	FVector4 uDirectionalContrast;
 };
 
 class FRenderState
@@ -295,6 +297,7 @@ public:
 #ifdef NPOT_EMULATION
 		mStreamData.uNpotEmulation = { 0,0 };
 #endif
+		mStreamData.uDirectionalContrast = { 0.0f, 0.0f, 0.0f, 0.0f };
 		mModelMatrix.loadIdentity();
 		mTextureMatrix.loadIdentity();
 		ClearClipSplit();
@@ -455,6 +458,11 @@ public:
 	void SetDetailParms(float xscale, float yscale, float bias)
 	{
 		mStreamData.uDetailParms = { xscale, yscale, bias, 0 };
+	}
+
+	void SetDirectionalContrast(FVector4 dl)
+	{
+		mStreamData.uDirectionalContrast = { dl.X, dl.Y, dl.Z, dl.W };
 	}
 
 	void SetDynLight(float r, float g, float b)

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -166,6 +166,8 @@ static const char *shaderBindings = R"(
 		#ifdef NPOT_EMULATION
 		vec2 uNpotEmulation;
 		#endif
+
+		vec4 uDirectionalContrast;
 	};
 
 	layout(set = 0, binding = 3, std140) uniform StreamUBO {
@@ -256,6 +258,7 @@ static const char *shaderBindings = R"(
 	#define uSplitBottomPlane data[uDataIndex].uSplitBottomPlane
 	#define uDetailParms data[uDataIndex].uDetailParms
 	#define uNpotEmulation data[uDataIndex].uNpotEmulation
+	#define uDirectionalContrast data[uDataIndex].uDirectionalContrast
 
 	#define SUPPORTS_SHADOWMAPS
 	#define VULKAN_COORDINATE_SYSTEM

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1665,6 +1665,8 @@ void FLevelLocals::Init()
 	deathsequence = info->deathsequence;
 
 	pixelstretch = info->pixelstretch;
+	directionalContrastMode = info->directionalcontrastmode;
+	directionalContrast = info->directionalcontrast;
 
 	compatflags.Callback();
 	compatflags2.Callback();

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -654,6 +654,7 @@ public:
 
 	FName		deathsequence;
 	float		pixelstretch;
+	int8_t		directionalContrastMode;
 	float		MusicVolume;
 
 	// Hardware render stuff that can either be set via CVAR or MAPINFO
@@ -662,6 +663,7 @@ public:
 	bool		lightadditivesurfaces;
 	bool		notexturefill;
 	int			ImpactDecalCount;
+	FVector4	directionalContrast;
 
 	FDynamicLight *lights;
 

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -282,6 +282,8 @@ void level_info_t::Reset()
 	outsidefogdensity = 0;
 	skyfog = 0;
 	pixelstretch = 1.2f;
+	directionalcontrastmode = 0;
+	directionalcontrast = FVector4(0, 0, 0, 0);
 
 	specialactions.Clear();
 	DefaultEnvironment = 0;
@@ -1428,6 +1430,29 @@ DEFINE_MAP_OPTION(pixelratio, false)
 	info->pixelstretch = (float)parse.sc.Float;
 }
 
+DEFINE_MAP_OPTION(directionalcontrastmode, false)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetNumber();
+	info->directionalcontrastmode = (int8_t)clamp(parse.sc.Number, 0, 2);
+}
+
+DEFINE_MAP_OPTION(directionalcontrast, true)
+{
+	parse.ParseAssign();
+	parse.sc.MustGetFloat();
+	info->directionalcontrast.X = (float)parse.sc.Float;
+	if (parse.format_type == FMapInfoParser::FMT_New) parse.sc.MustGetStringName(",");
+	parse.sc.MustGetFloat();
+	info->directionalcontrast.Y = (float)parse.sc.Float;
+	if (parse.format_type == FMapInfoParser::FMT_New) parse.sc.MustGetStringName(",");
+	parse.sc.MustGetFloat();
+	info->directionalcontrast.Z = (float)parse.sc.Float;
+	info->directionalcontrast.MakeUnit();
+	if (parse.format_type == FMapInfoParser::FMT_New) parse.sc.MustGetStringName(",");
+	parse.sc.MustGetFloat();
+	info->directionalcontrast.W = (float)parse.sc.Float;
+}
 
 DEFINE_MAP_OPTION(brightfog, false)
 {

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -352,6 +352,8 @@ struct level_info_t
 	int			outsidefogdensity;
 	int			skyfog;
 	float		pixelstretch;
+	int8_t		directionalcontrastmode;
+	FVector4	directionalcontrast;
 
 	// Redirection: If any player is carrying the specified item, then
 	// you go to the RedirectMap instead of this one.

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -213,7 +213,7 @@ void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, float ofsX, float o
 
 	float orientation = smf->xscale * smf->yscale * smf->zscale;
 
-	renderer->BeginDrawHUDModel(playermo->RenderStyle, objectToWorldMatrix, orientation < 0);
+	renderer->BeginDrawHUDModel(playermo->RenderStyle, smf, objectToWorldMatrix, orientation < 0);
 	RenderFrameModels(renderer, playermo->Level, smf, psp->GetState(), psp->GetTics(), playermo->player->ReadyWeapon->GetClass(), psp->Flags & PSPF_PLAYERTRANSLATED ? psp->Owner->mo->Translation : 0);
 	renderer->EndDrawHUDModel(playermo->RenderStyle);
 }
@@ -655,6 +655,10 @@ static void ParseModelDefLump(int Lump)
 					smf.rotationCenterX = 0.;
 					smf.rotationCenterY = 0.;
 					smf.rotationCenterZ = 0.;
+				}
+				else if (sc.Compare("nodirectionallightcontrast"))
+				{
+					smf.flags |= MDL_NODIRECTIONALCONTRAST;
 				}
 				else
 				{

--- a/src/r_data/models.h
+++ b/src/r_data/models.h
@@ -55,6 +55,7 @@ enum
 	MDL_BADROTATION					= 128,
 	MDL_DONTCULLBACKFACES			= 256,
 	MDL_USEROTATIONCENTER			= 512,
+	MDL_NODIRECTIONALCONTRAST		= 1024,
 };
 
 FSpriteModelFrame * FindModelFrame(const PClass * ti, int sprite, int frame, bool dropped);

--- a/src/rendering/hwrenderer/hw_models.cpp
+++ b/src/rendering/hwrenderer/hw_models.cpp
@@ -67,17 +67,20 @@ void FHWModelRenderer::BeginDrawModel(FRenderStyle style, FSpriteModelFrame *smf
 
 	state.mModelMatrix = objectToWorldMatrix;
 	state.EnableModelMatrix(true);
+	bool directionalContrastEnabled = level.info->directionalcontrastmode >= 1 && !(smf->flags & MDL_NODIRECTIONALCONTRAST);
+	if (directionalContrastEnabled) state.SetDirectionalContrast(di->GetDirectionalContrast());
 }
 
 void FHWModelRenderer::EndDrawModel(FRenderStyle style, FSpriteModelFrame *smf)
 {
+	state.SetDirectionalContrast(FVector4(0.f, 0.f, 0.f, 0.f));
 	state.EnableModelMatrix(false);
 	state.SetDepthFunc(DF_Less);
 	if (!(style == DefaultRenderStyle()) && !(smf->flags & MDL_DONTCULLBACKFACES))
 		state.SetCulling(Cull_None);
 }
 
-void FHWModelRenderer::BeginDrawHUDModel(FRenderStyle style, const VSMatrix &objectToWorldMatrix, bool mirrored)
+void FHWModelRenderer::BeginDrawHUDModel(FRenderStyle style, FSpriteModelFrame *smf, const VSMatrix &objectToWorldMatrix, bool mirrored)
 {
 	state.SetDepthFunc(DF_LEqual);
 
@@ -91,10 +94,13 @@ void FHWModelRenderer::BeginDrawHUDModel(FRenderStyle style, const VSMatrix &obj
 
 	state.mModelMatrix = objectToWorldMatrix;
 	state.EnableModelMatrix(true);
+	bool directionalContrastEnabled = level.info->directionalcontrastmode >= 1 && !(smf->flags & MDL_NODIRECTIONALCONTRAST);
+	if (directionalContrastEnabled) state.SetDirectionalContrast(di->GetDirectionalContrast());
 }
 
 void FHWModelRenderer::EndDrawHUDModel(FRenderStyle style)
 {
+	state.SetDirectionalContrast(FVector4(0.f, 0.f, 0.f, 0.f));
 	state.EnableModelMatrix(false);
 
 	state.SetDepthFunc(DF_Less);

--- a/src/rendering/hwrenderer/hw_models.h
+++ b/src/rendering/hwrenderer/hw_models.h
@@ -49,7 +49,7 @@ public:
 	void EndDrawModel(FRenderStyle style, FSpriteModelFrame *smf) override;
 	IModelVertexBuffer *CreateVertexBuffer(bool needindex, bool singleframe) override;
 	VSMatrix GetViewToWorldMatrix() override;
-	void BeginDrawHUDModel(FRenderStyle style, const VSMatrix &objectToWorldMatrix, bool mirrored) override;
+	void BeginDrawHUDModel(FRenderStyle style, FSpriteModelFrame *smf, const VSMatrix &objectToWorldMatrix, bool mirrored) override;
 	void EndDrawHUDModel(FRenderStyle style) override;
 	void SetInterpolation(double interpolation) override;
 	void SetMaterial(FGameTexture *skin, bool clampNoFilter, int translation) override;

--- a/src/rendering/hwrenderer/scene/hw_decal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_decal.cpp
@@ -57,6 +57,7 @@ void HWDecal::DrawDecal(HWDrawInfo *di, FRenderState &state)
 	state.SetTextureMode(decal->RenderStyle);
 	state.SetRenderStyle(decal->RenderStyle);
 	state.SetMaterial(texture, UF_Sprite, 0, CLAMP_XY, decal->Translation, -1);
+	state.SetDirectionalContrast(di->GetDirectionalContrast());
 
 
 	// If srcalpha is one it looks better with a higher alpha threshold
@@ -111,6 +112,7 @@ void HWDecal::DrawDecal(HWDrawInfo *di, FRenderState &state)
 	state.SetObjectColor(0xffffffff);
 	state.SetFog(fc, -1);
 	state.SetDynLight(0, 0, 0);
+	state.SetDirectionalContrast(FVector4(0.f, 0.f, 0.f, 0.f));
 }
 
 //==========================================================================

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -212,6 +212,7 @@ private:
 	PalEntry CalcLightColor(int light, PalEntry pe, int blendfactor);
 	float GetFogDensity(int lightlevel, PalEntry fogcolor, int sectorfogdensity, int blendfactor);
 	bool CheckFog(sector_t *frontsector, sector_t *backsector);
+	FVector4 GetDirectionalContrast(void);
 	WeaponLighting GetWeaponLighting(sector_t *viewsector, const DVector3 &pos, int cm, area_t in_area, const DVector3 &playerpos);
 public:
 

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -313,6 +313,8 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 
 	int rel = getExtraLight();
 
+	bool directionalContrastEnabled = level.info->directionalcontrastmode == 2;
+
 	state.SetNormal(plane.plane.Normal().X, plane.plane.Normal().Z, plane.plane.Normal().Y);
 
 	di->SetColor(state, lightlevel, rel, di->isFullbrightScene(), Colormap, alpha);
@@ -334,6 +336,7 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 	{
 		if (sector->special != GLSector_Skybox)
 		{
+			if (directionalContrastEnabled) state.SetDirectionalContrast(di->GetDirectionalContrast());
 			state.SetMaterial(texture, UF_Texture, 0, CLAMP_NONE, 0, -1);
 			SetPlaneTextureRotation(state, &plane, texture);
 			DrawSubsectors(di, state);
@@ -362,6 +365,7 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 		{
 			if (!texture->GetTranslucency()) state.AlphaFunc(Alpha_GEqual, gl_mask_threshold);
 			else state.AlphaFunc(Alpha_GEqual, 0.f);
+			if (directionalContrastEnabled) state.SetDirectionalContrast(di->GetDirectionalContrast());
 			state.SetMaterial(texture, UF_Texture, 0, CLAMP_NONE, 0, -1);
 			SetPlaneTextureRotation(state, &plane, texture);
 			DrawSubsectors(di, state);
@@ -369,6 +373,7 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 		}
 		state.SetRenderStyle(DefaultRenderStyle());
 	}
+	state.SetDirectionalContrast(FVector4(0.f, 0.f, 0.f, 0.f));
 	state.SetObjectColor(0xffffffff);
 	state.SetAddColor(0);
 	state.ApplyTextureManipulation(nullptr);

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -280,3 +280,7 @@ bool HWDrawInfo::CheckFog(sector_t *frontsector, sector_t *backsector)
 			 backsector->GetTexture(sector_t::ceiling)!=skyflatnum));
 }
 
+FVector4 HWDrawInfo::GetDirectionalContrast(void)
+{
+	return Level->directionalContrast;
+}

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -184,6 +184,8 @@ void HWWall::RenderTexturedWall(HWDrawInfo *di, FRenderState &state, int rflags)
 	int tmode = state.GetTextureMode();
 	int rel = rellight + getExtraLight();
 
+	bool directionalContrastEnabled = level.info->directionalcontrastmode == 2;
+
 	if (flags & HWWall::HWF_GLOW)
 	{
 		state.EnableGlow(true);
@@ -231,6 +233,7 @@ void HWWall::RenderTexturedWall(HWDrawInfo *di, FRenderState &state, int rflags)
 			state.SetObjectColor2((color1 != color2) ? color2 : PalEntry(0));
 			state.SetAddColor(side->GetAdditiveColor(tierndx, frontsector));
 			state.ApplyTextureManipulation(&tier.TextureFx);
+			if (directionalContrastEnabled) state.SetDirectionalContrast(di->GetDirectionalContrast());
 
 			if (color1 != color2)
 			{
@@ -303,6 +306,7 @@ void HWWall::RenderTexturedWall(HWDrawInfo *di, FRenderState &state, int rflags)
 	state.EnableGlow(false);
 	state.EnableGradient(false);
 	state.ApplyTextureManipulation(nullptr);
+	state.SetDirectionalContrast(FVector4(0.f, 0.f, 0.f, 0.f));
 }
 
 //==========================================================================

--- a/src/rendering/swrenderer/things/r_model.cpp
+++ b/src/rendering/swrenderer/things/r_model.cpp
@@ -314,7 +314,7 @@ namespace swrenderer
 		return objectToWorld;
 	}
 
-	void SWModelRenderer::BeginDrawHUDModel(FRenderStyle style, const VSMatrix &objectToWorldMatrix, bool mirrored)
+	void SWModelRenderer::BeginDrawHUDModel(FRenderStyle style, FSpriteModelFrame *smf, const VSMatrix &objectToWorldMatrix, bool mirrored)
 	{
 		const_cast<VSMatrix &>(objectToWorldMatrix).copy(ObjectToWorld.Matrix);
 		ClipTop = {};

--- a/src/rendering/swrenderer/things/r_model.h
+++ b/src/rendering/swrenderer/things/r_model.h
@@ -67,7 +67,7 @@ namespace swrenderer
 		void EndDrawModel(FRenderStyle style, FSpriteModelFrame *smf) override;
 		IModelVertexBuffer *CreateVertexBuffer(bool needindex, bool singleframe) override;
 		VSMatrix GetViewToWorldMatrix() override;
-		void BeginDrawHUDModel(FRenderStyle style, const VSMatrix &objectToWorldMatrix, bool mirrored) override;
+		void BeginDrawHUDModel(FRenderStyle style, FSpriteModelFrame *smf, const VSMatrix &objectToWorldMatrix, bool mirrored) override;
 		void EndDrawHUDModel(FRenderStyle style) override;
 		void SetInterpolation(double interpolation) override;
 		void SetMaterial(FTexture *skin, bool clampNoFilter, int translation) override;

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2663,6 +2663,49 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, setFrozen, setFrozen)
 	return 0;
 }
 
+static void SetDirectionalContrast(FLevelLocals* self, double x, double y, double z, double w)
+{
+	// normalize the vector
+	DVector3 dlv = DVector3(x, y, z);
+	dlv.MakeUnit();
+	self->directionalContrast = FVector4(dlv.X, dlv.Y, dlv.Z, w);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, SetDirectionalContrast, SetDirectionalContrast)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	PARAM_FLOAT(z);
+	PARAM_FLOAT(w);
+	SetDirectionalContrast(self, x, y, z, w);
+	return 0;
+}
+
+static void GetDirectionalContrastVec(FLevelLocals* self, DVector3* result)
+{
+	*result = DVector3(self->directionalContrast.X, self->directionalContrast.Y, self->directionalContrast.Z);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, GetDirectionalContrastVec, GetDirectionalContrastVec)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	DVector3 result;
+	GetDirectionalContrastVec(self, &result);
+	ACTION_RETURN_VEC3(result);
+}
+
+static double GetDirectionalContrastStr(FLevelLocals* self)
+{
+	return self->directionalContrast.W;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, GetDirectionalContrastStr, GetDirectionalContrastStr)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	ACTION_RETURN_FLOAT(GetDirectionalContrastStr(self));
+}
+
 //=====================================================================================
 //
 //
@@ -2772,6 +2815,7 @@ DEFINE_FIELD(FLevelLocals, fogdensity)
 DEFINE_FIELD(FLevelLocals, outsidefogdensity)
 DEFINE_FIELD(FLevelLocals, skyfog)
 DEFINE_FIELD(FLevelLocals, pixelstretch)
+DEFINE_FIELD(FLevelLocals, directionalContrastMode)
 DEFINE_FIELD(FLevelLocals, MusicVolume)
 DEFINE_FIELD(FLevelLocals, deathsequence)
 DEFINE_FIELD_BIT(FLevelLocals, frozenstate, frozen, 1)	// still needed for backwards compatibility.

--- a/wadsrc/static/shaders/glsl/material_normal.fp
+++ b/wadsrc/static/shaders/glsl/material_normal.fp
@@ -35,10 +35,23 @@ vec3 lightContribution(int i, vec3 normal)
 	}
 }
 
+float directionalContrastAttenuation(vec3 normal)
+{
+	vec3 lightdir = uDirectionalContrast.xyz;
+	return clamp(dot(lightdir, normal), 0.0, 1.0);
+}
+
 vec3 ProcessMaterialLight(Material material, vec3 color)
 {
 	vec4 dynlight = uDynLightColor;
 	vec3 normal = material.Normal;
+
+	if (uDirectionalContrast.w != 0 && normal != vec3(0.0))
+	{
+		float directionalContrastStrength = uDirectionalContrast.w;
+		dynlight.rgb += color * directionalContrastAttenuation(normal) * directionalContrastStrength;
+		color *= 1.0 - directionalContrastStrength;
+	}
 
 	if (uLightIndex >= 0)
 	{

--- a/wadsrc/static/shaders/glsl/material_pbr.fp
+++ b/wadsrc/static/shaders/glsl/material_pbr.fp
@@ -80,6 +80,36 @@ vec3 ProcessMaterialLight(Material material, vec3 ambientLight)
 
 	vec3 Lo = uDynLightColor.rgb;
 
+	if (uDirectionalContrast.w != 0.0 && N != vec3(0.0))
+	{
+		float directionalContrastStrength = uDirectionalContrast.w;
+
+		vec3 L = uDirectionalContrast.xyz;
+		float attenuation = clamp(dot(N, L), 0.0, 1.0);
+		if (attenuation > 0.0)
+		{
+			vec3 H = normalize(V + L);
+
+			vec3 radiance = ambientLight.rgb * attenuation * directionalContrastStrength;
+
+			// cook-torrance brdf
+			float NDF = DistributionGGX(N, H, roughness);
+			float G = GeometrySmith(N, V, L, roughness);
+			vec3 F = fresnelSchlick(clamp(dot(H, V), 0.0, 1.0), F0);
+
+			vec3 kS = F;
+			vec3 kD = (vec3(1.0) - kS) * (1.0 - metallic);
+
+			vec3 nominator = NDF * G * F;
+			float denominator = 4.0 * clamp(dot(N, V), 0.0, 1.0) * clamp(dot(N, L), 0.0, 1.0);
+			vec3 specular = nominator / max(denominator, 0.001);
+
+			Lo += (kD * albedo / PI + specular) * radiance;
+		}
+
+		ambientLight *= 1.0 - directionalContrastStrength;
+	}
+
 	if (uLightIndex >= 0)
 	{
 		ivec4 lightRange = ivec4(lights[uLightIndex]) + ivec4(uLightIndex + 1);

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -730,12 +730,16 @@ struct LevelLocals native
 	native readonly int outsidefogdensity;
 	native readonly int skyfog;
 	native readonly float pixelstretch;
+	native readonly int8 directionalcontrastmode;
 	native readonly float MusicVolume;
 	native name deathsequence;
 	native readonly int compatflags;
 	native readonly int compatflags2;
 // level_info_t *info cannot be done yet.
 
+	native void SetDirectionalContrast(double x, double y, double z, double w);
+	native Vector3 GetDirectionalContrastVec(void);
+	native double GetDirectionalContrastStr(void);
 	native String GetUDMFString(int type, int index, Name key);
 	native int GetUDMFInt(int type, int index, Name key);
 	native double GetUDMFFloat(int type, int index, Name key);


### PR DESCRIPTION
Continue dpJudas' work on directional contrast. For best results, EvenLighting is advised.

- New MAPINFO option: DirectionalContrastMode. 0 = default (no added contrast), 1 = affect models only, 2 = affect models and world textures (walls and flats).

- New MAPINFO option: DirectionalContrast = (X), (Y), (Z), (Strength). Sets the directional contrast vector, and strength. All defaults to 0.

- New ZScript functions: Level.SetDirectionalContrast(double x, double y, double z, double w), Level.GetDirectionalContrastVec() and Level.GetDirectionalContrastStr().

- New MODELDEF option: NoDirectionalContrast for disabling contrast effect on specific models.

Example file coming later, I need time to make it.