### PR TITLE
Fix a lift in Double Impact E1M7 that can only be used twice

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -2107,6 +2107,12 @@ class LevelCompatibility : LevelPostProcessor
 				SetSectorSpecial (97, 0);
 				break;
 			}
+
+			case 'A50AC05CCE4F07413A0C4883C5E24215': // dbimpact.wad e1m7
+			{
+				SetLineFlags(1461, Line.ML_REPEAT_SPECIAL);
+				SetLineFlags(1468, Line.ML_REPEAT_SPECIAL);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Now this is almost surely a map bug. A lift in [Double Impact](https://www.doomworld.com/idgames/levels/doom/Ports/d-f/dbimpact) E1M7 (at -1344, -960) can only be used twice from its lower side because that side is composed of two linedefs (1461 and 1468) and each of them has a once-only special. When the lift becomes inactive, it becomes impossible to leave the surrounding area without cheating. Considering that the other side of the lift has a repeatable special (linedef 1482), it is extremely unlikely that such a setup was intended.
