### PR TITLE
RandomSpawner Expansion

### DIFF
--- a/wadsrc/static/zscript/actors/shared/randomspawner.zs
+++ b/wadsrc/static/zscript/actors/shared/randomspawner.zs
@@ -21,7 +21,7 @@ class RandomSpawner : Actor
 	{}
 
 	// NOTE: Actor WILL return null if called before PostBeginPlay can process!
-	// Wait one tic before using this function to get the actor.
+	// Wait one tic after spawn before using this function to get the actor.
 	Actor, Name GetSpawned()
 	{	return Spawned, Chosen;	}
 	
@@ -240,7 +240,10 @@ class RandomSpawner : Actor
 				newmobj.CheckMissileSpawn(0);
 			// Bouncecount is used to count how many recursions we're in.
 			if (newmobj is 'RandomSpawner')
+			{
 				newmobj.bouncecount = ++bouncecount;
+				if (bBOSS)	newmobj.bBOSS = true;
+			}
 			// If the spawned actor has either of those flags, it's a boss.
 			if (newmobj.bBossDeath || newmobj.bBoss)
 				boss = true;

--- a/wadsrc/static/zscript/actors/shared/randomspawner.zs
+++ b/wadsrc/static/zscript/actors/shared/randomspawner.zs
@@ -6,7 +6,8 @@ class RandomSpawner : Actor
 	
 	const MAX_RANDOMSPAWNERS_RECURSION = 32; // Should be largely more than enough, honestly.
 	
-	Name Chosen;
+	protected Name Chosen;
+	protected Actor Spawned;
 
 	Default
 	{
@@ -18,6 +19,11 @@ class RandomSpawner : Actor
 	
 	virtual void PostSpawn(Actor spawned)
 	{}
+
+	// NOTE: Actor WILL return null if called before PostBeginPlay can process!
+	// Wait one tic before using this function to get the actor.
+	Actor, Name GetSpawned()
+	{	return Spawned, Chosen;	}
 	
 	static bool IsMonster(DropItem di)
 	{
@@ -243,6 +249,7 @@ class RandomSpawner : Actor
 			if (rep && (rep.bBossDeath || rep.bBoss))
 				boss = true;
 
+			Spawned = newmobj;
 			PostSpawn(newmobj);
 		}
 		if (boss)

--- a/wadsrc/static/zscript/actors/shared/randomspawner.zs
+++ b/wadsrc/static/zscript/actors/shared/randomspawner.zs
@@ -6,6 +6,8 @@ class RandomSpawner : Actor
 	
 	const MAX_RANDOMSPAWNERS_RECURSION = 32; // Should be largely more than enough, honestly.
 	
+	Name Chosen;
+
 	Default
 	{
 		+NOBLOCKMAP
@@ -106,6 +108,7 @@ class RandomSpawner : Actor
 	{
 		Super.BeginPlay();
 		let s = ChooseSpawn();
+		Chosen = s;
 
 		if (s == 'Unknown') // Spawn error markers immediately.
 		{
@@ -162,7 +165,7 @@ class RandomSpawner : Actor
 		}
 
 		Actor newmobj = null;
-		bool boss = false;
+		bool boss = (bBOSS || bBOSSDEATH);
 
 		if (Species == 'None')
 		{

--- a/wadsrc/static/zscript/actors/shared/randomspawner.zs
+++ b/wadsrc/static/zscript/actors/shared/randomspawner.zs
@@ -5,7 +5,7 @@ class RandomSpawner : Actor
 {
 	
 	const MAX_RANDOMSPAWNERS_RECURSION = 32; // Should be largely more than enough, honestly.
-	
+	protected bool fakeboss;
 	protected Name Chosen;
 	protected Actor Spawned;
 
@@ -171,7 +171,8 @@ class RandomSpawner : Actor
 		}
 
 		Actor newmobj = null;
-		bool boss = (bBOSS || bBOSSDEATH);
+		fakeboss = (bBOSS || bBOSSDEATH);
+		bool boss = false;
 
 		if (Species == 'None')
 		{
@@ -255,7 +256,7 @@ class RandomSpawner : Actor
 			Spawned = newmobj;
 			PostSpawn(newmobj);
 		}
-		if (boss)
+		if (boss || fakeboss)
 			tracer = newmobj;
 		else	// "else" because a boss-replacing spawner must wait until it can call A_BossDeath.
 			Destroy();
@@ -266,7 +267,8 @@ class RandomSpawner : Actor
 		Super.Tick();
 		if (tracer == null || tracer.health <= 0)
 		{
-			A_BossDeath();
+			if (!fakeboss)
+				A_BossDeath();
 			Destroy();
 		}
 	}


### PR DESCRIPTION
- If given the BOSS(DEATH) flags, RandomSpawners will remain as if the spawned had those flags.
- Now records the selected name from ChooseSpawn to Chosen variable, and the newly created actor to Spawned.
- Original actor and Chosen name can be retrieved with GetSpawn().
- Both are protected to help identify difference between the main spawned and the tracer in the event the latter is changed.
- BOSS flag will transfer to future RandomSpawners, but BOSSDEATH won't.