### PR TITLE
- implement ultra-violence+ for Unity Doom

### DIFF
--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -473,6 +473,7 @@ enum ESkillProperty
 	SKILLP_SlowMonsters,
 	SKILLP_Infight,
 	SKILLP_PlayerRespawn,
+	SKILLP_SpawnMulti,
 };
 enum EFSkillProperty	// floating point properties
 {
@@ -516,6 +517,7 @@ struct FSkillInfo
 	int RespawnLimit;
 	double Aggressiveness;
 	int SpawnFilter;
+	bool SpawnMulti;
 	int ACSReturn;
 	FString MenuName;
 	FString PicName;

--- a/src/gamedata/g_skill.cpp
+++ b/src/gamedata/g_skill.cpp
@@ -76,6 +76,7 @@ void FMapInfoParser::ParseSkill ()
 	skill.RespawnLimit = 0;
 	skill.Aggressiveness = 1.;
 	skill.SpawnFilter = 0;
+	skill.SpawnMulti = false;
 	skill.ACSReturn = 0;
 	skill.MustConfirm = false;
 	skill.Shortcut = 0;
@@ -191,6 +192,10 @@ void FMapInfoParser::ParseSkill ()
 				else if (sc.Compare("hard")) skill.SpawnFilter |= 8;
 				else if (sc.Compare("nightmare")) skill.SpawnFilter |= 16;
 			}
+		}
+		else if (sc.Compare ("spawnmulti"))
+		{
+			skill.SpawnMulti = true;
 		}
 		else if (sc.Compare("ACSReturn"))
 		{
@@ -395,6 +400,8 @@ int G_SkillProperty(ESkillProperty prop)
 
 		case SKILLP_PlayerRespawn:
 			return AllSkills[gameskill].PlayerRespawn;
+		case SKILLP_SpawnMulti:
+			return AllSkills[gameskill].SpawnMulti;
 		}
 	}
 	return 0;

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5347,7 +5347,6 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 	return mobj;
 }
 
-
 //
 // P_SpawnMapThing
 // The fields of the mapthing should
@@ -5359,6 +5358,8 @@ AActor *FLevelLocals::SpawnMapThing (FMapThing *mthing, int position)
 	PClassActor *i;
 	int mask;
 	AActor *mobj;
+
+	bool spawnmulti = G_SkillProperty(SKILLP_SpawnMulti) || multiplayer;
 
 	if (mthing->EdNum == 0 || mthing->EdNum == -1)
 		return NULL;
@@ -5430,12 +5431,13 @@ AActor *FLevelLocals::SpawnMapThing (FMapThing *mthing, int position)
 
 	if (pnum == -1 || (flags & LEVEL_FILTERSTARTS))
 	{
+
 		// check for appropriate game type
 		if (deathmatch) 
 		{
 			mask = MTF_DEATHMATCH;
 		}
-		else if (multiplayer)
+		else if (spawnmulti)
 		{
 			mask = MTF_COOPERATIVE;
 		}
@@ -5573,14 +5575,14 @@ AActor *FLevelLocals::SpawnMapThing (FMapThing *mthing, int position)
 		return NULL;
 
 	// don't spawn extra things in coop if so desired
-	if (multiplayer && !deathmatch && (dmflags2 & DF2_NO_COOP_THING_SPAWN))
+	if (spawnmulti && !deathmatch && (dmflags2 & DF2_NO_COOP_THING_SPAWN))
 	{
 		if ((mthing->flags & (MTF_DEATHMATCH|MTF_SINGLE)) == MTF_DEATHMATCH)
 			return NULL;
 	}
 
 	// [RH] don't spawn extra weapons in coop if so desired
-	if (multiplayer && !deathmatch && (dmflags & DF_NO_COOP_WEAPON_SPAWN))
+	if (spawnmulti && !deathmatch && (dmflags & DF_NO_COOP_WEAPON_SPAWN))
 	{
 		if (GetDefaultByType(i)->flags7 & MF7_WEAPONSPAWN)
 		{

--- a/wadsrc/static/mapinfo/doom2unity.txt
+++ b/wadsrc/static/mapinfo/doom2unity.txt
@@ -20,3 +20,12 @@ episode level01
 	key = "n"
 	optional
 }
+
+skill hardplus
+{
+	SpawnFilter = Hard
+	Name = "$SKILL_HARDPLUS"
+	Key = "u"
+	FastMonsters
+	SpawnMulti
+}


### PR DESCRIPTION
- add 'SpawnMulti' skill flag to support this
- differences from UV and UV+: monsters fast, all mutliplayer thing spawns active

Main reason I am putting this in a pull request is I am unsure if the new skill level could break mods.