### PR TITLE
Fix extra player translations not working in Heretic with predefined color sets

### DIFF
--- a/src/r_data/r_translate.cpp
+++ b/src/r_data/r_translate.cpp
@@ -474,21 +474,6 @@ static void R_CreatePlayerTranslation (float h, float s, float v, const FPlayerC
 			HSVtoRGB (&r, &g, &b, h, s, v);
 			SetRemap(table, i, r, g, b);
 		}
-
-		// Build rain/lifegem translation
-		if (alttable)
-		{
-			bases = MIN (bases*1.3f, 1.f);
-			basev = MIN (basev*1.3f, 1.f);
-			for (i = 145; i <= 168; i++)
-			{
-				s = MIN (bases, 0.8965f - 0.0962f*(float)(i - 161));
-				v = MIN (1.f, (0.2102f + 0.0489f*(float)(i - 144)) * basev);
-				HSVtoRGB (&r, &g, &b, h, s, v);
-				SetRemap(alttable, i, r, g, b);
-				SetPillarRemap(pillartable, i, h, s, v);
-			}
-		}
 	}
 	else if (gameinfo.gametype == GAME_Hexen)
 	{
@@ -522,30 +507,50 @@ static void R_CreatePlayerTranslation (float h, float s, float v, const FPlayerC
 			}
 		}
 	}
-	if (gameinfo.gametype == GAME_Hexen && alttable != NULL)
-	{
-		// Build Hexen's lifegem translation.
-		
-		// Is the player's translation range the same as the gem's and we are using a
-		// predefined translation? If so, then use the same one for the gem. Otherwise,
-		// build one as per usual.
-		if (colorset != NULL && start == 164 && end == 185)
-		{
-			*alttable = *table;
-		}
-		else
-		{
-			for (i = 164; i <= 185; ++i)
-			{
-				const PalEntry *base = &GPalette.BaseColors[i];
-				float dummy;
 
-				RGBtoHSV (base->r/255.f, base->g/255.f, base->b/255.f, &dummy, &s, &v);
-				HSVtoRGB (&r, &g, &b, h, s*bases, v*basev);
+	if (alttable != NULL)
+	{
+		if (gameinfo.gametype == GAME_Heretic)
+		{
+			// Build rain/lifegem translation
+			bases = MIN(bases * 1.3f, 1.f);
+			basev = MIN(basev * 1.3f, 1.f);
+			for (i = 145; i <= 168; i++)
+			{
+				s = MIN(bases, 0.8965f - 0.0962f * (float)(i - 161));
+				v = MIN(1.f, (0.2102f + 0.0489f * (float)(i - 144)) * basev);
+				HSVtoRGB(&r, &g, &b, h, s, v);
 				SetRemap(alttable, i, r, g, b);
+				SetPillarRemap(pillartable, i, h, s, v);
+			}
+		}
+		else if (gameinfo.gametype == GAME_Hexen)
+		{
+			// Build Hexen's lifegem translation.
+
+			// Is the player's translation range the same as the gem's and we are using a
+			// predefined translation? If so, then use the same one for the gem. Otherwise,
+			// build one as per usual.
+			if (colorset != NULL && start == 164 && end == 185)
+			{
+				*alttable = *table;
+			}
+			else
+			{
+				for (i = 164; i <= 185; ++i)
+				{
+					const PalEntry* base = &GPalette.BaseColors[i];
+					float dummy;
+
+					RGBtoHSV(base->r / 255.f, base->g / 255.f, base->b / 255.f, &dummy, &s, &v);
+					HSVtoRGB(&r, &g, &b, h, s * bases, v * basev);
+					SetRemap(alttable, i, r, g, b);
+				}
 			}
 		}
 	}
+		
+	
  }
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?f=2&t=69940) for details. The code to initialize extra player translations in Heretic did not execute if a predefined color set was selected. This PR changes it to be independent of that condition (same as for Hexen).