### PR TITLE
Export FLevelLocals::ChangeLevel to ZScript

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -739,6 +739,17 @@ void FLevelLocals::ChangeLevel(const char *levelname, int position, int inflags,
 	::nextlevel = nextlevel;
 }
 
+DEFINE_ACTION_FUNCTION(FLevelLocals, ChangeLevel)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_STRING(levelname);
+	PARAM_INT(position);
+	PARAM_INT(inflags);
+	PARAM_INT(nextSkill);
+	self->ChangeLevel(levelname, position, inflags, nextSkill);
+	return 0;
+}
+
 //==========================================================================
 //
 //

--- a/wadsrc/static/zscript/base.zs
+++ b/wadsrc/static/zscript/base.zs
@@ -804,6 +804,7 @@ struct LevelLocals native
 
 	native void ExitLevel(int position, bool keepFacing);
 	native void SecretExitLevel(int position);
+	native void ChangeLevel(string levelname, int position = 0, int flags = 0, int skill = -1);
 }
 
 struct StringTable native


### PR DESCRIPTION
This PR exports ```FLevelLocals::ChangeLevel``` to ZScript. This function is already available in ACS; however, it could still be useful if a project is written entirely in ZScript to avoid the need to use ACS specifically to call it. Note that ```EChangeLevelFlags``` enum is already exported to ZScript.