### PR TITLE
Removed some time specifiers that aren't standard and can crash GZDoom

### DIFF
--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2682,7 +2682,7 @@ static int GetEpochTime()
 static FString CheckStrfString(FString timeForm)
 {
 	// Valid Characters after %
-	const char validSingles[] = { 'a','A','b','B','c','C','d','D','e','F','G','g','h','H','I','j','k','l','m','M','n','p','P','r','R','s','S','t','T','u','U','V','w','W','x','X','y','Y','z','Z' };
+	const char validSingles[] = { 'a','A','b','B','c','C','d','D','e','F','g','G','h','H','I','j','m','M','n','p','r','R','S','t','T','u','U','V','w','W','x','X','y','Y','z','Z' };
 
 	timeForm.Substitute("%%", "%a"); //Prevent %% from causing tokenizing problems
 	timeForm = "a" + timeForm; //Prevent %* at the beginning from causing a false error from tokenizing


### PR DESCRIPTION
A number of the specifiers allowed were GNU extensions that aren't actually standard and would crash GZDoom on Windows. They've been updated to actually reflect what the standards actually [guarentee](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf) (page 344).