### PR TITLE
Disallow sound to be played on destroyed actors

### DIFF
--- a/src/sound/s_doomsound.cpp
+++ b/src/sound/s_doomsound.cpp
@@ -471,7 +471,8 @@ FSoundID DoomSoundEngine::ResolveSound(const void * ent, int type, FSoundID soun
 
 static bool VerifyActorSound(AActor* ent, FSoundID& sound_id, int& channel, EChanFlags flags)
 {
-	if (ent == nullptr || ent->Sector->Flags & SECF_SILENT || ent->Level != primaryLevel)
+	if (ent == nullptr || ent->ObjectFlags & OF_EuthanizeMe || ent->Sector->Flags & SECF_SILENT || 
+		ent->Level != primaryLevel)
 		return false;
 
 	if ((flags & CHANF_MAYBE_LOCAL) && (compatflags & COMPATF_SILENTPICKUP))


### PR DESCRIPTION
It's possible for an actor to call Destroy() in a ZScript method (such
as Tick()) and then subsequently call A_StartSound() to play a sound.
Generally speaking this doesn't happen within a given class, but with a
class hierarchy, Destroy() may be called unbeknownst to a mod developer.
Even though checking bDestroyed is likely good practice, this ensures
that sounds won't be started on actors flagged for cleanup.