### PR TITLE
Add optional filtering to `listmaps` CCMD output

### DIFF
--- a/src/g_dumpinfo.cpp
+++ b/src/g_dumpinfo.cpp
@@ -367,8 +367,14 @@ CCMD(listmaps)
 
 		if (map != NULL)
 		{
-			Printf("%s: '%s' (%s)\n", info->MapName.GetChars(), info->LookupLevelName().GetChars(),
-				fileSystem.GetResourceFileName(fileSystem.GetFileContainer(map->lumpnum)));
+			if (argv.argc() == 1 
+			    || CheckWildcards(argv[1], info->MapName.GetChars()) 
+			    || CheckWildcards(argv[1], info->LookupLevelName().GetChars())
+			    || CheckWildcards(argv[1], fileSystem.GetResourceFileName(fileSystem.GetFileContainer(map->lumpnum))))
+			{
+				Printf("%s: '%s' (%s)\n", info->MapName.GetChars(), info->LookupLevelName().GetChars(),
+					fileSystem.GetResourceFileName(fileSystem.GetFileContainer(map->lumpnum)));
+			}
 			delete map;
 		}
 	}
@@ -405,4 +411,3 @@ CCMD(listsnapshots)
 		}
 	}
 }
-


### PR DESCRIPTION
This PR adds an optional argument to `listmaps`, which acts as a wildcard to check lump name, map name or resource archive name against.

Examples:
```
]listmaps Z*
Z1M1: 'Hangar' (kdizd_12.pk3)
Z1M2: 'Nuclear Plant' (kdizd_12.pk3)
<...lines omitted...>
Z1M9: 'Military Base' (kdizd_12.pk3)
Z1M10: 'Penultimate Evil' (kdizd_12.pk3)
```
```
]listmaps KDIZD*
Z1M1: 'Hangar' (kdizd_12.pk3)
Z1M2: 'Nuclear Plant' (kdizd_12.pk3)
<...lines omitted...>
Z1M10: 'Penultimate Evil' (kdizd_12.pk3)
INTER: 'Intermission' (kdizd_12.pk3)
CREDITS: 'Credits' (kdizd_12.pk3)
```
```
]listmaps *ng*
E1M1: 'Hangar' (DOOM.WAD)
E1M6: 'Central Processing' (DOOM.WAD)
E2M7: 'Spawning Vats' (DOOM.WAD)
Z1M1: 'Hangar' (kdizd_12.pk3)
Z1M6: 'Central Processing' (kdizd_12.pk3)
```