### PR TITLE
add console command to reset a CVAR to default value

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -1507,7 +1507,13 @@ CCMD (resetcvar)
 	{
 		FBaseCVar *var = FindCVar (argv[1], NULL);
 		if (var != NULL)
+		{
 			var->ResetToDefault();
+		}
+		else
+		{
+			Printf ("No such variable: %s\n", argv[1]);
+		}
 	}
 }
 

--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -1497,6 +1497,22 @@ CCMD (unset)
 	}
 }
 
+CCMD (reset)
+{
+	if (argv.argc() != 2)
+	{
+		Printf ("usage: reset <variable>\n");
+	}
+	else
+	{
+		FBaseCVar *var = FindCVar (argv[1], NULL);
+		if (var == NULL)
+			var = new FStringCVar (argv[1], NULL, CVAR_AUTO | CVAR_UNSETTABLE | cvar_defflags);
+
+		var->ResetToDefault();
+	}
+}
+
 CCMD (get)
 {
 	FBaseCVar *var, *prev;

--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -1497,19 +1497,17 @@ CCMD (unset)
 	}
 }
 
-CCMD (reset)
+CCMD (resetcvar)
 {
 	if (argv.argc() != 2)
 	{
-		Printf ("usage: reset <variable>\n");
+		Printf ("usage: resetcvar <variable>\n");
 	}
 	else
 	{
 		FBaseCVar *var = FindCVar (argv[1], NULL);
-		if (var == NULL)
-			var = new FStringCVar (argv[1], NULL, CVAR_AUTO | CVAR_UNSETTABLE | cvar_defflags);
-
-		var->ResetToDefault();
+		if (var != NULL)
+			var->ResetToDefault();
 	}
 }
 


### PR DESCRIPTION
Rationale:
1. Now to reset a CVAR to default, the user doesn't need to remember the default value.
2. If a modder wants to reset a CVAR via menu command, they don't need to keep menudef and cvarinfo in sync.

```
usage: resetcvar <variable>
```