### PR TITLE
Fix decals not appearing when firing at walls point-blank

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6435,7 +6435,7 @@ bool P_CheckMissileSpawn (AActor* th, double maxdist)
 			}
 			else
 			{
-				P_ExplodeMissile (th, NULL, th->BlockingMobj);
+				P_ExplodeMissile (th, th->BlockingLine, th->BlockingMobj);
 			}
 			return false;
 		}


### PR DESCRIPTION
This PR implements a fix for [this bug](https://forum.zdoom.org/viewtopic.php?f=2&t=69928): when firing at walls point-blank, decals do not appear. This is because ```P_ExplodeMissile``` is called with ```line``` set to null if a projectile's movement is blocked immediately upon creation, which prevents the decal-spawning code from working.