### PR TITLE
Add WorldThingGround event

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -331,16 +331,16 @@ void EventManager::WorldThingDied(AActor* actor, AActor* inflictor)
 		handler->WorldThingDied(actor, inflictor);
 }
 
-void EventManager::WorldThingGrinded(AActor* actor)
+void EventManager::WorldThingGround(AActor* actor)
 {
 	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
 	if (actor->ObjectFlags & OF_EuthanizeMe)
 		return;
 
-	if (ShouldCallStatic(true)) staticEventManager.WorldThingGrinded(actor);
+	if (ShouldCallStatic(true)) staticEventManager.WorldThingGround(actor);
 
 	for (DStaticEventHandler* handler = FirstEventHandler; handler; handler = handler->next)
-		handler->WorldThingGrinded(actor);
+		handler->WorldThingGround(actor);
 }
 
 void EventManager::WorldThingRevived(AActor* actor)
@@ -807,9 +807,9 @@ void DStaticEventHandler::WorldThingDied(AActor* actor, AActor* inflictor)
 	}
 }
 
-void DStaticEventHandler::WorldThingGrinded(AActor* actor)
+void DStaticEventHandler::WorldThingGround(AActor* actor)
 {
-	IFVIRTUAL(DStaticEventHandler, WorldThingGrinded)
+	IFVIRTUAL(DStaticEventHandler, WorldThingGround)
 	{
 		// don't create excessive DObjects if not going to be processed anyway
 		if (isEmpty(func)) return;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -331,6 +331,18 @@ void EventManager::WorldThingDied(AActor* actor, AActor* inflictor)
 		handler->WorldThingDied(actor, inflictor);
 }
 
+void EventManager::WorldThingGrinded(AActor* actor)
+{
+	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
+	if (actor->ObjectFlags & OF_EuthanizeMe)
+		return;
+
+	if (ShouldCallStatic(true)) staticEventManager.WorldThingGrinded(actor);
+
+	for (DStaticEventHandler* handler = FirstEventHandler; handler; handler = handler->next)
+		handler->WorldThingGrinded(actor);
+}
+
 void EventManager::WorldThingRevived(AActor* actor)
 {
 	// don't call anything if actor was destroyed on PostBeginPlay/BeginPlay/whatever.
@@ -794,6 +806,20 @@ void DStaticEventHandler::WorldThingDied(AActor* actor, AActor* inflictor)
 		VMCall(func, params, 2, nullptr, 0);
 	}
 }
+
+void DStaticEventHandler::WorldThingGrinded(AActor* actor)
+{
+	IFVIRTUAL(DStaticEventHandler, WorldThingGrinded)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func)) return;
+		FWorldEvent e = owner->SetupWorldEvent();
+		e.Thing = actor;
+		VMValue params[2] = { (DStaticEventHandler*)this, &e };
+		VMCall(func, params, 2, nullptr, 0);
+	}
+}
+
 
 void DStaticEventHandler::WorldThingRevived(AActor* actor)
 {

--- a/src/events.h
+++ b/src/events.h
@@ -80,6 +80,7 @@ public:
 	void WorldUnloaded();
 	void WorldThingSpawned(AActor* actor);
 	void WorldThingDied(AActor* actor, AActor* inflictor);
+	void WorldThingGrinded(AActor* actor);
 	void WorldThingRevived(AActor* actor);
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 	void WorldThingDestroyed(AActor* actor);
@@ -234,6 +235,8 @@ struct EventManager
 	void WorldThingSpawned(AActor* actor);
 	// called after AActor::Die of each actor.
 	void WorldThingDied(AActor* actor, AActor* inflictor);
+	// called inside AActor::Grind just before the corpse is destroyed
+	void WorldThingGrinded(AActor* actor);
 	// called after AActor::Revive.
 	void WorldThingRevived(AActor* actor);
 	// called before P_DamageMobj and before AActor::DamageMobj virtuals.

--- a/src/events.h
+++ b/src/events.h
@@ -80,7 +80,7 @@ public:
 	void WorldUnloaded();
 	void WorldThingSpawned(AActor* actor);
 	void WorldThingDied(AActor* actor, AActor* inflictor);
-	void WorldThingGrinded(AActor* actor);
+	void WorldThingGround(AActor* actor);
 	void WorldThingRevived(AActor* actor);
 	void WorldThingDamaged(AActor* actor, AActor* inflictor, AActor* source, int damage, FName mod, int flags, DAngle angle);
 	void WorldThingDestroyed(AActor* actor);
@@ -236,7 +236,7 @@ struct EventManager
 	// called after AActor::Die of each actor.
 	void WorldThingDied(AActor* actor, AActor* inflictor);
 	// called inside AActor::Grind just before the corpse is destroyed
-	void WorldThingGrinded(AActor* actor);
+	void WorldThingGround(AActor* actor);
 	// called after AActor::Revive.
 	void WorldThingRevived(AActor* actor);
 	// called before P_DamageMobj and before AActor::DamageMobj virtuals.

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -1202,7 +1202,7 @@ bool AActor::Grind(bool items)
 				S_Sound (this, CHAN_BODY, 0, "misc/fallingsplat", 1, ATTN_IDLE);
 				Translation = BloodTranslation;
 			}
-			Level->localEventManager->WorldThingGrinded(this);
+			Level->localEventManager->WorldThingGround(this);
 			return false;
 		}
 		if (!(flags & MF_NOBLOOD))
@@ -1245,7 +1245,7 @@ bool AActor::Grind(bool items)
 				gib->Translation = BloodTranslation;
 			}
 			S_Sound (this, CHAN_BODY, 0, "misc/fallingsplat", 1, ATTN_IDLE);
-			Level->localEventManager->WorldThingGrinded(this);
+			Level->localEventManager->WorldThingGround(this);
 		}
 		if (flags & MF_ICECORPSE)
 		{

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -1202,6 +1202,7 @@ bool AActor::Grind(bool items)
 				S_Sound (this, CHAN_BODY, 0, "misc/fallingsplat", 1, ATTN_IDLE);
 				Translation = BloodTranslation;
 			}
+			Level->localEventManager->WorldThingGrinded(this);
 			return false;
 		}
 		if (!(flags & MF_NOBLOOD))
@@ -1244,6 +1245,7 @@ bool AActor::Grind(bool items)
 				gib->Translation = BloodTranslation;
 			}
 			S_Sound (this, CHAN_BODY, 0, "misc/fallingsplat", 1, ATTN_IDLE);
+			Level->localEventManager->WorldThingGrinded(this);
 		}
 		if (flags & MF_ICECORPSE)
 		{

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -15,7 +15,7 @@ struct WorldEvent native play version("2.4")
     native readonly bool IsSaveGame;
     // this will be true if we are re-entering the hub level.
     native readonly bool IsReopen;
-    // for thingspawned/thingdied/thingdestroyed/thinggrinded
+    // for thingspawned/thingdied/thingdestroyed/thingground
     native readonly Actor Thing;
     // for thingdied. can be null
     native readonly Actor Inflictor;
@@ -323,7 +323,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldUnloaded(WorldEvent e) {}
     virtual void WorldThingSpawned(WorldEvent e) {}
     virtual void WorldThingDied(WorldEvent e) {}
-    virtual void WorldThingGrinded(WorldEvent e) {}
+    virtual void WorldThingGround(WorldEvent e) {}
     virtual void WorldThingRevived(WorldEvent e) {}
     virtual void WorldThingDamaged(WorldEvent e) {}
     virtual void WorldThingDestroyed(WorldEvent e) {}

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -15,7 +15,7 @@ struct WorldEvent native play version("2.4")
     native readonly bool IsSaveGame;
     // this will be true if we are re-entering the hub level.
     native readonly bool IsReopen;
-    // for thingspawned/thingdied/thingdestroyed
+    // for thingspawned/thingdied/thingdestroyed/thinggrinded
     native readonly Actor Thing;
     // for thingdied. can be null
     native readonly Actor Inflictor;
@@ -323,6 +323,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldUnloaded(WorldEvent e) {}
     virtual void WorldThingSpawned(WorldEvent e) {}
     virtual void WorldThingDied(WorldEvent e) {}
+    virtual void WorldThingGrinded(WorldEvent e) {}
     virtual void WorldThingRevived(WorldEvent e) {}
     virtual void WorldThingDamaged(WorldEvent e) {}
     virtual void WorldThingDestroyed(WorldEvent e) {}


### PR DESCRIPTION
Use case is if you want to do something or get info about the actor right just before it gets crushed and the gib object spawns.

This only hooks into the part where the gib object spawns - NOT when the thing is actively being crushed - so it shouldn't pose much performance problems.

Example file attached

EDIT: example file has been updated to reflect the name change (WorldThingGrinded -> WorldThingGround)

[WorldThingGroundDemo.zip](https://github.com/coelckers/gzdoom/files/5179626/WorldThingGroundDemo.zip)


