### PR TITLE
Update copyright notice in cmake/FindSDL2.cmake.

### DIFF
--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -1,3 +1,6 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
 # Locate SDL2 library
 # This module defines
 # SDL2_LIBRARY, the name of the library to link against
@@ -56,19 +59,6 @@
 # module with the minor edit of changing "SDL" to "SDL2" where necessary. This
 # was not created for redistribution, and exists temporarily pending official
 # SDL2 CMake modules.
-
-#=============================================================================
-# Copyright 2003-2009 Kitware, Inc.
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
 
 FIND_PATH(SDL2_INCLUDE_DIR SDL.h
   HINTS


### PR DESCRIPTION
So, I wanted to use FindSDL2.cmake in a different project. I then stumbled upon this text:

```
#=============================================================================
# Copyright 2003-2009 Kitware, Inc.
#
# Distributed under the OSI-approved BSD License (the "License");
# see accompanying file Copyright.txt for details.
#
# This software is distributed WITHOUT ANY WARRANTY; without even the
# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
# See the License for more information.
#=============================================================================
# (To distribute this file outside of CMake, substitute the full
#  License text for the above reference.)
```

Although this repository includes "bsd.txt", the text is referencing a file named "Copyright.txt". Thus, I initially considered following their instructions and embedding a copy of the BSD 3-Clause License text.

However, I had a look at the most recent version of FindSDL.cmake in the CMake repository, and it had a different header. The change was done in this commit: https://github.com/Kitware/CMake/commit/86578eccf2e82286248796bad1032cd0e3a5e1e2 (Another link: https://gitlab.kitware.com/cmake/cmake/-/commit/86578eccf2e82286248796bad1032cd0e3a5e1e2)

Thus, I decided to use it as a base instead. While it's still referencing "Copyright.txt", there's also a link to https://cmake.org/licensing. I'm still unsure if Copyright.txt should be replaced with bsd.txt, and/or if another change will be better.