### PR TITLE
Display other kills in coop tally screen

### DIFF
--- a/src/g_hub.cpp
+++ b/src/g_hub.cpp
@@ -54,6 +54,7 @@ struct FHubInfo
 {
 	int			levelnum;
 	
+	int			totalkills;
 	int			maxkills;
 	int			maxitems;
 	int			maxsecret;
@@ -63,11 +64,12 @@ struct FHubInfo
 
 	FHubInfo &operator=(const wbstartstruct_t &wbs)
 	{
-		levelnum = wbs.finished_ep;
-		maxkills = wbs.maxkills;
-		maxsecret= wbs.maxsecret;
-		maxitems = wbs.maxitems;
-		maxfrags = wbs.maxfrags;
+		levelnum	= wbs.finished_ep;
+		totalkills	= wbs.totalkills;
+		maxkills	= wbs.maxkills;
+		maxsecret	= wbs.maxsecret;
+		maxitems	= wbs.maxitems;
+		maxfrags	= wbs.maxfrags;
 		memcpy(plyr, wbs.plyr, sizeof(plyr));
 		return *this;
 	}
@@ -107,6 +109,7 @@ void G_LeavingHub(FLevelLocals *Level, int mode, cluster_info_t * cluster, wbsta
 
 		if (mode != FINISH_SameHub)
 		{
+			wbs->totalkills = Level->killed_monsters;
 			wbs->maxkills = wbs->maxitems = wbs->maxsecret = 0;
 			for (i = 0; i < MAXPLAYERS; i++)
 			{
@@ -169,6 +172,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, FHubInfo &h, FHubInfo 
 	if (arc.BeginObject(key))
 	{
 		arc("levelnum", h.levelnum)
+			("totalkills", h.totalkills)
 			("maxkills", h.maxkills)
 			("maxitems", h.maxitems)
 			("maxsecret", h.maxsecret)

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -926,6 +926,7 @@ bool FLevelLocals::DoCompleted (FString nextlevel, wbstartstruct_t &wminfo)
 	nextlevel = wminfo.next;
 
 	wminfo.next_ep = FindLevelInfo (wminfo.next)->cluster - 1;
+	wminfo.totalkills = killed_monsters;
 	wminfo.maxkills = total_monsters;
 	wminfo.maxitems = total_items;
 	wminfo.maxsecret = total_secrets;

--- a/src/wi_stuff.cpp
+++ b/src/wi_stuff.cpp
@@ -863,6 +863,7 @@ DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, nextauthor);
 DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, thisauthor);
 DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, LName0);
 DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, LName1);
+DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, totalkills);
 DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, maxkills);
 DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, maxitems);
 DEFINE_FIELD_X(WBStartStruct, wbstartstruct_t, maxsecret);

--- a/src/wi_stuff.h
+++ b/src/wi_stuff.h
@@ -61,6 +61,7 @@ struct wbstartstruct_t
 	FTextureID	LName0;
 	FTextureID	LName1;
 
+	int			totalkills;
 	int			maxkills;
 	int			maxitems;
 	int			maxsecret;

--- a/wadsrc/static/language.csv
+++ b/wadsrc/static/language.csv
@@ -1172,14 +1172,15 @@ Color,SCORE_COLOR,,,Colour,Barva,Farbe,Χρώμα,Koloro,,,Väri,Couleur,Szín,C
 Secret,SCORE_SECRET,,,,Tajemství,Geheimnis,Μυστικό,Sekreta,Secreto,,Salat,,Rejtély,Segreto,シークレット,밝혀낸 비밀,Geheim,Sekret,Segredo,,Secret,Тайники,Тајна
 Name,SCORE_NAME,,,,Jméno,Name,Όνομα,Nomo,Nombre,,Nimi,Nom,Név,Nome,名前,이름,Naam,Nazwa,Nome,,Nume,Имя,Име
 Delay (ms),SCORE_DELAY,,,,Zpoždění (ms),Verzögerung (ms),Kαθυστέρηση (μδ),Prokrasto (ms),Retraso (ms),,Viive (ms),Délai (ms),Késleltetés (ms),Ritardo (ms) ,ping,핑 (밀리초당),Vertraging (ms),Opóźnienie (ms),Atraso (ms),,Întârziere (ms),Задержка (мс),Кашњење (мс)
-Kills,SCORE_KILLS,,,,Zabití,,Σκοτομοί,Mortigoj,Asesinatos,,Tapot,Victimes,Ölések,Uccisioni,キル,킬수,Doodt,Zabójstwa,Vítimas,,Ucideri,Убийства,Убиства
+Kills,SCORE_KILLS,,,,Zabití,,Σκοτομοί,Mortigoj,Asesinatos,,Tapot,Victimes,Ölések,Uccisioni,キル,킬수,Dood,Zabójstwa,Vítimas,,Ucideri,Убийства,Убиства
 Frags,SCORE_FRAGS,,,,Fragy,,Κοματιασμοί,Ĉesoj,Bajas,,Frägit,,Fragek,Frags,フラグ,플레이어 킬수,Frags,Fragi,,,Victime,Фраги,Фрагови
-Deaths,SCORE_DEATHS,,,,Smrti,Tode,Θάνατοι,Mortoj,Muertes,,Kuolemat,Morts,Halálok,Morti,デス,사망한 횟수,Overlijden,Śmierci,Mortes,,Decese,Смерти,Смрти
+Deaths,SCORE_DEATHS,,,,Smrti,Tode,Θάνατοι,Mortoj,Muertes,,Kuolemat,Morts,Halálok,Morti,デス,사망한 횟수,Doden,Śmierci,Mortes,,Decese,Смерти,Смрти
+Other,SCORE_OTHER,,,,,Anders,,,,,Muu,Autre,,,,,Anders,,,,,,
 Missed,SCORE_MISSED,,,,Minuto,Verfehlt,Ξεχάστηκαν,Mankita,Pérdidas,,Hudit,Ratés,Kihagyva,Mancati ,ミス,놓친 수,Gemist,Ominięte,Perdido,,Ratate,Пропущено,Промашаји
 Total,SCORE_TOTAL,,,,Celkem,Gesamt,Συνολικό,Tuta,,,Yhteensä,Total,Összesen,Totale,合計,총점,Totaal,Totalne,Total,,Total,Всего,Укупно
 Level Time,SCORE_LVLTIME,,,,Čas v levelu,Levelzeit,Χρόνος Πίστας,Nivel Daŭro,Tiempo de nivel,,Tasoaika,Temps niveau,Szint Idő,Tempo Livello ,時間,레벨 시간,Niveau Tijd,Czas,Tempo de Fase,Tempo do Nível,Timp Petrecut,Время уровня,Време нивоа
 ,,Level Summary,,,,,,,,,,,,,,,,,,,,,
-Kills,TXT_IMKILLS,,,,Zabití,,Σκοτομοί,Mortigoj,Muertes,,Tapot,Morts,Áldozatok,Uccisioni,キル,킬수,Doodt,Zabójstwa,Vítimas,,Ucideri,Враги,Убиства
+Kills,TXT_IMKILLS,,,,Zabití,,Σκοτομοί,Mortigoj,Muertes,,Tapot,Morts,Áldozatok,Uccisioni,キル,킬수,Dood,Zabójstwa,Vítimas,,Ucideri,Враги,Убиства
 Items,TXT_IMITEMS,,,,Předměty,Gegenstände,Αντεικείμενα,Aĵoj,Objetos,,Esineet,Objets,Tárgyak,Oggetti,アイテム,획득한 아이템,Artikelen,Przedmioty,Itens,,Obiecte,Предметы,Ставке
 Secrets,TXT_IMSECRETS,,,,Tajemství,Geheimnisse,Μυστικά,Sekretoj,Secretos,,Salat,,Rejtekhelyek,Segreti,シークレット,밝혀낸 비밀,Geheimen,Sekrety,Segredos,,Secrete,Тайники,Тајне
 Time,TXT_IMTIME,,,,Čas,Zeit,Χρόνος,Daŭro,Tiempo,,Aika,Temps,Idő,Tempo,経過時間,소모한 시간,Tijd,Czas,Tempo,,Timp,Время,Време

--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -86,7 +86,9 @@ class StatusScreen abstract play version("2.5")
 	int				CurState;				// specifies current CurState
 	wbstartstruct	wbs;				// contains information passed into intermission
 	wbplayerstruct	Plrs[MAXPLAYERS];				// wbs.plyr[]
+	int				otherkills;
 	int				cnt;				// used for general timing
+	int				cnt_otherkills;
 	int				cnt_kills[MAXPLAYERS];
 	int				cnt_items[MAXPLAYERS];
 	int				cnt_secret[MAXPLAYERS];
@@ -842,7 +844,12 @@ class StatusScreen abstract play version("2.5")
 		acceleratestage = 0;
 		cnt = bcnt = 0;
 		me = wbs.pnum;
-		for (int i = 0; i < MAXPLAYERS; i++) Plrs[i] = wbs.plyr[i];
+		otherkills = wbs.totalkills;
+		for (int i = 0; i < MAXPLAYERS; i++)
+		{
+			Plrs[i] = wbs.plyr[i];
+			otherkills -= Plrs[i].skills;
+		}
 		
 		entering.Init(gameinfo.mStatscreenEnteringFont);
 		finished.Init(gameinfo.mStatscreenFinishedFont);

--- a/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
@@ -71,6 +71,7 @@ class CoopStatusScreen : StatusScreen
 				if (dofrags)
 					cnt_frags[i] = fragSum (i);
 			}
+			cnt_otherkills = otherkills;
 			PlaySound("intermission/nextstage");
 			ng_state = 10;
 		}

--- a/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
@@ -36,6 +36,8 @@ class CoopStatusScreen : StatusScreen
 			dofrags += fragSum (i);
 		}
 
+		cnt_otherkills = 0;
+
 		dofrags = !!dofrags;
 	}
 
@@ -92,7 +94,14 @@ class CoopStatusScreen : StatusScreen
 				else
 					stillticking = true;
 			}
-		
+
+			cnt_otherkills += 2;
+
+			if (cnt_otherkills > otherkills)
+				cnt_otherkills = otherkills;
+			else
+				stillticking = true;
+
 			if (!stillticking)
 			{
 				PlaySound("intermission/nextstage");
@@ -215,7 +224,7 @@ class CoopStatusScreen : StatusScreen
 		int pwidth = IntermissionFont.GetCharWidth("%");
 		int icon_x, name_x, kills_x, bonus_x, secret_x;
 		int bonus_len, secret_len;
-		int missed_kills, missed_items, missed_secrets;
+		int other_kills, missed_kills, missed_items, missed_secrets;
 		float h, s, v, r, g, b;
 		int color;
 		String text_bonus, text_secret, text_kills;
@@ -258,6 +267,7 @@ class CoopStatusScreen : StatusScreen
 		drawTextScaled(displayFont, secret_x - secret_len * FontScale, y, text_secret, FontScale, textcolor);
 		y += int(height + 6 * FontScale);
 
+		other_kills = cnt_otherkills;
 		missed_kills = wbs.maxkills;
 		missed_items = wbs.maxitems;
 		missed_secrets = wbs.maxsecret;
@@ -296,8 +306,14 @@ class CoopStatusScreen : StatusScreen
 			y += lineheight + CleanYfac;
 		}
 
-		// Draw "MISSED" line
+		// Draw "OTHER" line
 		y += 3 * CleanYfac;
+		drawTextScaled(displayFont, name_x, y, Stringtable.Localize("$SCORE_OTHER"), FontScale, Font.CR_DARKGRAY);
+		drawPercentScaled(displayFont, kills_x, y, other_kills, wbs.maxkills, FontScale, Font.CR_DARKGRAY);
+		missed_kills -= cnt_otherkills;
+
+		// Draw "MISSED" line
+		y += height + 3 * CleanYfac;
 		drawTextScaled(displayFont, name_x, y, Stringtable.Localize("$SCORE_MISSED"), FontScale, Font.CR_DARKGRAY);
 		drawPercentScaled(displayFont, kills_x, y, missed_kills, wbs.maxkills, FontScale, Font.CR_DARKGRAY);
 		if (ng_state >= 4)

--- a/wadsrc/static/zscript/ui/statscreen/types.zs
+++ b/wadsrc/static/zscript/ui/statscreen/types.zs
@@ -30,6 +30,7 @@ struct WBStartStruct native version("2.4")
 	native TextureID	LName0;
 	native TextureID	LName1;
 
+	native int			totalkills;
 	native int			maxkills;
 	native int			maxitems;
 	native int			maxsecret;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16033706/91647624-7f815400-ea65-11ea-824b-5343d7906ac2.png)

Yay, I did it! The number of other kills counts up together with the personal kills. I added translations in Dutch (my native language), German, French, and Finnish, because I know these languages well enough to know those terms are correct.

The commit also includes some mistakes in Dutch, as "kills" was translated as the 3rd pers. s. of the verb "to kill", and "deaths" would have been reversely translated as "deceased" or "passed away".