### PR TITLE
Skip missing state checks for abstract weapon classes

### DIFF
--- a/src/scripting/thingdef.cpp
+++ b/src/scripting/thingdef.cpp
@@ -96,7 +96,7 @@ void FinalizeClass(PClass *ccls, FStateDefinitions &statedef)
 		def->flags |= MF_SPECIAL;
 	}
 
-	if (cls->IsDescendantOf(NAME_Weapon))
+	if (cls->IsDescendantOf(NAME_Weapon) && !cls->bAbstract)
 	{
 		FState *ready = def->FindState(NAME_Ready);
 		FState *select = def->FindState(NAME_Select);


### PR DESCRIPTION
Sometimes, there is a need to define an abstract weapon class with only some of the required states. For example, if I want all my weapons to be instantly selectable, I can define a common Select state. ZScript has a keyword to make a class abstract, but GZDoom will error out if a weapon is missing some of the required states (Ready, Select, Deselect, Fire) while having at least one of them defined. This PR changes this behavior so that abstract weapon classes are not checked for missing states at all. It doesn't make sense anyway because such classes cannot be used directly.