### PR TITLE
Add NORANDOMPUFFZ flag to A_Saw

### DIFF
--- a/wadsrc/static/zscript/actors/doom/weaponchainsaw.zs
+++ b/wadsrc/static/zscript/actors/doom/weaponchainsaw.zs
@@ -78,9 +78,11 @@ extend class StateProvider
 				return;
 		}
 
+		int puffFlags = (flags & SF_NORANDOMPUFFZ) ? LAF_NORANDOMPUFFZ : 0;
+
 		Actor puff;
 		int actualdamage;
-		[puff, actualdamage] = LineAttack (ang, range, slope, damage, 'Melee', pufftype, false, t);
+		[puff, actualdamage] = LineAttack (ang, range, slope, damage, 'Melee', pufftype, puffFlags, t);
 
 		if (!t.linetarget)
 		{

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -36,6 +36,7 @@ enum ESawFlags
 	SF_NOPULLIN = 32,
 	SF_NOTURN = 64,
 	SF_STEALARMOR = 128,
+	SF_NORANDOMPUFFZ = 256,
 };
 
 // Flags for A_BFGSpray


### PR DESCRIPTION
A_FireBullets and A_CustomPunch already have a flag to disable randomization of the spawned puff's Z offset. Proposing to add the same capability to A_Saw for consistency.

BTW, I've noticed that the call to ```LineAttack``` made from A_Saw is missing the ```LAF_ISMELEEATTACK``` flag. Is this intetional? If not, I can make another PR to fix this.