### PR TITLE
Change A_OverlayTranslation to accept a named translation instead.

### DIFF
--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -754,7 +754,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayTranslation)
 {
 	PARAM_ACTION_PROLOGUE(AActor);
 	PARAM_INT(layer);
-	PARAM_UINT(trans);
+	PARAM_NAME(trname);
 
 	if (!ACTION_CALL_FROM_PSPRITE())
 		return 0;
@@ -762,7 +762,21 @@ DEFINE_ACTION_FUNCTION(AActor, A_OverlayTranslation)
 	DPSprite* pspr = self->player->FindPSprite(((layer != 0) ? layer : stateinfo->mPSPIndex));
 	if (pspr != nullptr)
 	{
-		pspr->Translation = trans;
+		// There is no constant for the empty name...
+		if (trname.GetChars()[0] == 0)
+		{
+			// an empty string resets to the default
+			// (unlike AActor::SetTranslation, there is no Default block for PSprites, so just set the translation to 0)
+			pspr->Translation = 0;
+			return 0;
+		}
+
+		int tnum = R_FindCustomTranslation(trname);
+		if (tnum >= 0)
+		{
+			pspr->Translation = tnum;
+		}
+		// silently ignore if the name does not exist, this would create some insane message spam otherwise.
 	}
 
 	return 0;

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1185,7 +1185,7 @@ class Actor : Thinker native
 	action native void A_OverlayFlags(int layer, int flags, bool set);
 	action native void A_OverlayAlpha(int layer, double alph);
 	action native void A_OverlayRenderStyle(int layer, int style);
-	action native void A_OverlayTranslation(int layer, int trans);
+	action native void A_OverlayTranslation(int layer, name trname);
 	
 	native bool A_AttachLightDef(Name lightid, Name lightdef);
 	native bool A_AttachLight(Name lightid, int type, Color lightcolor, int radius1, int radius2, int flags = 0, Vector3 ofs = (0,0,0), double param = 0, double spoti = 10, double spoto = 25, double spotp = 0);


### PR DESCRIPTION
For more advanced use cases, the Translation member of PSprite can be written to directly.