### PR TITLE
CanCrossLine Virtual

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -725,6 +725,9 @@ public:
 	virtual void Touch(AActor *toucher);
 	void CallTouch(AActor *toucher);
 
+	// Performs the CanCrossLine virtual on ZScript's side.
+	bool CanCrossLine(line_t *line, int side);
+
 	// Centaurs and ettins squeal when electrocuted, poisoned, or "holy"-ed
 	// Made a metadata property so no longer virtual
 	void Howl ();

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -959,6 +959,10 @@ bool PIT_CheckLine(FMultiBlockLinesIterator &mit, FMultiBlockLinesIterator::Chec
 		}
 	}
 
+	// [MC] Allow modders some capability of control on ZScript's side.
+	if (!tm.thing->CanCrossLine(ld, P_PointOnLineSide(cres.Position, ld)))
+		return false;
+
 	// If the floor planes on both sides match we should recalculate open.bottom at the actual position we are checking
 	// This is to avoid bumpy movement when crossing a linedef with the same slope on both sides.
 	// This should never narrow down the opening, though, only widen it.
@@ -1048,7 +1052,21 @@ bool PIT_CheckLine(FMultiBlockLinesIterator &mit, FMultiBlockLinesIterator::Chec
 		spec.Oldrefpos = tm.thing->PosRelative(ld);
 		portalhit.Push(spec);
 	}
+	
+	return true;
+}
 
+bool AActor::CanCrossLine(line_t *line, int side)
+{
+	IFVIRTUAL(AActor, CanCrossLine)
+	{
+		VMValue params[3] = { (DObject*)this, line, side };
+		VMReturn ret;
+		int retval;
+		ret.IntAt(&retval);
+		VMCall(func, params, 3, &ret, 1);
+		return retval;
+	}
 	return true;
 }
 

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -462,6 +462,13 @@ class Actor : Thinker native
 	private native void Substitute(Actor replacement);
 	native ui void DisplayNameTag();
 
+	// Called by PIT_CheckLine after processing the line for primary cases.
+	// Returning false means the line will block.
+	virtual bool CanCrossLine(Line crossing, int side)
+	{
+		return true;
+	}
+
 	// Called by inventory items to see if this actor is capable of touching them.
 	// If true, the item will attempt to be picked up. Useful for things like
 	// allowing morphs to pick up limited items such as keys while preventing
@@ -791,8 +798,6 @@ class Actor : Thinker native
 	{
 		return 1. / (1 << (accuracy * 5 / 100));
 	}
-
-	
 	
 	protected native void DestroyAllInventory();	// This is not supposed to be called by user code!
 	native clearscope Inventory FindInventory(class<Inventory> itemtype, bool subclass = false) const;


### PR DESCRIPTION
Added CanCrossLine virtual.

- Allows actors to determine what lines can be crossed, after the original line checks are handled.