### PR TITLE
Add species parameter to A_RadiusThrust

### DIFF
--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -400,7 +400,7 @@ enum
 };
 int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, int distance, int fulldmgdistance, bool oldradiusdmg);
 int	P_RadiusAttack (AActor *spot, AActor *source, int damage, int distance, 
-						FName damageType, int flags, int fulldamagedistance=0);
+						FName damageType, int flags, int fulldamagedistance=0, FName species = NAME_None);
 
 void	P_DelSeclist(msecnode_t *, msecnode_t *sector_t::*seclisthead);
 void	P_DelSeclist(portnode_t *, portnode_t *FLinePortal::*seclisthead);

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5878,7 +5878,7 @@ int P_GetRadiusDamage(AActor *self, AActor *thing, int damage, int distance, int
 //==========================================================================
 
 int P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bombdistance, FName bombmod,
-	int flags, int fulldamagedistance)
+	int flags, int fulldamagedistance, FName species)
 {
 	if (bombdistance <= 0)
 		return 0;
@@ -5925,6 +5925,11 @@ int P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, int bom
 			((bombsource->flags6 & MF6_DONTHARMSPECIES) && (thing->GetSpecies() == bombsource->GetSpecies()))
 			)
 			)	continue;
+
+		if((species != NAME_None) && (thing->Species != species))
+		{
+			continue;
+		}
 
 		targets.Push(thing);
 	}

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1243,9 +1243,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetRadiusDamage, P_GetRadiusDamage)
 	ACTION_RETURN_INT(P_GetRadiusDamage(self, thing, damage, distance, fulldmgdistance, oldradiusdmg));
 }
 
-static int RadiusAttack(AActor *self, AActor *bombsource, int bombdamage, int bombdistance, int damagetype, int flags, int fulldamagedistance)
+static int RadiusAttack(AActor *self, AActor *bombsource, int bombdamage, int bombdistance, int damagetype, int flags, int fulldamagedistance, int species)
 {
-	return P_RadiusAttack(self, bombsource, bombdamage, bombdistance, ENamedName(damagetype), flags, fulldamagedistance);
+	return P_RadiusAttack(self, bombsource, bombdamage, bombdistance, ENamedName(damagetype), flags, fulldamagedistance, ENamedName(species));
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, RadiusAttack, RadiusAttack)
@@ -1257,7 +1257,8 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, RadiusAttack, RadiusAttack)
 	PARAM_INT(damagetype);
 	PARAM_INT(flags);
 	PARAM_INT(fulldamagedistance);
-	ACTION_RETURN_INT(RadiusAttack(self, bombsource, bombdamage, bombdistance, damagetype, flags, fulldamagedistance));
+	PARAM_INT(species);
+	ACTION_RETURN_INT(RadiusAttack(self, bombsource, bombdamage, bombdistance, damagetype, flags, fulldamagedistance, species));
 }
 
 static int ZS_GetSpriteIndex(int sprt)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1109,7 +1109,7 @@ class Actor : Thinker native
 	native void A_Burst(class<Actor> chunktype);
 	native void A_RadiusDamageSelf(int damage = 128, double distance = 128, int flags = 0, class<Actor> flashtype = null);
 	native int GetRadiusDamage(Actor thing, int damage, int distance, int fulldmgdistance = 0, bool oldradiusdmg = false);
-	native int RadiusAttack(Actor bombsource, int bombdamage, int bombdistance, Name bombmod = 'none', int flags = RADF_HURTSOURCE, int fulldamagedistance = 0);
+	native int RadiusAttack(Actor bombsource, int bombdamage, int bombdistance, Name bombmod = 'none', int flags = RADF_HURTSOURCE, int fulldamagedistance = 0, name species = "None");
 	
 	native void A_Respawn(int flags = 1);
 	native void A_RestoreSpecialPosition();

--- a/wadsrc/static/zscript/actors/attacks.zs
+++ b/wadsrc/static/zscript/actors/attacks.zs
@@ -613,7 +613,7 @@ extend class Actor
 	//
 	//==========================================================================
 
-	void A_RadiusThrust(int force = 128, int distance = -1, int flags = RTF_AFFECTSOURCE, int fullthrustdistance = 0)
+	void A_RadiusThrust(int force = 128, int distance = -1, int flags = RTF_AFFECTSOURCE, int fullthrustdistance = 0, name species = "None")
 	{
 		if (force == 0) force = 128;
 		if (distance <= 0) distance = abs(force);
@@ -628,7 +628,7 @@ extend class Actor
 				target.bNoDamageThrust = false;
 			}
 		}
-		RadiusAttack (target, force, distance, DamageType, flags | RADF_NODAMAGE, fullthrustdistance);
+		RadiusAttack (target, force, distance, DamageType, flags | RADF_NODAMAGE, fullthrustdistance, species);
 		CheckSplash(distance);
 		if (target) target.bNoDamageThrust = nothrust;
 	}


### PR DESCRIPTION
`species` is the last parameter for `A_RadiusThrust()` DECORATE function.
If it is omitted or none, then `A_RadiusThrust` will behave as usual.

If it is set for some species name, it will thrust only that species.
Of course, these species should be `+VULNERABLE` to be thrustable.

Demo WAD file: [test.wad.gz](https://github.com/coelckers/gzdoom/files/5105422/test.wad.gz)
It is MAP01 with two switches and two candlesticks, each one start thrusting objects (stimpacks and medikits) if the corresponding switch is activated. One of them (left relative to player, or upper on map view) thrusting all objects (like default behavior of `A_RadiusThrust`), the other one (right relative to player, or lower on map view) thrusting only objects of `"Thrustable"` species. All medikits are of `"NonThrustable"` species, so they are thrusted only by upper candlestick; stimpacks are of `"Thrustable"` species, so they are thrusted by both candlesticks. Distance of thrust is limited, so farthest stimpacks and medikits are not affected, while nearest are.