### PR TITLE
Show CVar's default value in addition to current

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -150,6 +150,11 @@ const char *FBaseCVar::GetHumanString(int precision) const
 	return GetGenericRep(CVAR_String).String;
 }
 
+const char *FBaseCVar::GetHumanStringDefault(int precision) const
+{
+	return GetGenericRepDefault(CVAR_String).String;
+}
+
 void FBaseCVar::ForceSet (UCVarValue value, ECVarType type, bool nouserinfosend)
 {
 	DoSet (value, type);
@@ -650,6 +655,16 @@ const char *FFloatCVar::GetHumanString(int precision) const
 		precision = 6;
 	}
 	mysnprintf(cstrbuf, countof(cstrbuf), "%.*g", precision, Value);
+	return cstrbuf;
+}
+
+const char *FFloatCVar::GetHumanStringDefault(int precision) const
+{
+	if (precision < 0)
+	{
+		precision = 6;
+	}
+	mysnprintf(cstrbuf, countof(cstrbuf), "%.*g", precision, DefaultValue);
 	return cstrbuf;
 }
 

--- a/src/common/console/c_cvars.h
+++ b/src/common/console/c_cvars.h
@@ -161,6 +161,7 @@ public:
 	virtual UCVarValue GetGenericRep (ECVarType type) const = 0;
 	virtual UCVarValue GetFavoriteRep (ECVarType *type) const = 0;
 
+	virtual const char *GetHumanStringDefault(int precision = -1) const;
 	virtual UCVarValue GetGenericRepDefault (ECVarType type) const = 0;
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const = 0;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type) = 0;
@@ -339,6 +340,7 @@ public:
 	virtual UCVarValue GetFavoriteRepDefault (ECVarType *type) const override;
 	virtual void SetGenericRepDefault (UCVarValue value, ECVarType type) override;
 	const char *GetHumanString(int precision) const override;
+	const char *GetHumanStringDefault(int precision) const override;
 
 	float operator= (float floatval)
 		{ UCVarValue val; val.Float = floatval; SetGenericRep (val, CVAR_Float); return floatval; }

--- a/src/common/console/c_dispatch.cpp
+++ b/src/common/console/c_dispatch.cpp
@@ -302,7 +302,8 @@ void C_DoCommand (const char *cmd, int keynum)
 			else
 			{ // Get the variable's value
 				if (var->GetDescription().Len()) Printf("%s\n", GStrings.localize(var->GetDescription()));
-				Printf ("\"%s\" is \"%s\"\n", var->GetName(), var->GetHumanString());
+				Printf ("\"%s\" is \"%s\" ", var->GetName(), var->GetHumanString());
+				Printf ("(default: \"%s\")\n", var->GetHumanStringDefault());
 			}
 		}
 		else
@@ -1149,4 +1150,3 @@ CCMD (pullin)
 	Printf (TEXTCOLOR_BOLD "Pullin" TEXTCOLOR_NORMAL " is only valid from .cfg\n"
 			"files and only when used at startup.\n");
 }
-


### PR DESCRIPTION
This PR changes console behavior to also print the default CVar value when a CVar name is entered.

For example:
```
]autoaim
"autoaim" is "0" (default: "35")
```

