### PR TITLE
$PitchSet for SNDINFO

### DIFF
--- a/src/common/audio/sound/s_sound.cpp
+++ b/src/common/audio/sound/s_sound.cpp
@@ -404,6 +404,7 @@ FSoundChan *SoundEngine::StartSound(int type, const void *source,
 	// the referenced sound so some additional checks are required
 	int near_limit = sfx->NearLimit;
 	float limit_range = sfx->LimitRange;
+	float defpitch = sfx->DefPitch;
 	auto pitchmask = sfx->PitchMask;
 	rolloff = &sfx->Rolloff;
 
@@ -419,6 +420,7 @@ FSoundChan *SoundEngine::StartSound(int type, const void *source,
 			{
 				near_limit = newsfx->NearLimit;
 				limit_range = newsfx->LimitRange;
+				defpitch = newsfx->DefPitch;
 			}
 			if (rolloff->MinDistance == 0)
 			{
@@ -525,7 +527,7 @@ FSoundChan *SoundEngine::StartSound(int type, const void *source,
 		return NULL;
 	}
 
-	// Vary the sfx pitches.
+	// Vary the sfx pitches. Overridden by $PitchSet and A_StartSound.
 	if (pitchmask != 0)
 	{
 		pitch = DEFAULT_PITCH - (rand() & pitchmask) + (rand() & pitchmask);
@@ -596,9 +598,11 @@ FSoundChan *SoundEngine::StartSound(int type, const void *source,
 		{
 			chan->Source = source;
 		}
-
-		if (spitch > 0.0)
+		
+		if (spitch > 0.0)				// A_StartSound has top priority over all others.
 			SetPitch(chan, spitch);
+		else if (defpitch > 0.0)	// $PitchSet overrides $PitchShift
+			SetPitch(chan, defpitch);
 	}
 
 	return chan;
@@ -1490,6 +1494,7 @@ int SoundEngine::AddSoundLump(const char* logicalname, int lump, int CurrentPitc
 	newsfx.Volume = 1;
 	newsfx.Attenuation = 1;
 	newsfx.PitchMask = CurrentPitchMask;
+	newsfx.DefPitch = 0.0;
 	newsfx.NearLimit = nearlimit;
 	newsfx.LimitRange = 256 * 256;
 	newsfx.bRandomHeader = false;

--- a/src/common/audio/sound/s_soundinternal.h
+++ b/src/common/audio/sound/s_soundinternal.h
@@ -29,6 +29,7 @@ struct sfxinfo_t
 	uint8_t		PitchMask;
 	int16_t		NearLimit;				// 0 means unlimited
 	float		LimitRange;				// Range for sound limiting (squared for faster computations)
+	float		DefPitch;				// A defined pitch instead of a random one the sound plays at, similar to A_StartSound.
 
 	unsigned		bRandomHeader:1;
 	unsigned		bLoadRAW:1;

--- a/src/sound/s_advsound.cpp
+++ b/src/sound/s_advsound.cpp
@@ -132,6 +132,7 @@ enum SICommands
 	SI_MusicAlias,
 	SI_EDFOverride,
 	SI_Attenuation,
+	SI_PitchSet,
 };
 
 // Blood was a cool game. If Monolith ever releases the source for it,
@@ -218,6 +219,7 @@ static const char *SICommandStrings[] =
 	"$musicalias",
 	"$edfoverride",
 	"$attenuation",
+	"$pitchset",
 	NULL
 };
 
@@ -1033,6 +1035,17 @@ static void S_AddSNDINFO (int lump)
 				sfx = soundEngine->FindSoundTentative (sc.String);
 				sc.MustGetNumber ();
 				S_sfx[sfx].PitchMask = (1 << clamp (sc.Number, 0, 7)) - 1;
+				}
+				break;
+
+			case SI_PitchSet: {
+				// $pitchset <logical name> <pitch amount as float>
+				int sfx;
+
+				sc.MustGetString();
+				sfx = soundEngine->FindSoundTentative(sc.String);
+				sc.MustGetFloat();
+				S_sfx[sfx].DefPitch = (float)sc.Float;
 				}
 				break;
 


### PR DESCRIPTION
Added $PitchSet <logical name> <float> for SNDINFO.

- Sets the direct pitch of the sound to the specific float. Default is 0.0, meaning do not set a specific pitch. Regular pitch is 1.0.
- Only works for direct sound definitions.
- Overrides $PitchShift unless value is <= 0.0
- Overridden by A_StartSound's pitch parameter if the value > 0.0.