### PR TITLE
Add MaxSlopeSteepness actor property

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1157,6 +1157,7 @@ public:
 
 	double MaxDropOffHeight;
 	double MaxStepHeight;
+	double MaxSlopeSteepness;
 
 	int32_t Mass;
 	int16_t PainChance;

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -952,7 +952,7 @@ bool PIT_CheckLine(FMultiBlockLinesIterator &mit, FMultiBlockLinesIterator::Chec
 	if (!(tm.thing->flags & MF_DROPOFF) &&
 		!(tm.thing->flags & (MF_NOGRAVITY | MF_NOCLIP)))
 	{
-		if ((open.frontfloorplane.fC() < STEEPSLOPE) != (open.backfloorplane.fC() < STEEPSLOPE))
+		if ((open.frontfloorplane.fC() < tm.thing->MaxSlopeSteepness) != (open.backfloorplane.fC() < tm.thing->MaxSlopeSteepness))
 		{
 			// on the boundary of a steep slope
 			return false;
@@ -3255,7 +3255,7 @@ const secplane_t * P_CheckSlopeWalk(AActor *actor, DVector2 &move)
 		if (t < 0)
 		{ // Desired location is behind (below) the plane
 			// (i.e. Walking up the plane)
-			if (plane->fC() < STEEPSLOPE)
+			if (plane->fC() < actor->MaxSlopeSteepness)
 			{ // Can't climb up slopes of ~45 degrees or more
 				if (actor->flags & MF_NOCLIP)
 				{
@@ -3266,12 +3266,12 @@ const secplane_t * P_CheckSlopeWalk(AActor *actor, DVector2 &move)
 					const msecnode_t *node;
 					bool dopush = true;
 
-					if (plane->fC() > STEEPSLOPE * 2 / 3)
+					if (plane->fC() > actor->MaxSlopeSteepness * 2 / 3)
 					{
 						for (node = actor->touching_sectorlist; node; node = node->m_tnext)
 						{
 							sector_t *sec = node->m_sector;
-							if (sec->floorplane.fC() >= STEEPSLOPE)
+							if (sec->floorplane.fC() >= actor->MaxSlopeSteepness)
 							{
 								DVector3 pos = actor->PosRelative(sec) +move;
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -293,6 +293,7 @@ void AActor::Serialize(FSerializer &arc)
 		A("meleestate", MeleeState)
 		A("missilestate", MissileState)
 		A("maxdropoffheight", MaxDropOffHeight)
+		A("maxslopesteepness", MaxSlopeSteepness)
 		A("maxstepheight", MaxStepHeight)
 		A("bounceflags", BounceFlags)
 		A("bouncefactor", bouncefactor)
@@ -3909,18 +3910,18 @@ void AActor::Tick ()
 			// Check 3D floors as well
 			floorplane = P_FindFloorPlane(floorsector, PosAtZ(floorz));
 
-			if (floorplane.fC() < STEEPSLOPE &&
+			if (floorplane.fC() < MaxSlopeSteepness &&
 				floorplane.ZatPoint (PosRelative(floorsector)) <= floorz)
 			{
 				const msecnode_t *node;
 				bool dopush = true;
 
-				if (floorplane.fC() > STEEPSLOPE*2/3)
+				if (floorplane.fC() > MaxSlopeSteepness*2/3)
 				{
 					for (node = touching_sectorlist; node; node = node->m_tnext)
 					{
 						const sector_t *sec = node->m_sector;
-						if (sec->floorplane.fC() >= STEEPSLOPE)
+						if (sec->floorplane.fC() >= MaxSlopeSteepness)
 						{
 							if (floorplane.ZatPoint(PosRelative(node->m_sector)) >= Z() - MaxStepHeight)
 							{

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1916,6 +1916,7 @@ DEFINE_FIELD(AActor, WallBounceSound)
 DEFINE_FIELD(AActor, CrushPainSound)
 DEFINE_FIELD(AActor, MaxDropOffHeight)
 DEFINE_FIELD(AActor, MaxStepHeight)
+DEFINE_FIELD(AActor, MaxSlopeSteepness)
 DEFINE_FIELD(AActor, PainChance)
 DEFINE_FIELD(AActor, PainType)
 DEFINE_FIELD(AActor, DeathType)
@@ -2002,5 +2003,3 @@ DEFINE_FIELD_X(FLineTraceData, FLineTraceData, LineSide);
 DEFINE_FIELD_X(FLineTraceData, FLineTraceData, LinePart);
 DEFINE_FIELD_X(FLineTraceData, FLineTraceData, SectorPlane);
 DEFINE_FIELD_X(FLineTraceData, FLineTraceData, HitType);
-
-

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -73,6 +73,7 @@ class Actor : Thinker native
 	const DEFAULT_HEALTH = 1000;
 	const ONFLOORZ = -2147483648.0;
 	const ONCEILINGZ = 2147483647.0;
+	const STEEPSLOPE = (46342./65536.);	// [RH] Minimum floorplane.c value for walking
 	const FLOATRANDZ = ONCEILINGZ-1;
 	const TELEFRAG_DAMAGE = 1000000;
 	const MinVel = 1./65536;
@@ -217,6 +218,7 @@ class Actor : Thinker native
 	native sound CrushPainSound;
 	native double MaxDropoffHeight;
 	native double MaxStepHeight;
+	native double MaxSlopeSteepness;
 	native int16 PainChance;
 	native name PainType;
 	native name DeathType;
@@ -313,6 +315,7 @@ class Actor : Thinker native
 	property MinMissileChance: MinMissileChance;
 	property MaxStepHeight: MaxStepHeight;
 	property MaxDropoffHeight: MaxDropoffHeight;
+	property MaxSlopeSteepness: MaxSlopeSteepness;
 	property PoisonDamageType: PoisonDamageType;
 	property RadiusDamageFactor: RadiusDamageFactor;
 	property SelfDamageFactor: SelfDamageFactor;
@@ -371,6 +374,7 @@ class Actor : Thinker native
 		MeleeRange 64 - 20;
 		MaxDropoffHeight 24;
 		MaxStepHeight 24;
+		MaxSlopeSteepness STEEPSLOPE;
 		BounceFactor 0.7;
 		WallBounceFactor 0.75;
 		BounceCount -1;


### PR DESCRIPTION
This PR adds `MaxSlopeSteepness` property to actors, which controls its ability to walk on slopes of specified steepness, and exposes it via ZScript.