### PR TITLE
ZScript abstract functions

### DIFF
--- a/src/common/objects/dobjtype.cpp
+++ b/src/common/objects/dobjtype.cpp
@@ -435,7 +435,7 @@ DObject *PClass::CreateNew()
 	else
 		memset (mem, 0, Size);
 
-	if (ConstructNative == nullptr)
+	if (ConstructNative == nullptr || bAbstract)
 	{
 		M_Free(mem);
 		I_Error("Attempt to instantiate abstract class %s.", TypeName.GetChars());

--- a/src/common/scripting/backend/vmbuilder.cpp
+++ b/src/common/scripting/backend/vmbuilder.cpp
@@ -767,13 +767,16 @@ FFunctionBuildList FunctionBuildList;
 
 VMFunction *FFunctionBuildList::AddFunction(PNamespace *gnspc, const VersionInfo &ver, PFunction *functype, FxExpression *code, const FString &name, bool fromdecorate, int stateindex, int statecount, int lumpnum)
 {
-	auto func = code->GetDirectFunction(functype, ver);
-	if (func != nullptr)
+	if (code != nullptr)
 	{
-		delete code;
+		auto func = code->GetDirectFunction(functype, ver);
+		if (func != nullptr)
+		{
+			delete code;
 
 
-		return func;
+			return func;
+		}
 	}
 
 	//Printf("Adding %s\n", name.GetChars());
@@ -815,6 +818,10 @@ void FFunctionBuildList::Build()
 
 	for (auto &item : mItems)
 	{
+		// [Player701] Do not emit code for abstract functions
+		bool isAbstract = item.Func->Variants[0].Implementation->VarFlags & VARF_Abstract;
+		if (isAbstract) continue;
+
 		assert(item.Code != NULL);
 
 		// We don't know the return type in advance for anonymous functions.

--- a/src/common/scripting/core/types.h
+++ b/src/common/scripting/core/types.h
@@ -36,6 +36,7 @@ enum
 	VARF_Play			= (1<<21),  // [ZZ] play: object is playsim-scope only (can't access ui)
 	VARF_VirtualScope	= (1<<22),  // [ZZ] virtualscope: object should use the scope of the particular class it's being used with (methods only)
 	VARF_ClearScope		= (1<<23),  // [ZZ] clearscope: this method ignores the member access chain that leads to it and is always plain data.
+	VARF_Abstract		= (1<<24),  // [Player701] Function does not have a body and must be overridden in subclasses
 };
 
 // Basic information shared by all types ------------------------------------

--- a/src/common/scripting/frontend/zcc-parse.lemon
+++ b/src/common/scripting/frontend/zcc-parse.lemon
@@ -1202,6 +1202,7 @@ decl_flag(X) ::= READONLY(T).	{ X.Int = ZCC_ReadOnly; X.SourceLoc =  T.SourceLoc
 decl_flag(X) ::= INTERNAL(T).	{ X.Int = ZCC_Internal; X.SourceLoc =  T.SourceLoc; }
 decl_flag(X) ::= VIRTUAL(T).	{ X.Int = ZCC_Virtual; X.SourceLoc =  T.SourceLoc; }
 decl_flag(X) ::= OVERRIDE(T).	{ X.Int = ZCC_Override; X.SourceLoc =  T.SourceLoc; }
+decl_flag(X) ::= ABSTRACT(T).	{ X.Int = ZCC_Abstract; X.SourceLoc =  T.SourceLoc; }
 decl_flag(X) ::= VARARG(T).     { X.Int = ZCC_VarArg; X.SourceLoc = T.SourceLoc; }
 decl_flag(X) ::= UI(T).			{ X.Int = ZCC_UIFlag; X.SourceLoc = T.SourceLoc; }
 decl_flag(X) ::= PLAY(T).		{ X.Int = ZCC_Play; X.SourceLoc = T.SourceLoc; }

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -2012,7 +2012,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 			} while (t != f->Type);
 		}
 
-		int notallowed = ZCC_Latent | ZCC_Meta | ZCC_ReadOnly | ZCC_Abstract | ZCC_Internal;
+		int notallowed = ZCC_Latent | ZCC_Meta | ZCC_ReadOnly | ZCC_Internal;
 
 		if (f->Flags & notallowed)
 		{
@@ -2058,6 +2058,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 		if (f->Flags & ZCC_Deprecated) varflags |= VARF_Deprecated;
 		if (f->Flags & ZCC_Virtual) varflags |= VARF_Virtual;
 		if (f->Flags & ZCC_Override) varflags |= VARF_Override;
+		if (f->Flags & ZCC_Abstract) varflags |= VARF_Abstract;
 		if (f->Flags & ZCC_VarArg) varflags |= VARF_VarArg;
 		if (f->Flags & ZCC_FuncConst) varflags |= VARF_ReadOnly; // FuncConst method is internally marked as VARF_ReadOnly
 		if (mVersion >= MakeVersion(2, 4, 0))
@@ -2101,7 +2102,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 
 		if (varflags & VARF_Override) varflags &= ~VARF_Virtual;	// allow 'virtual override'.
 																	// Only one of these flags may be used.
-		static int exclude[] = { ZCC_Virtual, ZCC_Override, ZCC_Action, ZCC_Static };
+		static int exclude[] = { ZCC_Abstract, ZCC_Virtual, ZCC_Override, ZCC_Action, ZCC_Static };
 		int excludeflags = 0;
 		int fc = 0;
 		for (size_t i = 0; i < countof(exclude); i++)
@@ -2117,7 +2118,7 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 			Error(f, "Invalid combination of qualifiers %s on function %s", FlagsToString(excludeflags).GetChars(), FName(f->Name).GetChars());
 			varflags |= VARF_Method;
 		}
-		if (varflags & VARF_Override) varflags |= VARF_Virtual;	// Now that the flags are checked, make all override functions virtual as well.
+		if (varflags & (VARF_Override | VARF_Abstract)) varflags |= VARF_Virtual;	// Now that the flags are checked, make all override and abstract functions virtual as well.
 
 		// [ZZ] this doesn't make sense either.
 		if ((varflags&(VARF_ReadOnly | VARF_Method)) == VARF_ReadOnly) // non-method const function
@@ -2150,6 +2151,12 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 
 		if (f->Flags & ZCC_Native)
 		{
+			if (varflags & VARF_Abstract)
+			{
+				Error(f, "Native functions cannot be abstract");
+				return;
+			}
+
 			varflags |= VARF_Native;
 			afd = FindFunction(c->Type(), FName(f->Name).GetChars());
 			if (afd == nullptr)
@@ -2341,19 +2348,20 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 
 		if (!(f->Flags & ZCC_Native))
 		{
-			if (f->Body == nullptr)
+			if (f->Body != nullptr && (varflags & VARF_Abstract))
+			{
+				Error(f, "Abstract function %s cannot have a body", FName(f->Name).GetChars());
+				return;
+			}
+
+			if (f->Body == nullptr && !(varflags & VARF_Abstract))
 			{
 				Error(f, "Empty function %s", FName(f->Name).GetChars());
 				return;
 			}
-			else
-			{
-				auto code = ConvertAST(c->Type(), f->Body);
-				if (code != nullptr)
-				{
-					newfunc = FunctionBuildList.AddFunction(OutNamespace, mVersion, sym, code, FStringf("%s.%s", c->Type()->TypeName.GetChars(), FName(f->Name).GetChars()), false, -1, 0, Lump);
-				}
-			}
+
+			FxExpression* code = f->Body != nullptr ? ConvertAST(c->Type(), f->Body) : nullptr;
+			newfunc = FunctionBuildList.AddFunction(OutNamespace, mVersion, sym, code, FStringf("%s.%s", c->Type()->TypeName.GetChars(), FName(f->Name).GetChars()), false, -1, 0, Lump);
 		}
 		if (sym->Variants[0].Implementation != nullptr && hasdefault)	// do not copy empty default lists, they only waste space and processing time.
 		{
@@ -2378,6 +2386,12 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 
 			if (forclass)
 			{
+				if ((varflags & VARF_Abstract) && !clstype->bAbstract)
+				{
+					Error(f, "Abstract functions can only be defined in abstract classes");
+					return;
+				}
+
 				auto parentfunc = clstype->ParentClass? dyn_cast<PFunction>(clstype->ParentClass->VMType->Symbols.FindSymbol(sym->SymbolName, true)) : nullptr;
 
 				int vindex = clstype->FindVirtualIndex(sym->SymbolName, &sym->Variants[0], parentfunc, exactReturnType);
@@ -2495,6 +2509,18 @@ void ZCCCompiler::InitFunctions()
 		for (auto f : c->Functions)
 		{
 			CompileFunction(c, f, true);
+		}
+
+		// [Player701] Make sure all abstract functions are overridden
+		if (!c->ClassType()->bAbstract)
+		{
+			for (auto v : c->ClassType()->Virtuals)
+			{
+				if (v->VarFlags & VARF_Abstract)
+				{
+					Error(c->cls, "Non-abstract class %s must override abstract function %s", c->Type()->TypeName.GetChars(), v->PrintableName.GetChars());
+				}
+			}
 		}
 	}
 }

--- a/src/common/scripting/vm/vmframe.cpp
+++ b/src/common/scripting/vm/vmframe.cpp
@@ -284,6 +284,13 @@ static bool CanJit(VMScriptFunction *func)
 
 int VMScriptFunction::FirstScriptCall(VMFunction *func, VMValue *params, int numparams, VMReturn *ret, int numret)
 {
+	// [Player701] Check that we aren't trying to call an abstract function.
+	// This shouldn't happen normally, but if it does, let's catch this explicitly
+	// rather than let GZDoom crash.
+	if (func->VarFlags & VARF_Abstract)
+	{
+		ThrowAbortException(X_OTHER, "attempt to call abstract function %s.", func->PrintableName.GetChars());
+	}
 #ifdef HAVE_VM_JIT
 	if (vm_jit && CanJit(static_cast<VMScriptFunction*>(func)))
 	{
@@ -654,7 +661,11 @@ CVMAbortException::CVMAbortException(EVMAbortException reason, const char *morei
 	}
 	if (moreinfo != nullptr)
 	{
-		AppendMessage(" ");
+		// [Player701] avoid double space
+		if (reason != X_OTHER)
+		{
+			AppendMessage(" ");
+		}
 		size_t len = strlen(m_Message);
 		myvsnprintf(m_Message + len, MAX_ERRORTEXT - len, moreinfo, ap);
 	}

--- a/src/gamedata/info.cpp
+++ b/src/gamedata/info.cpp
@@ -777,11 +777,6 @@ static void SummonActor (int command, int command2, FCommandLine argv)
 			Printf ("Unknown actor '%s'\n", argv[1]);
 			return;
 		}
-		if (type->bAbstract)
-		{
-			Printf("Cannot instantiate abstract class %s\n", argv[1]);
-			return;
-		}
 		Net_WriteByte (argv.argc() > 2 ? command2 : command);
 		Net_WriteString (type->TypeName.GetChars());
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -4625,6 +4625,12 @@ AActor *AActor::StaticSpawn(FLevelLocals *Level, PClassActor *type, const DVecto
 	{
 		I_Error("Tried to spawn a class-less actor\n");
 	}
+	else if (type->bAbstract)
+	{
+		// [Player701] Abstract actors cannot be spawned by any means
+		Printf("Attempt to spawn an instance of abstract actor class %s\n", type->TypeName.GetChars());
+		return nullptr;
+	}
 
 	if (allowreplacement)
 	{

--- a/src/scripting/decorate/thingdef_parse.cpp
+++ b/src/scripting/decorate/thingdef_parse.cpp
@@ -78,6 +78,19 @@ PClassActor *DecoDerivedClass(const FScriptPosition &sc, PClassActor *parent, FN
 	{
 		sc.Message(MSG_ERROR, "Parent class %s of %s not accessible to DECORATE", parent->TypeName.GetChars(), typeName.GetChars());
 	}
+	else
+	{
+		// [Player701] Parent class must not have abstract functions
+		for (auto v : parent->Virtuals)
+		{
+			if (v->VarFlags & VARF_Abstract)
+			{
+				sc.Message(MSG_ERROR, "Parent class %s of %s cannot have abstract functions.", parent->TypeName.GetChars(), typeName.GetChars());
+				break;
+			}
+		}
+	}
+
 	bool newlycreated;
 	PClassActor *type = static_cast<PClassActor *>(parent->CreateDerivedClass(typeName, parent->Size, &newlycreated));
 	if (type == nullptr)


### PR DESCRIPTION
**This PR implements a functionality to define abstract functions in ZScript.**

Example syntax:

```
class Base abstract
{
    abstract void Func();
}

class Derived : Base
{
    override void Func()
    {
        //...
    }
}
```

Notes:

* Abstract functions are implicitly virtual, and cannot be marked virtual or override.
* Abstract functions cannot have a body.
* Abstract functions can only be defined in an abstract class.
* Any non-abstract class must override all parent abstract functions.

### Justification

The primary justification for abstract functions is that they can help reduce the amount of potential bugs in user code by checking for errors at compile time. If a base class has virtual functions that are always overridden in subclasses, it is easy to forget to override one or two of them. A workaround for now is to put calls to ```ThrowAbortException``` into these virtuals so that GZDoom aborts with a meaningful error message indicating a programming error. However, this necessitates writing all this extra code by hand, while the best solution would be to simply make the base functions abstract.

### Technical information

The implementation is rather simple, although we do need some safety checks mostly to ensure that abstract classes can never be instantiated.

* First of all, I've extended the check in ```PClass::CreateNew```. This is a fallback case for all instances where non-actor objects are created by the engine. There seem to be quite a few of those, for example, StatusBarClass in MAPINFO, event handlers, menus and so on - there may be more, and this is the most efficient way to handle them all at once.
* I've also moved the check for ```bAbstract``` from the summon CCMD handler to ```AActor::StaticSpawn```. In this case, we only output a warning instead of an error. This covers all cases where actors get spawned via DECORATE, ZScript and ACS - since this is likely to happen with user code, we should try to be user-friendly and do not error out to the console. However, in case Graf or other devs consider a simple warning not enough, I can make this an error instead and reinstate the original check in the summon handler.
* Finally, we should check that we are not calling an abstract function in ```VMFunction::FirstScriptCall``` - although this should never happen normally, it may indicate a bug, and we should error out gracefully instead of crashing so that it will be easier to investigate the issue.

Note that since it's not possible to override functions in DECORATE, I've also added a check to ```DecoDerivedClass``` so that an actor class with abstract functions does not get created.

### Unit tests

I've written a simple PowerShell-based unit test suite that allows loading DECORATE and ZScript files and check for presence or absence of certain error messages in the log. This way, we can ensure that everything works as intended. I'm sharing the test suite [here on my personal server](https://files.player701.ru/abstract_tests.7z). Simply extract all files to a separate subfolder and run ```powershell ./test.ps1 -gzdoom_path <path_to_your_gzdoom_exe>```.

Optional arguments:

* ```-gzdoom_iwad```: if you don't have doom2.wad then specify another IWAD
* ```-gzdoom_run_delay```: how much to wait for GZDoom to complete startup (default: 5 seconds)
* ```-gzdoom_stop_delay```: how much to wait after GZDoom process has been killed - for some reason it doesn't release locks on temporary files right away (default: 1 second)

Test away! And hey, remember that the test system may have bugs since I've spent basically only a couple hours on it. In case you have more tests to propose, go ahead. If you think this PR should be tested more, then let us take all the time we need.
