### PR TITLE
Fix server CVars not immediately reverting to saved values upon loading game

### DIFF
--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -627,7 +627,7 @@ EXTERN_CVAR (Float, sv_gravity)
 
 bool D_SendServerInfoChange (FBaseCVar *cvar, UCVarValue value, ECVarType type)
 {
-	if (gamestate != GS_STARTUP && !demoplayback)
+	if (gamestate != GS_STARTUP && !demoplayback && !savegamerestore)
 	{
 		if (netgame && !players[consoleplayer].settings_controller)
 		{
@@ -657,7 +657,7 @@ bool D_SendServerInfoChange (FBaseCVar *cvar, UCVarValue value, ECVarType type)
 
 bool D_SendServerFlagChange (FBaseCVar *cvar, int bitnum, bool set, bool silent)
 {
-	if (gamestate != GS_STARTUP && !demoplayback)
+	if (gamestate != GS_STARTUP && !demoplayback && !savegamerestore)
 	{
 		if (netgame && !players[consoleplayer].settings_controller)
 		{

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2043,6 +2043,8 @@ void G_DoLoadGame ()
 
 	primaryLevel->BotInfo.RemoveAllBots(primaryLevel, true);
 
+	savegamerestore = true;		// Use the player actors in the savegame
+
 	FString cvar;
 	arc("importantcvars", cvar);
 	if (!cvar.IsEmpty())
@@ -2068,7 +2070,6 @@ void G_DoLoadGame ()
 	G_ReadVisited(arc);
 
 	// load a base level
-	savegamerestore = true;		// Use the player actors in the savegame
 	bool demoplaybacksave = demoplayback;
 	G_InitNew(map, false);
 	demoplayback = demoplaybacksave;


### PR DESCRIPTION
See https://forum.zdoom.org/viewtopic.php?f=2&t=70190

This fixes the issue for me, and as far as I'm aware, it shouldn't cause any breakage - especially considering that it isn't possible to load save files in multiplayer (except upon game startup). Feel free to close this in case I'm wrong, or if a more elegant solution is found.
