### PR TITLE
Fixed wrong number of lines displayed in the menu when scrolling

### DIFF
--- a/wadsrc/static/zscript/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/optionmenu.zs
@@ -239,7 +239,7 @@ class OptionMenu : Menu
 
 					if (y <= 0)
 					{
-						y = DrawCaption(mDesc.mTitle, y, false);
+						y = DrawCaption(mDesc.mTitle, -y, false);
 					}
 					y *= CleanYfac_1;
 					int	rowheight = OptionMenuSettings.mLinespacing * CleanYfac_1;


### PR DESCRIPTION
I've caught this in LZDoom with the old font and lower resolutions, it's a typo i guess.