### PR TITLE
Pass ScriptPosition down to color parser functions

### DIFF
--- a/src/scripting/thingdef.h
+++ b/src/scripting/thingdef.h
@@ -324,7 +324,7 @@ int MatchString (const char *in, const char **strings);
 #define PROP_DOUBLE_PARM(var, no) \
 	double var = params[(no)+1].d;
 
-#define PROP_COLOR_PARM(var, no) \
-	int var = params[(no)+1].i== 0? params[(no)+2].i : V_GetColor(NULL, params[(no)+2].s);
+#define PROP_COLOR_PARM(var, no, scriptpos) \
+	int var = params[(no)+1].i== 0? params[(no)+2].i : V_GetColor(NULL, params[(no)+2].s, scriptpos);
 
 #endif

--- a/src/scripting/thingdef_properties.cpp
+++ b/src/scripting/thingdef_properties.cpp
@@ -766,7 +766,7 @@ DEFINE_PROPERTY(translation, L, Actor)
 //==========================================================================
 DEFINE_PROPERTY(stencilcolor, C, Actor)
 {
-	PROP_COLOR_PARM(color, 0);
+	PROP_COLOR_PARM(color, 0, &bag.ScriptPosition);
 
 	defaults->fillcolor = color | (ColorMatcher.Pick (RPART(color), GPART(color), BPART(color)) << 24);
 }
@@ -776,7 +776,7 @@ DEFINE_PROPERTY(stencilcolor, C, Actor)
 //==========================================================================
 DEFINE_PROPERTY(bloodcolor, C, Actor)
 {
-	PROP_COLOR_PARM(color, 0);
+	PROP_COLOR_PARM(color, 0, &bag.ScriptPosition);
 
 	defaults->BloodColor = color;
 	defaults->BloodColor.a = 255;	// a should not be 0.
@@ -1608,7 +1608,7 @@ DEFINE_CLASS_PROPERTY_PREFIX(player, crouchsprite, S, PlayerPawn)
 //==========================================================================
 DEFINE_CLASS_PROPERTY_PREFIX(player, damagescreencolor, Cfs, PlayerPawn)
 {
-	PROP_COLOR_PARM(c, 0);
+	PROP_COLOR_PARM(c, 0, &bag.ScriptPosition);
 
 	PalEntry color = c;
 


### PR DESCRIPTION
Bug report: https://forum.zdoom.org/viewtopic.php?f=2&t=69894

If a mod had actor definitions with invalid color, like "none", the only output you get was this:
```
LoadActors: Load actor definitions.
Bad hex number: no
Bad hex number: no
``` 
making it difficult to identify where the problem was. Even though the `ParseHex` function supports ScriptPosition, it was always null due to not being passed down from some property handler.

With these changes, ParseHex now gives the user detailed info about script name and line number with the invalid data:
``` 
LoadActors: Load actor definitions.
Script warning, "Project_Brutality-master.zip:actors/monsters/t3-floaters/lostsoul.dec" line 51:
Bad hex number: no
Script warning, "Project_Brutality-master.zip:actors/monsters/t3-floaters/phantasm.dec" line 31:
Bad hex number: no
``` 

I'm a C# guy modifying C++ code, how  am I doing?
