### PR TITLE
Add string table lookup to SECRETS lump handling

### DIFF
--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -1112,7 +1112,7 @@ static void PrintSecretString(const char *string, bool thislevel)
 				else colstr = TEXTCOLOR_GREEN;
 			}
 		}
-		auto brok = V_BreakLines(CurrentConsoleFont, twod->GetWidth()*95/100, string);
+		auto brok = V_BreakLines(CurrentConsoleFont, twod->GetWidth()*95/100, *string == '$' ? GStrings(++string) : string);
 
 		for (auto &line : brok)
 		{


### PR DESCRIPTION
- If the hint text portion of a SECRETS lump entry begins with a '$', the value is treated as a string table lookup

Allows SECRETS strings to be translated via LANGUAGE lump.  Reference: https://forum.zdoom.org/viewtopic.php?f=15&t=69827

Example use in SECRETS lump:
_[MAP01]
$s1;1. This is a secret that is only in English, but the next one looks up a string table entry.
$s2;$QUITMSG_