### PR TITLE
Prevent abstract calls via Super et al. at compile time

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -8546,6 +8546,13 @@ FxExpression *FxVMFunctionCall::Resolve(FCompileContext& ctx)
 		if (!result) return nullptr;
 	}
 
+	// [Player701] Catch attempts to call abstract functions directly at compile time
+	if (NoVirtual && Function->Variants[0].Implementation->VarFlags & VARF_Abstract)
+	{
+		ScriptPosition.Message(MSG_ERROR, "Cannot call abstract function %s", Function->Variants[0].Implementation->PrintableName.GetChars());
+		delete this;
+		return nullptr;
+	}
 
 	CallingFunction = ctx.Function;
 	if (ArgList.Size() > 0)


### PR DESCRIPTION
This is a minor addition to the abstract functions feature that I somehow overlooked earlier. It prevents calling abstract functions via ```Super``` or parent class name qualifiers by catching such attempts at compile time. Right now, it triggers a VM abort (not a crash, mind you), but it'd be more user-friendly if the compiler could detect such calls instead.

Unit test:

```
class Base abstract
{
    abstract void Test();
}
    
class Derived : Base
{
    override void Test()
    {
        //!11,Cannot call abstract function Base.Test
        Super.Test();
    }
}

class Derived2 : Base
{
    override void Test()
    {
        // Do stuff
    }    
}

class Derived3 : Derived2
{
    override void Test()
    {
        // ok, Derived2.Test is not abstract
        Super.Test();
    }
}

class Derived4 : Derived2
{
    override void Test()
    {
        //!37,Cannot call abstract function Base.Test
        Base.Test();
    }
}
```
