### PR TITLE
Optimize UE1 vertex normal computation

### DIFF
--- a/src/common/models/model_ue1.h
+++ b/src/common/models/model_ue1.h
@@ -13,7 +13,7 @@ public:
 		PT_TwoSided = 1,	// like normal, but don't cull backfaces
 		PT_Translucent = 2,	// additive blending
 		PT_Masked = 3,		// draw with alpha testing
-		PT_Modulated = 4,	// overlay-like blending (rgb values below 128 darken, 128 is unchanged, and above 128 lighten)
+		PT_Modulated = 4,	// modulated blending (src*dest*2)
 		// types mask
 		PT_Type = 7,
 		// flags
@@ -86,6 +86,8 @@ private:
 	struct UE1Vertex
 	{
 		FVector3 Pos, Normal;
+		TArray<int> P;	// polys that reference this vertex, used in normal computation to save time
+		int nP;	// count of those polys
 	};
 	struct UE1Poly
 	{
@@ -103,7 +105,7 @@ private:
 	int numFrames;
 	int numPolys;
 	int numGroups;
-	int weaponPoly;	// for future model attachment support, unused for now
+	TArray<int> specialPolys;	// for future model attachment support, unused for now
 
 	TArray<UE1Vertex> verts;
 	TArray<UE1Poly> polys;


### PR DESCRIPTION
Previously, vertices would loop through every triangle in the model and check if they were referenced. This was very slow and bad.

I've figured now that by storing poly refs beforehand, this would be sped up by a lot, and sure enough, it is much faster.

For very large models the speedup when loading can be up to 20x (tested with SWWM GZ).

(apologies for the small unrelated changes, those are just a bit of cleanup + futureproofing)