### PR TITLE
Fixed: extra player translation tables were not fully initialized

### DIFF
--- a/src/r_data/r_translate.cpp
+++ b/src/r_data/r_translate.cpp
@@ -371,6 +371,9 @@ static void R_CreatePlayerTranslation (float h, float s, float v, const FPlayerC
 	float sdelta, vdelta;
 	float range;
 
+	if (alttable) alttable->MakeIdentity();
+	if (pillartable) pillartable->MakeIdentity();
+
 	// Set up the base translation for this skin. If the skin was created
 	// for the current game, then this is just an identity translation.
 	// Otherwise, it remaps the colors from the skin's original palette to


### PR DESCRIPTION
See [this bug report](https://forum.zdoom.org/viewtopic.php?f=2&t=69897) for details. The problem was that ```R_CreatePlayerTranslation``` did not fully initialize the extra tables (alttable and pillartable). Before [this commit](https://github.com/coelckers/gzdoom/commit/520a96033b499d3346c555d849fa096537a8b660), the values that were passed in there had already been initialized before as identity remaps; everything used to work fine but broke after that refactoring.