### PR TITLE
P_CheckPosition optimization

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -1298,14 +1298,14 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 	if (thing == tm.thing)
 		return true;
 
+	if ((thing->flags2 | tm.thing->flags2) & MF2_THRUACTORS)
+		return true;
+
 	if (!((thing->flags & (MF_SOLID | MF_SPECIAL | MF_SHOOTABLE)) || thing->flags6 & MF6_TOUCHY))
 		return true;	// can't hit thing
 
 	double blockdist = thing->radius + tm.thing->radius;
 	if (fabs(thing->X() - cres.Position.X) >= blockdist || fabs(thing->Y() - cres.Position.Y) >= blockdist)
-		return true;
-
-	if ((thing->flags2 | tm.thing->flags2) & MF2_THRUACTORS)
 		return true;
 
 	if ((tm.thing->flags6 & MF6_THRUSPECIES) && (tm.thing->GetSpecies() == thing->GetSpecies()))
@@ -1787,6 +1787,7 @@ bool P_CheckPosition(AActor *thing, const DVector2 &pos, FCheckPosition &tm, boo
 	FMultiBlockThingsIterator it2(pcheck, thing->Level, pos.X, pos.Y, thing->Z(), thing->Height, thing->radius, false, newsec);
 	FMultiBlockThingsIterator::CheckResult tcres;
 
+	if (!(thing->flags2 & MF2_THRUACTORS))
 	while ((it2.Next(&tcres)))
 	{
 		if (!PIT_CheckThing(it2, tcres, it2.Box(), tm))


### PR DESCRIPTION
- If the actor passed into the function has THRUACTORS, PIT_CheckThing won't be called anymore.
- Moved THRUACTORS check to just under the self clipping check in PIT_CheckThing.