### PR TITLE
- fixed: the minotaur spawned its floor flames regardless of the sett…

### DIFF
--- a/wadsrc/static/zscript/actors/raven/minotaur.zs
+++ b/wadsrc/static/zscript/actors/raven/minotaur.zs
@@ -347,7 +347,7 @@ class Minotaur : Actor
 		}
 		else
 		{
-			if (Floorclip > 0 && (Level.compatflags & COMPAT_MINOTAUR))
+			if (Floorclip > 0 && (Level.compatflags & COMPATF_MINOTAUR))
 			{
 				// only play the sound. 
 				A_StartSound ("minotaur/fx2hit", CHAN_WEAPON);


### PR DESCRIPTION
…ing of compat_minotaur

A_MinotaurAtk3 was checking against the CVAR instead of the compatibility flag constant.