### PR TITLE
Fix obscure error in Animated Doors where the Actor can be NULL

### DIFF
--- a/src/playsim/mapthinkers/a_doors.cpp
+++ b/src/playsim/mapthinkers/a_doors.cpp
@@ -766,7 +766,7 @@ bool FLevelLocals::EV_SlidingDoor (line_t *line, AActor *actor, int tag, int spe
 		// Make sure door isn't already being animated
 		if (sec->ceilingdata != NULL )
 		{
-			if (actor->player == NULL)
+			if (actor == NULL || actor->player == NULL)
 				return false;
 
 			if (sec->ceilingdata->IsA (RUNTIME_CLASS(DAnimatedDoor)))


### PR DESCRIPTION
This is a quick fix for an error in which Animated Doors crash the game by trying to check "actor->player" when "actor" itself is NULL.  Deleting the check entirely also worked, but I worried it might be there for some higher-level scripting reason.  This just puts in a check to make sure actor isn't NULL before checking actor->player, and keeps the behavior in that case the same.

I think this was happening because I had doors being opened by projectiles (like in Metroid) which were being despawned into NULL pointers when they hit the doors, as this was an issue when initially programming said doors..