### PR TITLE
PSprite Scale/Rotation/Pivot/Vertex

### DIFF
--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -155,7 +155,6 @@ DEFINE_FIELD_BIT(DPSprite, Flags, bMirror, PSPF_MIRROR)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPlayerTranslated, PSPF_PLAYERTRANSLATED)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPivotPercent, PSPF_PIVOTPERCENT)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPivotScreen, PSPF_PIVOTSCREEN)
-DEFINE_FIELD_BIT(DPSprite, Flags, bPivotOffsetRel, PSPF_PIVOTOFFSETREL)
 
 //------------------------------------------------------------------------
 //
@@ -184,8 +183,7 @@ DPSprite::DPSprite(player_t *owner, AActor *caller, int id)
   oldpx(.0), oldpy(.0),
   oldrotation(.0),
   PivotPercent(true),
-  PivotScreen(false),
-  PivotOffsetRel(false)
+  PivotScreen(false)
 {
 	alpha = 1;
 	Renderstyle = STYLE_Normal;
@@ -671,6 +669,7 @@ enum WOFFlags
 	WOF_KEEPY = 1 << 1,
 	WOF_ADD = 1 << 2,
 	WOF_INTERPOLATE = 1 << 3,
+	WOF_RELATIVE = 1 << 4,
 };
 
 DEFINE_ACTION_FUNCTION(AActor, A_OverlayScale)

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -803,6 +803,15 @@ void A_OverlayOffset(AActor *self, int layer, double wx, double wy, int flags)
 		if (psp == nullptr)
 			return;
 
+		if (flags & WOF_RELATIVE)
+		{
+			DAngle rot = psp->rotation;
+			double c = rot.Cos(), s = rot.Sin();
+			double nx = wx * c + wy * s;
+			double ny = wx * s - wy * c;
+			wx = nx; wy = ny;
+		}
+
 		if (!(flags & WOF_KEEPX))
 		{
 			if (flags & WOF_ADD)

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -314,7 +314,7 @@ DPSprite *player_t::GetPSprite(PSPLayers layer)
 		}
 		else
 		{
-			pspr->Flags = (PSPF_ADDWEAPON|PSPF_ADDBOB|PSPF_CVARFAST|PSPF_POWDOUBLE);
+			pspr->Flags = (PSPF_ADDWEAPON|PSPF_ADDBOB|PSPF_CVARFAST|PSPF_POWDOUBLE|PSPF_PIVOTPERCENT);
 		}
 		if (layer == PSP_STRIFEHANDS)
 		{

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -841,14 +841,8 @@ void A_OverlayOffset(AActor *self, int layer, double wx, double wy, int flags)
 		if (!(flags & WOF_KEEPX))		psp->x = (flags & WOF_ADD) ? psp->x + wx : wx;
 		if (!(flags & WOF_KEEPY))		psp->y = (flags & WOF_ADD) ? psp->y + wy : wy;
 		
-		if (flags & (WOF_ADD | WOF_INTERPOLATE))	psp->InterpolateTic = true;
-		/*
-		if (!(flags & (WOF_INTERPOLATE|WOF_ADD))) 
-		{
-			psp->oldx = psp->x;
-			psp->oldy = psp->y;
-		}
-		*/
+		if (!(flags & (WOF_ADD | WOF_INTERPOLATE)))
+			psp->ResetInterpolation();
 	}
 }
 

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -142,8 +142,6 @@ DEFINE_FIELD(DPSprite, oldscalex)
 DEFINE_FIELD(DPSprite, oldscaley)
 DEFINE_FIELD(DPSprite, rotation)
 DEFINE_FIELD(DPSprite, oldrotation)
-DEFINE_FIELD(DPSprite, PivotPercent)
-DEFINE_FIELD(DPSprite, PivotScreen)
 DEFINE_FIELD(DPSprite, firstTic)
 DEFINE_FIELD(DPSprite, Tics)
 DEFINE_FIELD(DPSprite, Translation)
@@ -157,6 +155,7 @@ DEFINE_FIELD_BIT(DPSprite, Flags, bMirror, PSPF_MIRROR)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPlayerTranslated, PSPF_PLAYERTRANSLATED)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPivotPercent, PSPF_PIVOTPERCENT)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPivotScreen, PSPF_PIVOTSCREEN)
+DEFINE_FIELD_BIT(DPSprite, Flags, bPivotOffsetRel, PSPF_PIVOTOFFSETREL)
 
 //------------------------------------------------------------------------
 //
@@ -185,7 +184,8 @@ DPSprite::DPSprite(player_t *owner, AActor *caller, int id)
   oldpx(.0), oldpy(.0),
   oldrotation(.0),
   PivotPercent(true),
-  PivotScreen(false)
+  PivotScreen(false),
+  PivotOffsetRel(false)
 {
 	alpha = 1;
 	Renderstyle = STYLE_Normal;

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -136,10 +136,7 @@ DEFINE_FIELD(DPSprite, px)
 DEFINE_FIELD(DPSprite, py)
 DEFINE_FIELD(DPSprite, scalex)
 DEFINE_FIELD(DPSprite, scaley)
-DEFINE_FIELD(DPSprite, oldscalex)
-DEFINE_FIELD(DPSprite, oldscaley)
 DEFINE_FIELD(DPSprite, rotation)
-DEFINE_FIELD(DPSprite, oldrotation)
 DEFINE_FIELD_NAMED(DPSprite, Coord[0], Coord0)
 DEFINE_FIELD_NAMED(DPSprite, Coord[1], Coord1)
 DEFINE_FIELD_NAMED(DPSprite, Coord[2], Coord2)
@@ -150,6 +147,7 @@ DEFINE_FIELD(DPSprite, Translation)
 DEFINE_FIELD(DPSprite, HAlign)
 DEFINE_FIELD(DPSprite, VAlign)
 DEFINE_FIELD(DPSprite, alpha)
+DEFINE_FIELD(DPSprite, InterpolateTic)
 DEFINE_FIELD_BIT(DPSprite, Flags, bAddWeapon, PSPF_ADDWEAPON)
 DEFINE_FIELD_BIT(DPSprite, Flags, bAddBob, PSPF_ADDBOB)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPowDouble, PSPF_POWDOUBLE)
@@ -158,6 +156,7 @@ DEFINE_FIELD_BIT(DPSprite, Flags, bFlip, PSPF_FLIP)
 DEFINE_FIELD_BIT(DPSprite, Flags, bMirror, PSPF_MIRROR)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPlayerTranslated, PSPF_PLAYERTRANSLATED)
 DEFINE_FIELD_BIT(DPSprite, Flags, bPivotPercent, PSPF_PIVOTPERCENT)
+DEFINE_FIELD_BIT(DPSprite, Flags, bInterpolate, PSPF_INTERPOLATE)
 
 //------------------------------------------------------------------------
 //
@@ -182,15 +181,16 @@ DPSprite::DPSprite(player_t *owner, AActor *caller, int id)
   scalex(1.0), scaley(1.0),
   px(.0), py(.0),
   rotation(.0),
-  oldscalex(.0), oldscaley(.0),
-  oldrotation(.0),
-  PivotPercent(true),
   HAlign(0),
-  VAlign(0)
+  VAlign(0),
+  InterpolateTic(false)
 {
 	for (int i = 0; i < 4; i++)
-		Coord[i] = DVector2(0,0);
-
+	{
+		Coord[i] = DVector2(0, 0);
+		Prev.v[i] = Vert.v[i] = FVector2(0,0);
+	}
+	
 	alpha = 1;
 	Renderstyle = STYLE_Normal;
 
@@ -698,8 +698,10 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayVertexOffset)
 	if (pspr == nullptr)
 		return 0;
 
-	if (!(flags & WOF_KEEPX))	pspr->Coord[index].X = x;
-	if (!(flags & WOF_KEEPY))	pspr->Coord[index].Y = y;
+	if (!(flags & WOF_KEEPX))	pspr->Coord[index].X = (flags & WOF_ADD) ? pspr->Coord[index].X + x : x;
+	if (!(flags & WOF_KEEPY))	pspr->Coord[index].Y = (flags & WOF_ADD) ? pspr->Coord[index].Y + y : y;
+
+	if (flags & WOF_INTERPOLATE)	pspr->InterpolateTic = true;
 
 	return 0;
 }
@@ -729,16 +731,10 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayScale)
 	if (!(flags & WOF_ZEROY) && wy == 0.0)
 		wy = wx;
 
-	if (!(flags & WOF_KEEPX))
-		pspr->scalex = (flags & WOF_ADD) ? pspr->scalex + wx : wx;
-	if (!(flags & WOF_KEEPY))
-		pspr->scaley = (flags & WOF_ADD) ? pspr->scaley + wy : wy;
+	if (!(flags & WOF_KEEPX))	pspr->scalex = (flags & WOF_ADD) ? pspr->scalex + wx : wx;
+	if (!(flags & WOF_KEEPY))	pspr->scaley = (flags & WOF_ADD) ? pspr->scaley + wy : wy;
 
-	if (!(flags & WOF_INTERPOLATE))
-	{
-		pspr->oldscalex = pspr->scalex;
-		pspr->oldscaley = pspr->scaley;
-	}
+	if (flags & WOF_INTERPOLATE)	pspr->InterpolateTic = true;
 
 	return 0;
 }
@@ -761,13 +757,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayRotate)
 
 	DPSprite *pspr = self->player->FindPSprite(((layer != 0) ? layer : stateinfo->mPSPIndex));
 
-	if (pspr == nullptr)
-		return 0;
-
-	pspr->rotation = (flags & WOF_ADD) ? pspr->rotation + degrees : degrees;
-	
-	if (!(flags & WOF_INTERPOLATE))
-		pspr->oldrotation = degrees;
+	if (pspr != nullptr)
+	{
+		pspr->rotation = (flags & WOF_ADD) ? pspr->rotation + degrees : degrees;
+		if (flags & WOF_INTERPOLATE)	pspr->InterpolateTic = true;
+	}
 
 	return 0;
 }
@@ -803,10 +797,10 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayPivot)
 		wx = nx; wy = ny;
 	}
 
-	if (!(flags & WOF_KEEPX))
-		pspr->px = (flags & WOF_ADD) ? pspr->px + wx : wx;
-	if (!(flags & WOF_KEEPY))
-		pspr->py = (flags & WOF_ADD) ? pspr->py + wy : wy;
+	if (!(flags & WOF_KEEPX))	pspr->px = (flags & WOF_ADD) ? pspr->px + wx : wx;
+	if (!(flags & WOF_KEEPY))	pspr->py = (flags & WOF_ADD) ? pspr->py + wy : wy;
+
+	if (flags & WOF_INTERPOLATE)	pspr->InterpolateTic = true;
 
 	return 0;
 }
@@ -843,30 +837,17 @@ void A_OverlayOffset(AActor *self, int layer, double wx, double wy, int flags)
 			wx = nx; wy = ny;
 		}
 
-		if (!(flags & WOF_KEEPX))
+		if (!(flags & WOF_KEEPX))		psp->x = (flags & WOF_ADD) ? psp->x + wx : wx;
+		if (!(flags & WOF_KEEPY))		psp->y = (flags & WOF_ADD) ? psp->y + wy : wy;
+		
+		if (flags & WOF_INTERPOLATE)	psp->InterpolateTic = true;
+		/*
+		if (!(flags & (WOF_INTERPOLATE|WOF_ADD))) 
 		{
-			if (flags & WOF_ADD)
-			{
-				psp->x += wx;
-			}
-			else
-			{
-				psp->x = wx;
-				if (!(flags & WOF_INTERPOLATE)) psp->oldx = psp->x;
-			}
+			psp->oldx = psp->x;
+			psp->oldy = psp->y;
 		}
-		if (!(flags & WOF_KEEPY))
-		{
-			if (flags & WOF_ADD)
-			{
-				psp->y += wy;
-			}
-			else
-			{
-				psp->y = wy;
-				if (!(flags & WOF_INTERPOLATE)) psp->oldy = psp->y;
-			}
-		}
+		*/
 	}
 }
 
@@ -915,8 +896,14 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayFlags)
 	if (set)
 		pspr->Flags |= flags;
 	else
+	{
 		pspr->Flags &= ~flags;
 
+		// This is the only way to shut off the temporary interpolation tic
+		// in the event another mod is causing potential interference
+		if (flags & PSPF_INTERPOLATE)
+			pspr->ResetInterpolation();
+	}
 	return 0;
 }
 
@@ -1254,10 +1241,7 @@ void DPSprite::Serialize(FSerializer &arc)
 		("py", py)
 		("scalex", scalex)
 		("scaley", scaley)
-		("oldscalex", oldscalex)
-		("oldscaley", oldscaley)
 		("rotation", rotation)
-		("oldrotation", oldrotation)
 		("halign", HAlign)
 		("valign", VAlign)
 		("renderstyle_", Renderstyle);	// The underscore is intentional to avoid problems with old savegames which had this as an ERenderStyle (which is not future proof.)

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -73,6 +73,7 @@ enum PSPFlags
 	PSPF_PLAYERTRANSLATED = 1 << 10,
 	PSPF_PIVOTPERCENT	= 1 << 11,
 	PSPF_PIVOTSCREEN	= 1 << 12,
+	PSPF_PIVOTOFFSETREL	= 1 << 13,
 };
 
 class DPSprite : public DObject
@@ -101,6 +102,7 @@ public:
 
 	bool PivotScreen;		// If true, the pivot is based on the entire screen width/height instead of the image's dimensions/position.
 	bool PivotPercent;		// If true, the pivot goes between [0.0, 1.0]. Otherwise, it's a pixel position offset from the image size.
+	bool PivotOffsetRel;	// If true, x & y are relative to rotation. Otherwise, x is left/right and y is up/down.
 	double px, py;			// pivot points
 	double oldpx, oldpy;	
 	double rotation;		// How much rotation to apply.

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -114,15 +114,15 @@ public:
 	float GetYAdjust(bool fullscreen);
 
 	int HAlign, VAlign;		// Horizontal and vertical alignment
-	double px, py;			// pivot points
-	double rotation;		// How much rotation to apply.
-	double scalex, scaley;	// Scale
+	DAngle rotation;		// How much rotation to apply.
+	DVector2 pivot;			// pivot points
+	DVector2 scale;			// Scale
 	double x, y, alpha;
 	double oldx, oldy;
-	bool InterpolateTic;
-	DVector2 Coord[4];	// Offsets
-	WeaponInterp Prev;	// Interpolation
-	WeaponInterp Vert;	// Current Position
+	bool InterpolateTic;	// One tic interpolation (WOF_INTERPOLATE)
+	DVector2 Coord[4];		// Offsets
+	WeaponInterp Prev;		// Interpolation
+	WeaponInterp Vert;		// Current Position
 	bool firstTic;
 	int Tics;
 	uint32_t Translation;

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -72,7 +72,15 @@ enum PSPFlags
 	PSPF_MIRROR			= 1 << 9,
 	PSPF_PLAYERTRANSLATED = 1 << 10,
 	PSPF_PIVOTPERCENT	= 1 << 11,
-	PSPF_PIVOTSCREEN	= 1 << 12,
+};
+
+enum PSPAlign
+{
+	PSPA_TOP = 0,
+	PSPA_CENTER,
+	PSPA_BOTTOM,
+	PSPA_LEFT = PSPA_TOP,
+	PSPA_RIGHT = 2
 };
 
 class DPSprite : public DObject
@@ -99,16 +107,16 @@ public:
 	std::pair<FRenderStyle, float> GetRenderStyle(FRenderStyle ownerstyle, double owneralpha);
 	float GetYAdjust(bool fullscreen);
 
-	bool PivotScreen;		// If true, the pivot is based on the entire screen width/height instead of the image's dimensions/position.
+	int HAlign, VAlign;		// Horizontal and vertical alignment
 	bool PivotPercent;		// If true, the pivot goes between [0.0, 1.0]. Otherwise, it's a pixel position offset from the image size.
 	double px, py;			// pivot points
-	double oldpx, oldpy;	
 	double rotation;		// How much rotation to apply.
 	double oldrotation;
 	double scalex, scaley;	// Scale
 	double oldscalex, oldscaley;	
 	double x, y, alpha;
 	double oldx, oldy;
+	DVector2 Coord[4];
 	bool firstTic;
 	int Tics;
 	uint32_t Translation;

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -72,6 +72,7 @@ enum PSPFlags
 	PSPF_MIRROR			= 1 << 9,
 	PSPF_PLAYERTRANSLATED = 1 << 10,
 	PSPF_PIVOTPERCENT	= 1 << 11,
+	PSPF_INTERPOLATE	= 1 << 12,
 };
 
 enum PSPAlign
@@ -81,6 +82,11 @@ enum PSPAlign
 	PSPA_BOTTOM,
 	PSPA_LEFT = PSPA_TOP,
 	PSPA_RIGHT = 2
+};
+
+struct WeaponInterp
+{
+	FVector2 v[4];
 };
 
 class DPSprite : public DObject
@@ -102,21 +108,21 @@ public:
 	DPSprite*	GetNext()							  { return Next; }
 	AActor*		GetCaller()							  { return Caller; }
 	void		SetCaller(AActor *newcaller)		  { Caller = newcaller; }
-	void		ResetInterpolation()				  { oldx = x; oldy = y; }
+	void		ResetInterpolation()				  { oldx = x; oldy = y; Prev = Vert; InterpolateTic = false; }
 	void OnDestroy() override;
 	std::pair<FRenderStyle, float> GetRenderStyle(FRenderStyle ownerstyle, double owneralpha);
 	float GetYAdjust(bool fullscreen);
 
 	int HAlign, VAlign;		// Horizontal and vertical alignment
-	bool PivotPercent;		// If true, the pivot goes between [0.0, 1.0]. Otherwise, it's a pixel position offset from the image size.
 	double px, py;			// pivot points
 	double rotation;		// How much rotation to apply.
-	double oldrotation;
 	double scalex, scaley;	// Scale
-	double oldscalex, oldscaley;	
 	double x, y, alpha;
 	double oldx, oldy;
-	DVector2 Coord[4];
+	bool InterpolateTic;
+	DVector2 Coord[4];	// Offsets
+	WeaponInterp Prev;	// Interpolation
+	WeaponInterp Vert;	// Current Position
 	bool firstTic;
 	int Tics;
 	uint32_t Translation;

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -70,7 +70,9 @@ enum PSPFlags
 	PSPF_FORCEALPHA		= 1 << 7,
 	PSPF_FORCESTYLE		= 1 << 8,
 	PSPF_MIRROR			= 1 << 9,
-	PSPF_PLAYERTRANSLATED = 1 << 10
+	PSPF_PLAYERTRANSLATED = 1 << 10,
+	PSPF_PIVOTPERCENT	= 1 << 11,
+	PSPF_PIVOTSCREEN	= 1 << 12,
 };
 
 class DPSprite : public DObject
@@ -97,6 +99,14 @@ public:
 	std::pair<FRenderStyle, float> GetRenderStyle(FRenderStyle ownerstyle, double owneralpha);
 	float GetYAdjust(bool fullscreen);
 
+	bool PivotScreen;		// If true, the pivot is based on the entire screen width/height instead of the image's dimensions/position.
+	bool PivotPercent;		// If true, the pivot goes between [0.0, 1.0]. Otherwise, it's a pixel position offset from the image size.
+	double px, py;			// pivot points
+	double oldpx, oldpy;	
+	double rotation;		// How much rotation to apply.
+	double oldrotation;
+	double scalex, scaley;	// Scale
+	double oldscalex, oldscaley;	
 	double x, y, alpha;
 	double oldx, oldy;
 	bool firstTic;

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -73,7 +73,6 @@ enum PSPFlags
 	PSPF_PLAYERTRANSLATED = 1 << 10,
 	PSPF_PIVOTPERCENT	= 1 << 11,
 	PSPF_PIVOTSCREEN	= 1 << 12,
-	PSPF_PIVOTOFFSETREL	= 1 << 13,
 };
 
 class DPSprite : public DObject
@@ -102,7 +101,6 @@ public:
 
 	bool PivotScreen;		// If true, the pivot is based on the entire screen width/height instead of the image's dimensions/position.
 	bool PivotPercent;		// If true, the pivot goes between [0.0, 1.0]. Otherwise, it's a pixel position offset from the image size.
-	bool PivotOffsetRel;	// If true, x & y are relative to rotation. Otherwise, x is left/right and y is up/down.
 	double px, py;			// pivot points
 	double oldpx, oldpy;	
 	double rotation;		// How much rotation to apply.

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -291,7 +291,7 @@ public:
 	void GetDynSpriteLight(AActor *thing, particle_t *particle, float *out);
 
 	void PreparePlayerSprites(sector_t * viewsector, area_t in_area);
-	void PrepareTargeterSprites(WeaponPosition *weap);
+	void PrepareTargeterSprites(double ticfrac);
 
 	void UpdateCurrentMapSection();
 	void SetViewMatrix(const FRotator &angles, float vx, float vy, float vz, bool mirror, bool planemirror);

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -291,7 +291,7 @@ public:
 	void GetDynSpriteLight(AActor *thing, particle_t *particle, float *out);
 
 	void PreparePlayerSprites(sector_t * viewsector, area_t in_area);
-	void PrepareTargeterSprites();
+	void PrepareTargeterSprites(WeaponPosition *weap);
 
 	void UpdateCurrentMapSection();
 	void SetViewMatrix(const FRotator &angles, float vx, float vy, float vz, bool mirror, bool planemirror);

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -489,69 +489,67 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	// Big thanks to IvanDobrovski who helped me modify this.
 	if (psp->rotation != 0.0 || psp->scalex != 1.0 || psp->scaley != 1.0)
 	{
-		FAngle rot = (float)psp->rotation;
+		FAngle rot = float(psp->rotation);
 		rot.Normalized360();
-		float radang = rot.Radians();
-		float cosang = cos(radang);
-		float sinang = sin(radang);
-
-		float xcenter, ycenter;
-
+		float cosang = rot.Cos();
+		float sinang = rot.Sin();
 		float px = float(psp->px);
 		float py = float(psp->py);
-
+		
+		float xcenter, ycenter;
+		float width = MAX(x1, x2) - MIN(x1, x2);
+		float height = MAX(y1, y2) - MIN(y1, y2);
 		if (psp->Flags & PSPF_PIVOTSCREEN)
 		{
 			if (psp->Flags & PSPF_PIVOTPERCENT)
 			{
-				xcenter = vw * psp->px + viewwindowx + psp->x;
-				ycenter = vh * psp->py + viewwindowy + psp->y;
+				xcenter = vw * px + viewwindowx;
+				ycenter = vh * py + viewwindowy;
 			}
 			else
 			{
-				xcenter = vw * 0.5 + viewwindowx + psp->x + psp->px;
-				ycenter = vh * 0.5 + viewwindowy + psp->y + psp->py;
+				xcenter = vw * 0.5 + viewwindowx + px;
+				ycenter = vh * 0.5 + viewwindowy + py;
 			}
 		}
 		else
 		{
 			if (psp->Flags & PSPF_PIVOTPERCENT)
 			{
-				xcenter = (x1 + x2) * psp->px + psp->x;
-				ycenter = (y1 + y2) * psp->py + psp->y;
+				xcenter = (x1 + width * px);
+				ycenter = (y1 + height * py);
 			}
 			else
 			{
-				xcenter = ((x1 + x2) * 0.5 + psp->x) + psp->px;
-				ycenter = ((x1 + x2) * 0.5 + psp->y) + psp->py;
+				xcenter = (x1 + width * 0.5) + px;
+				ycenter = (y1 + height * 0.5) - py;
 			}
 		}
-
 		x1 -= xcenter;
 		y1 -= ycenter;
 
 		x2 -= xcenter;
 		y2 -= ycenter;
-
-		float ssx = (float)psp->scalex;
-		float ssy = (float)psp->scaley;
+		
+		float ssx = float(psp->scalex);
+		float ssy = float(psp->scaley);
 
 		float xx1 = xcenter + ssx * (x1 * cosang + y1 * sinang);
-		float yy1 = ycenter - ssy * (x1 * sinang - y1 * cosang);
-
 		float xx2 = xcenter + ssx * (x1 * cosang + y2 * sinang);
-		float yy2 = ycenter - ssy * (x1 * sinang - y2 * cosang);
-
 		float xx3 = xcenter + ssx * (x2 * cosang + y1 * sinang);
-		float yy3 = ycenter - ssy * (x2 * sinang - y1 * cosang);
-
 		float xx4 = xcenter + ssx * (x2 * cosang + y2 * sinang);
+
+		float yy1 = ycenter - ssy * (x1 * sinang - y1 * cosang);
+		float yy2 = ycenter - ssy * (x1 * sinang - y2 * cosang);
+		float yy3 = ycenter - ssy * (x2 * sinang - y1 * cosang);
 		float yy4 = ycenter - ssy * (x2 * sinang - y2 * cosang);
+		
 
 		verts.first[0].Set(xx1, yy1, 0, u1, v1);
 		verts.first[1].Set(xx2, yy2, 0, u1, v2);
 		verts.first[2].Set(xx3, yy3, 0, u2, v1);
 		verts.first[3].Set(xx4, yy4, 0, u2, v2);
+		
 	}
 	else
 	{

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -485,29 +485,67 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	auto verts = screen->mVertexData->AllocVertices(4);
 	mx = verts.second;
 
-
+	// [MC] Code copied from DTA_Rotate
+	// Big thanks to IvanDobrovski who helped me modify this.
 	if (psp->rotation != 0.0 || psp->scalex != 1.0 || psp->scaley != 1.0)
 	{
-		double radang = psp->rotation * (pi::pi() / 180.);
-		double cosang = cos(radang);
-		double sinang = sin(radang);
+		float radang = psp->rotation * (pi::pi() / 180.);
+		float cosang = -cos(radang);
+		float sinang = -sin(radang);
 
-		double xcenter = psp->x;
-		double ycenter = psp->y;
+		float xcenter, ycenter;
 
+		float px = float(psp->px);
+		float py = float(psp->py);
 
-		double xx1 = xcenter + psp->scalex * (x1 * cosang + y1 * sinang);
-		double yy1 = ycenter + psp->scaley * (x1 * sinang - y1 * cosang);
+		if (psp->Flags & PSPF_PIVOTSCREEN)
+		{
+			if (psp->Flags & PSPF_PIVOTPERCENT)
+			{
+				xcenter = vw * psp->px + viewwindowx + psp->x;
+				ycenter = vh * psp->py + viewwindowy + psp->y;
+			}
+			else
+			{
+				xcenter = vw * 0.5 + viewwindowx + psp->x + psp->px;
+				ycenter = vh * 0.5 + viewwindowy + psp->y + psp->py;
+			}
+		}
+		else
+		{
+			if (psp->Flags & PSPF_PIVOTPERCENT)
+			{
+				xcenter = (x1 + x2) * psp->px + psp->x;
+				ycenter = (y1 + y2) * psp->py + psp->y;
+			}
+			else
+			{
+				xcenter = ((x1 + x2) * 0.5 + psp->x) + psp->px;
+				ycenter = ((x1 + x2) * 0.5 + psp->y) + psp->py;
+			}
+		}
 
-		double xx2 = xcenter + psp->scalex * (x1 * cosang + y2 * sinang);
-		double yy2 = ycenter + psp->scaley * (x1 * sinang - y2 * cosang);
+		x1 -= xcenter;
+		y1 -= ycenter;
 
-		double xx3 = xcenter + psp->scalex * (x2 * cosang + y1 * sinang);
-		double yy3 = ycenter + psp->scaley * (x2 * sinang - y1 * cosang);
+		x2 -= xcenter;
+		y2 -= ycenter;
 
-		double xx4 = xcenter + psp->scalex * (x2 * cosang + y2 * sinang);
-		double yy4 = ycenter + psp->scaley * (x2 * sinang - y2 * cosang);
-	
+		float ssx = (float)psp->scalex;
+		float ssy = (float)psp->scaley;
+
+		float xx1 = xcenter + ssx * (x1 * cosang + y1 * sinang);
+		float yy1 = ycenter + ssy * (x1 * sinang - y1 * cosang);
+
+		float xx2 = xcenter + ssx * (x1 * cosang + y2 * sinang);
+		float yy2 = ycenter + ssy * (x1 * sinang - y2 * cosang);
+
+		float xx3 = xcenter + ssx * (x2 * cosang + y1 * sinang);
+		float yy3 = ycenter + ssy * (x2 * sinang - y1 * cosang);
+
+		float xx4 = xcenter + ssx * (x2 * cosang + y2 * sinang);
+		float yy4 = ycenter + ssy * (x2 * sinang - y2 * cosang);
+
 		verts.first[0].Set(xx1, yy1, 0, u1, v1);
 		verts.first[1].Set(xx2, yy2, 0, u1, v2);
 		verts.first[2].Set(xx3, yy3, 0, u2, v1);
@@ -515,7 +553,6 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	}
 	else
 	{
-
 		verts.first[0].Set(x1, y1, 0, u1, v1);
 		verts.first[1].Set(x1, y2, 0, u1, v2);
 		verts.first[2].Set(x2, y1, 0, u2, v1);

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -490,8 +490,8 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	if (psp->rotation != 0.0 || psp->scalex != 1.0 || psp->scaley != 1.0)
 	{
 		float radang = psp->rotation * (pi::pi() / 180.);
-		float cosang = -cos(radang);
-		float sinang = -sin(radang);
+		float cosang = cos(radang);
+		float sinang = sin(radang);
 
 		float xcenter, ycenter;
 
@@ -535,16 +535,16 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 		float ssy = (float)psp->scaley;
 
 		float xx1 = xcenter + ssx * (x1 * cosang + y1 * sinang);
-		float yy1 = ycenter + ssy * (x1 * sinang - y1 * cosang);
+		float yy1 = ycenter - ssy * (x1 * sinang - y1 * cosang);
 
 		float xx2 = xcenter + ssx * (x1 * cosang + y2 * sinang);
-		float yy2 = ycenter + ssy * (x1 * sinang - y2 * cosang);
+		float yy2 = ycenter - ssy * (x1 * sinang - y2 * cosang);
 
 		float xx3 = xcenter + ssx * (x2 * cosang + y1 * sinang);
-		float yy3 = ycenter + ssy * (x2 * sinang - y1 * cosang);
+		float yy3 = ycenter - ssy * (x2 * sinang - y1 * cosang);
 
 		float xx4 = xcenter + ssx * (x2 * cosang + y2 * sinang);
-		float yy4 = ycenter + ssy * (x2 * sinang - y2 * cosang);
+		float yy4 = ycenter - ssy * (x2 * sinang - y2 * cosang);
 
 		verts.first[0].Set(xx1, yy1, 0, u1, v1);
 		verts.first[1].Set(xx2, yy2, 0, u1, v2);

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -540,7 +540,6 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	if (psp->scale.X == 0.0 || psp->scale.Y == 0.0)
 		return false;
 
-	bool vertsOnScreen = false;
 	const bool interp = (psp->InterpolateTic || psp->Flags & PSPF_INTERPOLATE);
 
 	for (int i = 0; i < 4; i++)
@@ -549,15 +548,23 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 		if (interp)
 			t = psp->Prev.v[i] + (psp->Vert.v[i] - psp->Prev.v[i]) * ticfrac;
 
-		if (!vertsOnScreen)
-			vertsOnScreen = (t.X >= 0.0 && t.X <= vw);
-
 		Vert.v[i] = t;
 	}
-
-	if (!vertsOnScreen)
+	
+	// [MC] If this is absolutely necessary, uncomment it. It just checks if all the vertices 
+	// are all off screen either to the right or left, but is it honestly needed?
+	/*
+	if ((
+		Vert.v[0].X > 0.0 &&
+		Vert.v[1].X > 0.0 &&
+		Vert.v[2].X > 0.0 &&
+		Vert.v[3].X > 0.0) || (
+		Vert.v[0].X < vw &&
+		Vert.v[1].X < vw &&
+		Vert.v[2].X < vw &&
+		Vert.v[3].X < vw))
 		return false;
-
+	*/
 	auto verts = screen->mVertexData->AllocVertices(4);
 	mx = verts.second;
 

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -489,7 +489,9 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	// Big thanks to IvanDobrovski who helped me modify this.
 	if (psp->rotation != 0.0 || psp->scalex != 1.0 || psp->scaley != 1.0)
 	{
-		float radang = psp->rotation * (pi::pi() / 180.);
+		FAngle rot = (float)psp->rotation;
+		rot.Normalized360();
+		float radang = rot.Radians();
 		float cosang = cos(radang);
 		float sinang = sin(radang);
 

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -481,7 +481,7 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 		const float cx = (flip) ? -psp->Coord[i].X : psp->Coord[i].X;
 		Vert.v[i] += FVector2(cx * scalex, psp->Coord[i].Y * scale);
 	}
-	if (psp->rotation != 0.0 || psp->scalex != 1.0 || psp->scaley != 1.0)
+	if (psp->rotation != 0.0 || !psp->scale.isZero())
 	{
 		// [MC] Sets up the alignment for starting the pivot at, in a corner.
 		float anchorx, anchory;
@@ -503,16 +503,15 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 		// Handle PSPF_FLIP.
 		if (flip) anchorx = 1.0 - anchorx;
 
-		FAngle rot = float((flip) ? -psp->rotation : psp->rotation);
-		rot.Normalized360();
+		FAngle rot = float((flip) ? -psp->rotation.Degrees : psp->rotation.Degrees);
 		const float cosang = rot.Cos();
 		const float sinang = rot.Sin();
 		
 		float xcenter, ycenter;
 		const float width = x2 - x1;
 		const float height = y2 - y1;
-		const float px = float((flip) ? -psp->px : psp->px);
-		const float py = float(psp->py);
+		const float px = float((flip) ? -psp->pivot.X : psp->pivot.X);
+		const float py = float(psp->pivot.Y);
 
 		// Set up the center and offset accordingly. PivotPercent changes it to be a range [0.0, 1.0]
 		// instead of pixels and is enabled by default.
@@ -531,14 +530,14 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 		for (int i = 0; i < 4; i++)
 		{
 			Vert.v[i] -= {xcenter, ycenter};
-			const float xx = xcenter + psp->scalex * (Vert.v[i].X * cosang + Vert.v[i].Y * sinang);
-			const float yy = ycenter - psp->scaley * (Vert.v[i].X * sinang - Vert.v[i].Y * cosang);
+			const float xx = xcenter + psp->scale.X * (Vert.v[i].X * cosang + Vert.v[i].Y * sinang);
+			const float yy = ycenter - psp->scale.Y * (Vert.v[i].X * sinang - Vert.v[i].Y * cosang);
 			Vert.v[i] = {xx, yy};
 		}
 	}
 	psp->Vert = Vert;
 
-	if (psp->scalex == 0.0 || psp->scaley == 0.0)
+	if (psp->scale.X == 0.0 || psp->scale.Y == 0.0)
 		return false;
 
 	bool vertsOnScreen = false;

--- a/src/rendering/hwrenderer/scene/hw_weapon.h
+++ b/src/rendering/hwrenderer/scene/hw_weapon.h
@@ -15,6 +15,9 @@ struct WeaponPosition
 {
 	float wx, wy;
 	float bobx, boby;
+	float sx, sy;
+	float px, py;
+	float r;
 	DPSprite *weapon;
 };
 
@@ -47,6 +50,6 @@ struct HUDSprite
 
 	void SetBright(bool isbelow);
 	bool GetWeaponRenderStyle(DPSprite *psp, AActor *playermo, sector_t *viewsector, WeaponLighting &light);
-	bool GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy, player_t *player);
+	bool GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy, player_t *player, WeaponPosition *weap);
 
 };

--- a/src/rendering/hwrenderer/scene/hw_weapon.h
+++ b/src/rendering/hwrenderer/scene/hw_weapon.h
@@ -16,7 +16,6 @@ struct WeaponPosition
 	float wx, wy;
 	float bobx, boby;
 	float sx, sy;
-	float px, py;
 	float r;
 	DPSprite *weapon;
 };

--- a/src/rendering/hwrenderer/scene/hw_weapon.h
+++ b/src/rendering/hwrenderer/scene/hw_weapon.h
@@ -15,8 +15,6 @@ struct WeaponPosition
 {
 	float wx, wy;
 	float bobx, boby;
-	float sx, sy;
-	float r;
 	DPSprite *weapon;
 };
 
@@ -49,6 +47,6 @@ struct HUDSprite
 
 	void SetBright(bool isbelow);
 	bool GetWeaponRenderStyle(DPSprite *psp, AActor *playermo, sector_t *viewsector, WeaponLighting &light);
-	bool GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy, player_t *player, WeaponPosition *weap);
+	bool GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy, player_t *player, double ticfrac);
 
 };

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1181,6 +1181,9 @@ class Actor : Thinker native
 
 	action native bool A_Overlay(int layer, statelabel start = null, bool nooverride = false);
 	native void A_WeaponOffset(double wx = 0, double wy = 32, int flags = 0);
+	action native void A_OverlayScale(int layer, double wx = 1, double wy = 0, int flags = 0);
+	action native void A_OverlayRotate(int layer, double degrees = 0, int flags = 0);
+	action native void A_OverlayPivot(int layer, double wx = 0.5, double wy = 0.5, int flags = 0);
 	action native void A_OverlayOffset(int layer = PSP_WEAPON, double wx = 0, double wy = 32, int flags = 0);
 	action native void A_OverlayFlags(int layer, int flags, bool set);
 	action native void A_OverlayAlpha(int layer, double alph);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1184,6 +1184,8 @@ class Actor : Thinker native
 	action native void A_OverlayScale(int layer, double wx = 1, double wy = 0, int flags = 0);
 	action native void A_OverlayRotate(int layer, double degrees = 0, int flags = 0);
 	action native void A_OverlayPivot(int layer, double wx = 0.5, double wy = 0.5, int flags = 0);
+	action native void A_OverlayPivotAlign(int layer, int halign, int valign);
+	action native void A_OverlayVertexOffset(int layer, int index, double x, double y, int flags = 0);
 	action native void A_OverlayOffset(int layer = PSP_WEAPON, double wx = 0, double wy = 32, int flags = 0);
 	action native void A_OverlayFlags(int layer, int flags, bool set);
 	action native void A_OverlayAlpha(int layer, double alph);

--- a/wadsrc/static/zscript/actors/heretic/chicken.zs
+++ b/wadsrc/static/zscript/actors/heretic/chicken.zs
@@ -60,6 +60,7 @@ class Beak : Weapon
 		if (psp)
 		{
 			psp.y = WEAPONTOP;
+			ResetPSprite(psp);
 		}
 		player.SetPsprite(PSP_WEAPON, player.ReadyWeapon.GetReadyState());
 	}

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -217,8 +217,10 @@ class Weapon : StateProvider
 	{
 		if (!psp)	return;
 		psp.rotation = 0;
-		psp.scalex = 1.0;
-		psp.scaley = 1.0;
+		psp.scale.x = 1;
+		psp.scale.y = 1;
+		psp.pivot.x = 0;
+		psp.pivot.y = 0;
 		psp.valign = 0;
 		psp.halign = 0;
 		psp.Coord0 = (0,0);

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -213,6 +213,20 @@ class Weapon : StateProvider
 	//
 	//---------------------------------------------------------------------------
 
+	action void ResetPSprite(PSprite psp)
+	{
+		if (!psp)	return;
+		psp.rotation = 0;
+		psp.scalex = 1.0;
+		psp.scaley = 1.0;
+		psp.valign = 0;
+		psp.halign = 0;
+		psp.Coord0 = (0,0);
+		psp.Coord1 = (0,0);
+		psp.Coord2 = (0,0);
+		psp.Coord3 = (0,0);
+	}
+
 	action void A_Lower(int lowerspeed = 6)
 	{
 		let player = player;
@@ -240,6 +254,8 @@ class Weapon : StateProvider
 		{ // Not lowered all the way yet
 			return;
 		}
+		ResetPSprite(psp);
+		
 		if (player.playerstate == PST_DEAD)
 		{ // Player is dead, so don't bring up a pending weapon
 			// Player is dead, so keep the weapon off screen
@@ -278,12 +294,18 @@ class Weapon : StateProvider
 		}
 		let psp = player.GetPSprite(PSP_WEAPON);
 		if (!psp) return;
+
+		if (psp.y <= WEAPONBOTTOM)
+		{
+			ResetPSprite(psp);
+		}
 		psp.y -= raisespeed;
 		if (psp.y > WEAPONTOP)
 		{ // Not raised all the way yet
 			return;
 		}
 		psp.y = WEAPONTOP;
+		
 		psp.SetState(player.ReadyWeapon.GetReadyState());
 		return;
 	}

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2557,6 +2557,16 @@ class PSprite : Object native play
 	native double y;
 	native double oldx;
 	native double oldy;
+	native double px;
+	native double py;
+	native double oldpx;
+	native double oldpy;
+	native double scalex;
+	native double scaley;
+	native double oldscalex;
+	native double oldscaley;
+	native double rotation;
+	native double oldrotation;
 	native double alpha;
 	native Bool firstTic;
 	native int Tics;
@@ -2568,6 +2578,8 @@ class PSprite : Object native play
 	native bool bFlip;	
 	native bool bMirror;
 	native bool bPlayerTranslated;
+	native bool bPivotPercent;
+	native bool bPivotScreen;
 
 	native void SetState(State newstate, bool pending = false);
 

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1664,7 +1664,11 @@ class PlayerPawn : Actor
 			if (player.ReadyWeapon != null)
 			{
 				let psp = player.GetPSprite(PSP_WEAPON);
-				if (psp) psp.y = WEAPONTOP;
+				if (psp) 
+				{
+					psp.y = WEAPONTOP;
+					player.ReadyWeapon.ResetPSprite(psp);
+				}
 				player.SetPsprite(PSP_WEAPON, player.ReadyWeapon.GetReadyState());
 			}
 			return;
@@ -2559,14 +2563,17 @@ class PSprite : Object native play
 	native double oldy;
 	native double px;
 	native double py;
-	native double oldpx;
-	native double oldpy;
 	native double scalex;
 	native double scaley;
 	native double oldscalex;
 	native double oldscaley;
 	native double rotation;
 	native double oldrotation;
+	native int HAlign, VAlign;
+	native Vector2 Coord0;
+	native Vector2 Coord1;
+	native Vector2 Coord2;
+	native Vector2 Coord3;
 	native double alpha;
 	native Bool firstTic;
 	native int Tics;
@@ -2579,7 +2586,6 @@ class PSprite : Object native play
 	native bool bMirror;
 	native bool bPlayerTranslated;
 	native bool bPivotPercent;
-	native bool bPivotScreen;
 
 	native void SetState(State newstate, bool pending = false);
 

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2580,7 +2580,6 @@ class PSprite : Object native play
 	native bool bPlayerTranslated;
 	native bool bPivotPercent;
 	native bool bPivotScreen;
-	native bool bPivotOffsetRel;
 
 	native void SetState(State newstate, bool pending = false);
 

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2561,10 +2561,8 @@ class PSprite : Object native play
 	native double y;
 	native double oldx;
 	native double oldy;
-	native double px;
-	native double py;
-	native double scalex;
-	native double scaley;
+	native Vector2 pivot;
+	native Vector2 scale;
 	native double rotation;
 	native int HAlign, VAlign;
 	native Vector2 Coord0;		// [MC] Not the actual coordinates. Just the offsets by A_OverlayVertexOffset.

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2565,17 +2565,15 @@ class PSprite : Object native play
 	native double py;
 	native double scalex;
 	native double scaley;
-	native double oldscalex;
-	native double oldscaley;
 	native double rotation;
-	native double oldrotation;
 	native int HAlign, VAlign;
-	native Vector2 Coord0;
+	native Vector2 Coord0;		// [MC] Not the actual coordinates. Just the offsets by A_OverlayVertexOffset.
 	native Vector2 Coord1;
 	native Vector2 Coord2;
 	native Vector2 Coord3;
 	native double alpha;
 	native Bool firstTic;
+	native bool InterpolateTic;
 	native int Tics;
 	native uint Translation;
 	native bool bAddWeapon;
@@ -2586,6 +2584,7 @@ class PSprite : Object native play
 	native bool bMirror;
 	native bool bPlayerTranslated;
 	native bool bPivotPercent;
+	native bool bInterpolate;
 
 	native void SetState(State newstate, bool pending = false);
 

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2580,6 +2580,7 @@ class PSprite : Object native play
 	native bool bPlayerTranslated;
 	native bool bPivotPercent;
 	native bool bPivotScreen;
+	native bool bPivotOffsetRel;
 
 	native void SetState(State newstate, bool pending = false);
 

--- a/wadsrc/static/zscript/actors/player/player_morph.zs
+++ b/wadsrc/static/zscript/actors/player/player_morph.zs
@@ -60,7 +60,11 @@ extend class PlayerPawn
 		if (player.ReadyWeapon != null)
 		{
 			let psp = player.GetPSprite(PSP_WEAPON);
-			if (psp) psp.y = WEAPONTOP;
+			if (psp) 
+			{
+				psp.y = WEAPONTOP;
+				player.ReadyWeapon.ResetPSprite(psp);
+			}
 		}
 
 		if (morphweaponcls == null || !(morphweaponcls is 'Weapon'))

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -739,6 +739,7 @@ enum EWeaponOffsetFlags
 	WOF_KEEPY =		1 << 1,
 	WOF_ADD =		1 << 2,
 	WOF_INTERPOLATE = 1 << 3,
+	WOF_RELATIVE	= 1 << 4,
 };
 
 // Flags for psprite layers

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -740,6 +740,7 @@ enum EWeaponOffsetFlags
 	WOF_ADD =		1 << 2,
 	WOF_INTERPOLATE = 1 << 3,
 	WOF_RELATIVE	= 1 << 4,
+	WOF_ZEROY		= 1 << 5,
 };
 
 // Flags for psprite layers

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -758,6 +758,7 @@ enum EPSpriteFlags
 	PSPF_MIRROR			= 1 << 9,
 	PSPF_PLAYERTRANSLATED = 1 << 10,
 	PSPF_PIVOTPERCENT	= 1 << 11,
+	PSPF_INTERPOLATE	= 1 << 12,
 };
 
 // Alignment constants for A_OverlayPivotAlign

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -746,17 +746,28 @@ enum EWeaponOffsetFlags
 // Flags for psprite layers
 enum EPSpriteFlags
 {
-	PSPF_ADDWEAPON	= 1 << 0,
-	PSPF_ADDBOB		= 1 << 1,
-	PSPF_POWDOUBLE	= 1 << 2,
-	PSPF_CVARFAST	= 1 << 3,
-	PSPF_ALPHA		= 1 << 4,
-	PSPF_RENDERSTYLE= 1 << 5,
-	PSPF_FLIP		= 1 << 6,
-	PSPF_FORCEALPHA	= 1 << 7,
-	PSPF_FORCESTYLE	= 1 << 8,
-	PSPF_MIRROR		= 1 << 9,
-	PSPF_PLAYERTRANSLATED = 1 << 10
+	PSPF_ADDWEAPON		= 1 << 0,
+	PSPF_ADDBOB			= 1 << 1,
+	PSPF_POWDOUBLE		= 1 << 2,
+	PSPF_CVARFAST		= 1 << 3,
+	PSPF_ALPHA			= 1 << 4,
+	PSPF_RENDERSTYLE	= 1 << 5,
+	PSPF_FLIP			= 1 << 6,
+	PSPF_FORCEALPHA		= 1 << 7,
+	PSPF_FORCESTYLE		= 1 << 8,
+	PSPF_MIRROR			= 1 << 9,
+	PSPF_PLAYERTRANSLATED = 1 << 10,
+	PSPF_PIVOTPERCENT	= 1 << 11,
+};
+
+// Alignment constants for A_OverlayPivotAlign
+enum EPSpriteAlign
+{
+	PSPA_TOP = 0,
+	PSPA_CENTER,
+	PSPA_BOTTOM,
+	PSPA_LEFT = PSPA_TOP,
+	PSPA_RIGHT = 2
 };
 
 // Default psprite layers


### PR DESCRIPTION
This submission adds the ability to manipulate the visuals of PSprites far more than ever before: Scaling, rotating, pivoting and vertex manipulation.

The functions effectively follow the usual A_Overlay* format.

`A_OverlayScale(int layer, double x, double y, int flags);`
Changes the overlay's scale. Behaves similar to A_SetScale, but has `WOF_ZEROY` to allow for y scale to be 0.

`A_OverlayRotate(int layer, double degrees, int flags);`
Changes the overlay's rotation.

`A_OverlayPivot(int layer, double x, double y, int flags);`
Offsets the pivot point for the overlay's rotation and scale.

`A_OverlayPivotAlign(int layer, int halign, int valign);`
Sets the alignment start at one of the corners.
- `halign`: Horizontal alignment. Values can be `PSPA_LEFT`, `PSPA_CENTER`, or `PSPA_RIGHT`
- `valign`: Vertical alignment. Values can be `PSPA_TOP`, `PSPA_CENTER`, or `PSPA_BOTTOM`
- Defaults to top left.

`A_OverlayVertexOffset(int layer, int index, double x, double y, int flags);`
Modifies one of the four vertices that make up the image. Essentially allows for skewing of the weapon sprite.
- `index`: Specifies the index to manipulate. Valid numbers are within range [0,3].

NOTE: In order to maintain backwards compatibility, `A_OverlayOffset` has the final say on whether an overlay interpolates or not. Some mods use this function to cancel interpolation completely.

-----
New overlay flags:
- `PSPF_INTERPOLATE`: A persistent flag to always interpolate so actors don't need to specify `WOF_INTERPOLATE`. Ignored by `A_OverlayOffset`.
- `PSPF_PIVOTPERCENT`: Applied to weapon PSprites by default. Turns the pivot offsets into a scalar (so (0.5, 0.5) means the center of the sprite's bounding box).
