### PR TITLE
Pre/PostTeleport actor virtuals

### DIFF
--- a/src/playsim/p_teleport.cpp
+++ b/src/playsim/p_teleport.cpp
@@ -148,6 +148,19 @@ bool P_Teleport (AActor *thing, DVector3 pos, DAngle angle, int flags)
 			pos.Z = floorheight;
 		}
 	}
+	// [MK] notify thing of incoming teleport, check for an early cancel
+	// if it returns false
+	{
+		int nocancel = 1;
+		IFVIRTUALPTR(thing, AActor, PreTeleport)
+		{
+			VMValue params[] = { thing, pos.X, pos.Y, pos.Z, angle.Degrees, flags };
+			VMReturn ret;
+			ret.IntAt(&nocancel);
+			VMCall(func, params, countof(params), &ret, 1);
+		}
+		if ( !nocancel ) return false;
+	}
 	if (!P_TeleportMove (thing, pos, false))
 	{
 		return false;
@@ -212,6 +225,14 @@ bool P_Teleport (AActor *thing, DVector3 pos, DAngle angle, int flags)
 		thing->Vel.Zero();
 		// killough 10/98: kill all bobbing velocity too
 		if (player)	player->Vel.Zero();
+	}
+	// [MK] notify thing of successful teleport
+	{
+		IFVIRTUALPTR(thing, AActor, PostTeleport)
+		{
+			VMValue params[] = { thing, pos.X, pos.Y, pos.Z, angle.Degrees, flags };
+			VMCall(func, params, countof(params), nullptr, 1);
+		}
 	}
 	return true;
 }

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -588,6 +588,11 @@ class Actor : Thinker native
 
 	// called on getting a secret, return false to disable default "secret found" message/sound
 	virtual bool OnGiveSecret(bool printmsg, bool playsound) { return true; }
+
+	// called before and after triggering a teleporter
+	// return false in PreTeleport() to cancel the action early
+	virtual bool PreTeleport( Vector3 destpos, double destangle, int flags ) { return true; }
+	virtual void PostTeleport( Vector3 destpos, double destangle, int flags ) {}
 	
 	native virtual bool OkayToSwitchTarget(Actor other);
 	native static class<Actor> GetReplacement(class<Actor> cls);


### PR DESCRIPTION
These two functions may come in handy for modders, allowing them to perform special actions before/after a teleport takes place (or cancelling the action early by returning false in PreTeleport).

Once again like in my previous PR, no examples are provided, but it has been tested to build, run, and work as intended.