### PR TITLE
Travelled virtual for PlayerPawn

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1562,6 +1562,12 @@ int FLevelLocals::FinishTravel ()
 		{
 			pawn->Speed = pawn->GetDefault()->Speed;
 		}
+
+		IFVIRTUALPTRNAME(pawn, NAME_PlayerPawn, Travelled)
+		{
+			VMValue params[1] = { pawn };
+			VMCall(func, params, 1, nullptr, 0);
+		}
 		// [ZZ] we probably don't want to fire any scripts before all players are in, especially with runNow = true.
 		pawns[pawnsnum++] = pawn;
 	}

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2432,6 +2432,18 @@ class PlayerPawn : Actor
 		return wasdrowning;
 	}
 
+	//===========================================================================
+	//
+	// PlayerPawn :: Travelled
+	//
+	// Called when the player moves to another map, in case it needs to do
+	// special reinitialization. This is called after all carried items have
+	// executed their respective Travelled() virtuals too.
+	//
+	//===========================================================================
+
+	virtual void Travelled() {}
+
 	//----------------------------------------------------------------------------
 	//
 	// 


### PR DESCRIPTION
Useful to reset certain variables or do other checks within the player class itself on map change, akin to the same already existing virtual for inventory items.

I feel that something this trivial really doesn't need an example wad or anything. I have tested that it works with a simple printf.