### PR TITLE
Time in coop tally

### DIFF
--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -515,7 +515,6 @@ class StatusScreen abstract play version("2.5")
 
 	void drawTimeScaled (Font fnt, int x, int y, int t, double scale, int color = Font.CR_UNTRANSLATED)
 	{
-		int sec = Thinker.Tics2Seconds(Plrs[me].stime);
 		if (t < 0)
 			return;
 
@@ -525,23 +524,7 @@ class StatusScreen abstract play version("2.5")
 		t -= minutes * 60;
 		int seconds = t;
 
-		String s = "";
-		if (hours > 0)
-		{
-			s = String.Format("%d", hours) .. ":";
-		}
-
-		if (hours > 0 || minutes < 10)
-		{
-			s = s .. "0";
-		}
-		s = s .. String.Format("%d", minutes) .. ":";
-
-		if (seconds < 10)
-		{
-			s = s .. "0";
-		}
-		s = s .. String.Format("%d", seconds);
+		String s = (hours > 0 ? String.Format("%d:", hours) : "") .. String.Format("%02d:%02d", minutes, seconds);
 
 		drawTextScaled(fnt, x - fnt.StringWidth(s) * scale, y, s, scale, color);
 	}

--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -509,6 +509,45 @@ class StatusScreen abstract play version("2.5")
 
 	//====================================================================
 	//
+	// Display the completed time scaled
+	//
+	//====================================================================
+
+	void drawTimeScaled (Font fnt, int x, int y, int t, double scale, int color = Font.CR_UNTRANSLATED)
+	{
+		int sec = Thinker.Tics2Seconds(Plrs[me].stime);
+		if (t < 0)
+			return;
+
+		int hours = t / 3600;
+		t -= hours * 3600;
+		int minutes = t / 60;
+		t -= minutes * 60;
+		int seconds = t;
+
+		String s = "";
+		if (hours > 0)
+		{
+			s = String.Format("%d", hours) .. ":";
+		}
+
+		if (hours > 0 || minutes < 10)
+		{
+			s = s .. "0";
+		}
+		s = s .. String.Format("%d", minutes) .. ":";
+
+		if (seconds < 10)
+		{
+			s = s .. "0";
+		}
+		s = s .. String.Format("%d", seconds);
+
+		drawTextScaled(fnt, x - fnt.StringWidth(s) * scale, y, s, scale, color);
+	}
+
+	//====================================================================
+	//
 	// Display level completion time and par, or "sucks" message if overflow.
 	//
 	//====================================================================

--- a/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
@@ -69,6 +69,10 @@ class CoopStatusScreen : StatusScreen
 				if (dofrags)
 					cnt_frags[i] = fragSum (i);
 			}
+
+			cnt_time = Thinker.Tics2Seconds(Plrs[me].stime);
+			cnt_total_time = Thinker.Tics2Seconds(wbs.totaltime);
+
 			PlaySound("intermission/nextstage");
 			ng_state = 12;
 		}

--- a/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
@@ -53,7 +53,7 @@ class CoopStatusScreen : StatusScreen
 		bool stillticking;
 		bool autoskip = autoSkip();
 
-		if ((acceleratestage || autoskip) && ng_state != 10)
+		if ((acceleratestage || autoskip) && ng_state != 12)
 		{
 			acceleratestage = 0;
 
@@ -70,7 +70,7 @@ class CoopStatusScreen : StatusScreen
 					cnt_frags[i] = fragSum (i);
 			}
 			PlaySound("intermission/nextstage");
-			ng_state = 10;
+			ng_state = 12;
 		}
 
 		if (ng_state == 2)
@@ -146,10 +146,38 @@ class CoopStatusScreen : StatusScreen
 			if (!stillticking)
 			{
 				PlaySound("intermission/nextstage");
-				ng_state += 1 + 2*!dofrags;
+				ng_state ++;
 			}
 		}
 		else if (ng_state == 8)
+		{
+			if (!(bcnt&3))
+				PlaySound("intermission/tick");
+
+			stillticking = false;
+
+			cnt_time += 3;
+			cnt_total_time += 3;
+
+			int sec = Thinker.Tics2Seconds(Plrs[me].stime);
+			if (cnt_time > sec)
+				cnt_time = sec;
+			else
+				stillticking = true;
+
+			int tsec = Thinker.Tics2Seconds(wbs.totaltime);
+			if (cnt_total_time > tsec)
+				cnt_total_time = tsec;
+			else
+				stillticking = true;
+
+			if (!stillticking)
+			{
+				PlaySound("intermission/nextstage");
+				ng_state += 1 + 2*!dofrags;
+			}
+		}
+		else if (ng_state == 10)
 		{
 			if (!(bcnt&3))
 				PlaySound("intermission/tick");
@@ -175,7 +203,7 @@ class CoopStatusScreen : StatusScreen
 				ng_state++;
 			}
 		}
-		else if (ng_state == 10)
+		else if (ng_state == 12)
 		{
 			int i;
 			for (i = 0; i < MAXPLAYERS; i++)
@@ -320,6 +348,15 @@ class CoopStatusScreen : StatusScreen
 			{
 				drawNumScaled(displayFont, secret_x, y, FontScale, wbs.maxsecret, 0, textcolor);
 			}
+		}
+
+		y += height + 3 * CleanYfac;
+		drawTextScaled(displayFont, name_x, y, Stringtable.Localize("$TXT_IMTIME"), FontScale, textcolor);
+
+		if (ng_state >= 8)
+		{
+			drawTimeScaled(displayFont, kills_x, y, cnt_time, FontScale, textcolor);
+			drawTimeScaled(displayFont, secret_x, y, cnt_total_time, FontScale, textcolor);
 		}
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16033706/91648802-6cc24b80-ea74-11ea-9ef5-3fb6eb653b15.png)

Added the completed time for the level and episode to the tally screen in coop mode. This means an extra 'stage': after counting the kills, items, and secrets, the time is counted upwards with the same speed as in single player mode (3 seconds per tick).