### PR TITLE
ViewPos

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -414,7 +414,8 @@ enum ActorFlag8
 	MF8_STOPRAILS		= 0x00000200,	// [MC] Prevent rails from going further if an actor has this flag.
 	MF8_ABSVIEWANGLES	= 0x00000400,	// [MC] By default view angle/pitch/roll is an offset. This will make it absolute instead.
 	MF8_FALLDAMAGE		= 0x00000800,	// Monster will take fall damage regardless of map settings.
-
+	MF8_VIEWPOSNOANGLES	= 0x00001000,	// [MC] View position takes no angles into account
+	MF8_ABSVIEWPOS		= 0x00002000,	// [MC] Absolute position, so the actor must update it manually.
 };
 
 // --- mobj.renderflags ---
@@ -968,7 +969,8 @@ public:
 	DAngle			SpriteAngle;
 	DAngle			SpriteRotation;
 	DRotator		Angles;
-	DRotator		ViewAngles;			// Offsets for cameras
+	DRotator		ViewAngles;			// Angle offsets for cameras
+	DVector3		ViewPos;			// Position offsets for cameras
 	DVector2		Scale;				// Scaling values; 1 is normal size
 	double			Alpha;				// Since P_CheckSight makes an alpha check this can't be a float. It has to be a double.
 

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -394,6 +394,9 @@ void	P_PlaySpawnSound(AActor *missile, AActor *spawner);
 // [RH] Position the chasecam
 void	P_AimCamera (AActor *t1, DVector3 &, DAngle &, sector_t *&sec, bool &unlinked);
 
+// [MC] Aiming for viewpos.
+void	P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &, DAngle &, sector_t *&sec, bool &unlinked);
+
 // [RH] Means of death
 enum
 {

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -395,7 +395,7 @@ void	P_PlaySpawnSound(AActor *missile, AActor *spawner);
 void	P_AimCamera (AActor *t1, DVector3 &, DAngle &, sector_t *&sec, bool &unlinked);
 
 // [MC] Aiming for viewpos.
-void	P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &, DAngle &, sector_t *&sec, bool &unlinked);
+void	P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &, sector_t *&sec, bool &unlinked);
 
 // [RH] Means of death
 enum

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5386,14 +5386,12 @@ void P_AimCamera(AActor *t1, DVector3 &campos, DAngle &camangle, sector_t *&Came
 
 void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, sector_t *&CameraSector, bool &unlinked)
 {
-	DAngle angle = t1->Angles.Yaw;
-	DAngle pitch = t1->Angles.Pitch;
 	FTraceResults trace;
 	DVector3 vvec = campos - orig;
 	double distance = vvec.Length();
 
 	// Trace handles all of the portal crossing, which is why there is no usage of Vec#Offset(Z).
-	if (Trace(orig, t1->Sector, vvec.Unit(), distance, 0, 0, NULL, trace) &&
+	if (Trace(orig, t1->Sector, vvec.Unit(), distance, 0, 0, t1, trace) &&
 		trace.Distance > 5)
 	{
 		// Position camera slightly in front of hit thing

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5384,6 +5384,29 @@ void P_AimCamera(AActor *t1, DVector3 &campos, DAngle &camangle, sector_t *&Came
 	camangle = trace.SrcAngleFromTarget - 180.;
 }
 
+void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, DAngle &camangle, sector_t *&CameraSector, bool &unlinked)
+{
+	DAngle angle = t1->Angles.Yaw;
+	DAngle pitch = t1->Angles.Pitch;
+	FTraceResults trace;
+	DVector3 vvec = campos - orig;
+	double distance = vvec.Length();
+
+	if (Trace(orig, t1->Sector, vvec.Unit(), distance, 0, 0, NULL, trace) &&
+		trace.Distance > 10)
+	{
+		// Position camera slightly in front of hit thing
+		campos = orig + vvec.Unit() * (trace.Distance - 5);
+	}
+	else
+	{
+		campos = trace.HitPos - trace.HitVector * 1 / 256.;
+	}
+	CameraSector = trace.Sector;
+	unlinked = trace.unlinked;
+	camangle = trace.SrcAngleFromTarget;
+}
+
 
 //==========================================================================
 //

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -5384,7 +5384,7 @@ void P_AimCamera(AActor *t1, DVector3 &campos, DAngle &camangle, sector_t *&Came
 	camangle = trace.SrcAngleFromTarget - 180.;
 }
 
-void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, DAngle &camangle, sector_t *&CameraSector, bool &unlinked)
+void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, sector_t *&CameraSector, bool &unlinked)
 {
 	DAngle angle = t1->Angles.Yaw;
 	DAngle pitch = t1->Angles.Pitch;
@@ -5392,8 +5392,9 @@ void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, DAngle &camang
 	DVector3 vvec = campos - orig;
 	double distance = vvec.Length();
 
+	// Trace handles all of the portal crossing, which is why there is no usage of Vec#Offset(Z).
 	if (Trace(orig, t1->Sector, vvec.Unit(), distance, 0, 0, NULL, trace) &&
-		trace.Distance > 10)
+		trace.Distance > 5)
 	{
 		// Position camera slightly in front of hit thing
 		campos = orig + vvec.Unit() * (trace.Distance - 5);
@@ -5404,7 +5405,6 @@ void P_AdjustViewPos(AActor *t1, DVector3 orig, DVector3 &campos, DAngle &camang
 	}
 	CameraSector = trace.Sector;
 	unlinked = trace.unlinked;
-	camangle = trace.SrcAngleFromTarget;
 }
 
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -368,7 +368,8 @@ void AActor::Serialize(FSerializer &arc)
 		A("spawnorder", SpawnOrder)
 		A("friction", Friction)
 		A("SpriteOffset", SpriteOffset)
-		A("userlights", UserLights);
+		A("userlights", UserLights)
+		A("viewpos", ViewPos);
 
 		SerializeTerrain(arc, "floorterrain", floorterrain, &def->floorterrain);
 		SerializeArgs(arc, "args", args, def->args, special);

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -725,8 +725,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	if (thing == camera && !vp.showviewer)
 	{
 		DVector3 thingorigin = thing->Pos();
-		if (thruportal == 1) thingorigin += di->Level->Displacements.getOffset(thing->Sector->PortalGroup, sector->PortalGroup);
-		if (vp.InPortal)	return;
+		if (thruportal == 1) 	thingorigin += di->Level->Displacements.getOffset(thing->Sector->PortalGroup, sector->PortalGroup);
 		if (fabs(thingorigin.X - vp.ActorPos.X) < 2 && fabs(thingorigin.Y - vp.ActorPos.Y) < 2) return;
 	}
 	// Thing is invisible if close to the camera.

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -726,6 +726,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		DVector3 thingorigin = thing->Pos();
 		if (thruportal == 1) thingorigin += di->Level->Displacements.getOffset(thing->Sector->PortalGroup, sector->PortalGroup);
+		if (vp.InPortal)	return;
 		if (fabs(thingorigin.X - vp.ActorPos.X) < 2 && fabs(thingorigin.Y - vp.ActorPos.Y) < 2) return;
 	}
 	// Thing is invisible if close to the camera.

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -22,6 +22,7 @@ struct FRenderViewpoint
 	player_t		*player;		// For which player is this viewpoint being renderered? (can be null for camera textures)
 	DVector3		Pos;			// Camera position
 	DVector3		ActorPos;		// Camera actor's position
+	DVector3		VPos;			// Camera ViewPos offset
 	DRotator		Angles;			// Camera angles
 	FRotator		HWAngles;		// Actual rotation angles for the hardware renderer
 	DVector2		ViewVector;		// HWR only: direction the camera is facing.

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -22,7 +22,6 @@ struct FRenderViewpoint
 	player_t		*player;		// For which player is this viewpoint being renderered? (can be null for camera textures)
 	DVector3		Pos;			// Camera position
 	DVector3		ActorPos;		// Camera actor's position
-	DVector3		VPos;			// Camera ViewPos offset
 	DRotator		Angles;			// Camera angles
 	FRotator		HWAngles;		// Actual rotation angles for the hardware renderer
 	DVector2		ViewVector;		// HWR only: direction the camera is facing.
@@ -45,8 +44,7 @@ struct FRenderViewpoint
 	int				extralight;		// extralight to be added to this viewpoint
 	bool			showviewer;		// show the camera actor?
 
-	bool			InPortal;		// disable actor rendering if the camera viewpos is separated by portal.
-
+	bool			NoPortalPath;	// Disable portal interpolation path for actor viewpos.
 
 	void SetViewAngle(const FViewWindow &viewwindow);
 

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -44,6 +44,8 @@ struct FRenderViewpoint
 	int				extralight;		// extralight to be added to this viewpoint
 	bool			showviewer;		// show the camera actor?
 
+	bool			InPortal;		// disable actor rendering if the camera viewpos is separated by portal.
+
 
 	void SetViewAngle(const FViewWindow &viewwindow);
 

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -327,6 +327,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, STOPRAILS, AActor, flags8),
 	DEFINE_FLAG(MF8, FALLDAMAGE, AActor, flags8),
 	DEFINE_FLAG(MF8, ABSVIEWANGLES, AActor, flags8),
+	DEFINE_FLAG(MF8, VIEWPOSNOANGLES, AActor, flags8),
+	DEFINE_FLAG(MF8, ABSVIEWPOS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1948,6 +1948,7 @@ DEFINE_FIELD(AActor, InventoryID)
 DEFINE_FIELD_NAMED(AActor, ViewAngles.Yaw, viewangle)
 DEFINE_FIELD_NAMED(AActor, ViewAngles.Pitch, viewpitch)
 DEFINE_FIELD_NAMED(AActor, ViewAngles.Roll, viewroll)
+DEFINE_FIELD(AActor, ViewPos)
 
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, thing);
 DEFINE_FIELD_X(FCheckPosition, FCheckPosition, pos);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -235,6 +235,7 @@ class Actor : Thinker native
 	native double CameraHeight;	// Height of camera when used as such
 	native double CameraFOV;
 	native double ViewAngle, ViewPitch, ViewRoll;
+	native Vector3 ViewPos;
 	native double RadiusDamageFactor;		// Radius damage factor
 	native double SelfDamageFactor;
 	native double StealthAlpha;


### PR DESCRIPTION
Added ViewPos vector3, which offsets the actor view.by the specified amount. Primarily used by cameras and players.

- VIEWPOSNOANGLES: Angles (yaw/pitch/roll) are not taken into account, but the position is still relative.
- ABSVIEWPOS: Absolute position of the view in world coordinates. When used, portal interpolation is **NOT** performed, which is left to the modder to handle instead.

Currently, the only known problem is the inability to turn off the player sprite when the view point and the player are separated via portals, but should otherwise be ready for implementation.