### PR TITLE
Fix truncation warnings in playerdisplay.zs

### DIFF
--- a/wadsrc/static/zscript/ui/menu/playerdisplay.zs
+++ b/wadsrc/static/zscript/ui/menu/playerdisplay.zs
@@ -282,7 +282,7 @@ class ListMenuItemPlayerDisplay : ListMenuItem
 				DTA_Color, c,
 				DTA_Masked, true);
 
-			Screen.DrawFrame (x, y, 72*sx, 80*sy-1);
+			Screen.DrawFrame (x, y, int(72*sx), int(80*sy-1));
 
 			if (mPlayerState != NULL)
 			{


### PR DESCRIPTION
Correct me if I'm wrong, but these two have probably been overlooked, right?

```
Script warning, "gzdoom.pk3:zscript/ui/menu/playerdisplay.zs" line 285:
Truncation of floating point value
Script warning, "gzdoom.pk3:zscript/ui/menu/playerdisplay.zs" line 285:
Truncation of floating point value
```