### PR TITLE
CanCrossLine (Attempt #2)

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -163,7 +163,7 @@ bool P_CanCollideWith(AActor *tmthing, AActor *thing)
 // If false, the line blocks them.
 //==========================================================================
 
-bool P_CanCrossLine(AActor *mo, line_t *line, int side)
+bool P_CanCrossLine(AActor *mo, line_t *line, int side, DVector3 next)
 {
 	static unsigned VIndex = ~0u;
 	if (VIndex == ~0u)
@@ -172,7 +172,7 @@ bool P_CanCrossLine(AActor *mo, line_t *line, int side)
 		assert(VIndex != ~0u);
 	}
 
-	VMValue params[4] = { mo, line, side, false };
+	VMValue params[] = { mo, line, side, next.X, next.Y, next.Z, false };
 	VMReturn ret;
 	int retval;
 	ret.IntAt(&retval);
@@ -181,7 +181,7 @@ bool P_CanCrossLine(AActor *mo, line_t *line, int side)
 	VMFunction *func = clss->Virtuals.Size() > VIndex ? clss->Virtuals[VIndex] : nullptr;
 	if (func != nullptr)
 	{
-		VMCall(func, params, 4, &ret, 1);
+		VMCall(func, params, countof(params), &ret, 1);
 		return retval;
 	}
 	return true;
@@ -991,7 +991,7 @@ bool PIT_CheckLine(FMultiBlockLinesIterator &mit, FMultiBlockLinesIterator::Chec
 		}
 	}
 
-	if (!P_CanCrossLine(tm.thing, ld, P_PointOnLineSide(cres.Position, ld)))
+	if (!P_CanCrossLine(tm.thing, ld, P_PointOnLineSide(cres.Position, ld), tm.pos))
 	{
 		if (wasfit)
 			tm.thing->BlockingLine = ld;

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -156,6 +156,38 @@ bool P_CanCollideWith(AActor *tmthing, AActor *thing)
 }
 
 //==========================================================================
+// 
+// CanCrossLine
+//
+// Checks if an actor can cross a line after all checks are processed.
+// If false, the line blocks them.
+//==========================================================================
+
+bool P_CanCrossLine(AActor *mo, line_t *line, int side)
+{
+	static unsigned VIndex = ~0u;
+	if (VIndex == ~0u)
+	{
+		VIndex = GetVirtualIndex(RUNTIME_CLASS(AActor), "CanCrossLine");
+		assert(VIndex != ~0u);
+	}
+
+	VMValue params[4] = { mo, line, side, false };
+	VMReturn ret;
+	int retval;
+	ret.IntAt(&retval);
+
+	auto clss = mo->GetClass();
+	VMFunction *func = clss->Virtuals.Size() > VIndex ? clss->Virtuals[VIndex] : nullptr;
+	if (func != nullptr)
+	{
+		VMCall(func, params, 4, &ret, 1);
+		return retval;
+	}
+	return true;
+}
+
+//==========================================================================
 //
 // FindRefPoint
 //
@@ -959,6 +991,13 @@ bool PIT_CheckLine(FMultiBlockLinesIterator &mit, FMultiBlockLinesIterator::Chec
 		}
 	}
 
+	if (!P_CanCrossLine(tm.thing, ld, P_PointOnLineSide(cres.Position, ld)))
+	{
+		if (wasfit)
+			tm.thing->BlockingLine = ld;
+		
+		return false;
+	}
 	// If the floor planes on both sides match we should recalculate open.bottom at the actual position we are checking
 	// This is to avoid bumpy movement when crossing a linedef with the same slope on both sides.
 	// This should never narrow down the opening, though, only widen it.

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -479,6 +479,12 @@ class Actor : Thinker native
 		return true;
 	}
 
+	// Called by PIT_CheckLine to check if an actor can cross a line.
+	virtual bool CanCrossLine(Line crossing, int side)
+	{
+		return true;
+	}
+
 	// Called by revival/resurrection to check if one can resurrect the other.
 	// "other" can be null when not passive.
 	virtual bool CanResurrect(Actor other, bool passive)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -480,7 +480,7 @@ class Actor : Thinker native
 	}
 
 	// Called by PIT_CheckLine to check if an actor can cross a line.
-	virtual bool CanCrossLine(Line crossing, int side)
+	virtual bool CanCrossLine(Line crossing, int side, Vector3 next)
 	{
 		return true;
 	}


### PR DESCRIPTION
Added CanCrossLine virtual for actors.

- Called last after all other line checks occur. Returning false means the actor cannot cross that line.