### PR TITLE
Remove GLSL version declarations from user shaders

### DIFF
--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -417,14 +417,14 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 					int pl_lump = fileSystem.CheckNumForFullName("shaders/glsl/func_defaultmat2.fp", 0);
 					if (pl_lump == -1) I_Error("Unable to load '%s'", "shaders/glsl/func_defaultmat2.fp");
 					FileData pl_data = fileSystem.ReadFile(pl_lump);
-					fp_comb << "\n" << pl_data.GetString().GetChars();
+					fp_comb << "\n" << RemoveVersionDeclaration(pl_data.GetString()).GetChars();
 				}
 				else
 				{
 					int pl_lump = fileSystem.CheckNumForFullName("shaders/glsl/func_defaultmat.fp", 0);
 					if (pl_lump == -1) I_Error("Unable to load '%s'", "shaders/glsl/func_defaultmat.fp");
 					FileData pl_data = fileSystem.ReadFile(pl_lump);
-					fp_comb << "\n" << pl_data.GetString().GetChars();
+					fp_comb << "\n" << RemoveVersionDeclaration(pl_data.GetString()).GetChars();
 
 					if (pp_data.GetString().IndexOf("ProcessTexel") < 0)
 					{
@@ -451,7 +451,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 				int pl_lump = fileSystem.CheckNumForFullName("shaders/glsl/func_defaultlight.fp", 0);
 				if (pl_lump == -1) I_Error("Unable to load '%s'", "shaders/glsl/func_defaultlight.fp");
 				FileData pl_data = fileSystem.ReadFile(pl_lump);
-				fp_comb << "\n" << pl_data.GetString().GetChars();
+				fp_comb << "\n" << RemoveVersionDeclaration(pl_data.GetString()).GetChars();
 			}
 
 			// ProcessMaterial must be considered broken because it requires the user to fill in data they possibly cannot know all about.

--- a/src/common/rendering/hwrenderer/data/hw_shaderpatcher.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_shaderpatcher.cpp
@@ -267,6 +267,28 @@ FString RemoveLayoutLocationDecl(FString code, const char *inoutkeyword)
 	return code;
 }
 
+FString RemoveVersionDeclaration(FString code)
+{
+	long length = code.Len();
+	char* chars = code.LockBuffer();
+	// Find #version
+	long matchIndex = code.IndexOf("#version");
+	if (matchIndex >= 0)
+	{
+		long endIndex = matchIndex + 8;
+		// Find end-of-line
+		while(chars[endIndex++] != '\n' && endIndex < length);
+		// Replace with spaces
+		for(long i = matchIndex; i < endIndex; i++)
+		{
+			chars[i] = ' ';
+		}
+	}
+	code.UnlockBuffer();
+	return code;
+	
+}
+
 /////////////////////////////////////////////////////////////////////////////
 
 // Note: the MaterialShaderIndex enum in gl_shader.h needs to be updated whenever this array is modified.

--- a/src/common/rendering/hwrenderer/data/hw_shaderpatcher.h
+++ b/src/common/rendering/hwrenderer/data/hw_shaderpatcher.h
@@ -7,6 +7,7 @@
 FString RemoveLegacyUserUniforms(FString code);
 FString RemoveSamplerBindings(FString code, TArray<std::pair<FString, int>> &samplerstobind);	// For GL 3.3 compatibility which cannot declare sampler bindings in the sampler source.
 FString RemoveLayoutLocationDecl(FString code, const char *inoutkeyword);
+FString RemoveVersionDeclaration(FString code);
 
 struct FDefaultShader
 {

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -311,7 +311,7 @@ std::unique_ptr<VulkanShader> VkShaderManager::LoadFragShader(FString shadername
 	{
 		if (material_lump[0] != '#')
 		{
-			FString pp_code = LoadPublicShaderLump(material_lump);
+			FString pp_code = RemoveVersionDeclaration(LoadPublicShaderLump(material_lump));
 
 			if (pp_code.IndexOf("ProcessMaterial") < 0 && pp_code.IndexOf("SetupMaterial") < 0)
 			{


### PR DESCRIPTION
Add a RemoveVersionDeclaration function to hw_shaderpatcher
Apply RemoveVersionDeclaration to OpenGL and Vulkan user shaders