### PR TITLE
change BloodSmear2 decal to use correct graphic

### DIFF
--- a/wadsrc/static/decaldef.txt
+++ b/wadsrc/static/decaldef.txt
@@ -206,7 +206,7 @@ decal BloodSmear1
 
 decal BloodSmear2
 {
-	pic BSMEAR1
+	pic BSMEAR2
 	x-scale 0.625
 	y-scale 0.625
 	shade "BloodDefault"


### PR DESCRIPTION
BloodSmear2's definition is the exact same as BloodSmear1 despite the existence of the BSMEAR2 graphic.

I have no idea if this was intentional or not but to me it clearly seems like a copy-paste error from when this was first done.