### PR TITLE
THRUBITS Opt-In flag

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -414,7 +414,7 @@ enum ActorFlag8
 	MF8_STOPRAILS		= 0x00000200,	// [MC] Prevent rails from going further if an actor has this flag.
 	MF8_ABSVIEWANGLES	= 0x00000400,	// [MC] By default view angle/pitch/roll is an offset. This will make it absolute instead.
 	MF8_FALLDAMAGE		= 0x00000800,	// Monster will take fall damage regardless of map settings.
-
+	MF8_THRUBITS		= 0x00008000,	// [MC] Enable ThruBits property
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -414,7 +414,7 @@ enum ActorFlag8
 	MF8_STOPRAILS		= 0x00000200,	// [MC] Prevent rails from going further if an actor has this flag.
 	MF8_ABSVIEWANGLES	= 0x00000400,	// [MC] By default view angle/pitch/roll is an offset. This will make it absolute instead.
 	MF8_FALLDAMAGE		= 0x00000800,	// Monster will take fall damage regardless of map settings.
-	MF8_THRUBITS		= 0x00008000,	// [MC] Enable ThruBits property
+	MF8_ALLOWTHRUBITS		= 0x00008000,	// [MC] Enable ThruBits property
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -450,7 +450,7 @@ bool	P_TeleportMove(AActor* thing, const DVector3 &pos, bool telefrag, bool modi
 		if ((th->flags2 | tmf.thing->flags2) & MF2_THRUACTORS)
 			continue;
 
-		if (((th->flags8 | tmf.thing->flags8) & MF8_THRUBITS) && th->ThruBits & tmf.thing->ThruBits)
+		if ((th->ThruBits & tmf.thing->ThruBits) && ((th->flags8 | tmf.thing->flags8) & MF8_ALLOWTHRUBITS))
 			continue;
 
 		double blockdist = th->radius + tmf.thing->radius;
@@ -1304,7 +1304,7 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 	if ((thing->flags2 | tm.thing->flags2) & MF2_THRUACTORS)
 		return true;
 
-	if (((thing->flags8 | tm.thing->flags8) & MF8_THRUBITS) && thing->ThruBits & tm.thing->ThruBits)
+	if ((thing->ThruBits & tm.thing->ThruBits) && ((thing->flags8 | tm.thing->flags8) & MF8_ALLOWTHRUBITS))
 		return true;
 
 	if (!((thing->flags & (MF_SOLID | MF_SPECIAL | MF_SHOOTABLE)) || thing->flags6 & MF6_TOUCHY))
@@ -2000,7 +2000,7 @@ int P_TestMobjZ(AActor *actor, bool quick, AActor **pOnmobj)
 		{
 			continue;
 		}
-		if (((actor->flags8 | thing->flags8) & MF8_THRUBITS) && actor->ThruBits & thing->ThruBits)
+		if ((actor->ThruBits & thing->ThruBits) && ((actor->flags8 | thing->flags8) & MF8_ALLOWTHRUBITS))
 		{
 			continue;
 		}
@@ -4509,7 +4509,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 		if (tempuff != NULL)
 		{
 			TData.PuffSpecies = tempuff->GetSpecies();
-			TData.UseThruBits = tempuff->flags8 & MF8_THRUBITS;
+			TData.UseThruBits = tempuff->flags8 & MF8_ALLOWTHRUBITS;
 			TData.ThruBits = tempuff->ThruBits;
 			tempuff->Destroy();
 		}
@@ -5269,7 +5269,7 @@ void P_RailAttack(FRailParams *p)
 	{
 		rail_data.ThruBits = thepuff->ThruBits;
 		if (rail_data.UseThruBits)
-			rail_data.UseThruBits = (thepuff->flags8 & MF8_THRUBITS);
+			rail_data.UseThruBits = !!(thepuff->flags8 & MF8_ALLOWTHRUBITS);
 	}
 
 	Trace(start, source->Sector, vec, p->distance, MF_SHOOTABLE, ML_BLOCKEVERYTHING, source, trace,	flags, ProcessRailHit, &rail_data);

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -450,7 +450,7 @@ bool	P_TeleportMove(AActor* thing, const DVector3 &pos, bool telefrag, bool modi
 		if ((th->flags2 | tmf.thing->flags2) & MF2_THRUACTORS)
 			continue;
 
-		if (th->ThruBits & tmf.thing->ThruBits)
+		if (((th->flags8 | tmf.thing->flags8) & MF8_THRUBITS) && th->ThruBits & tmf.thing->ThruBits)
 			continue;
 
 		double blockdist = th->radius + tmf.thing->radius;
@@ -1304,7 +1304,7 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 	if ((thing->flags2 | tm.thing->flags2) & MF2_THRUACTORS)
 		return true;
 
-	if (thing->ThruBits & tm.thing->ThruBits)
+	if (((thing->flags8 | tm.thing->flags8) & MF8_THRUBITS) && thing->ThruBits & tm.thing->ThruBits)
 		return true;
 
 	if (!((thing->flags & (MF_SOLID | MF_SPECIAL | MF_SHOOTABLE)) || thing->flags6 & MF6_TOUCHY))
@@ -2000,7 +2000,7 @@ int P_TestMobjZ(AActor *actor, bool quick, AActor **pOnmobj)
 		{
 			continue;
 		}
-		if (actor->ThruBits & thing->ThruBits)
+		if (((actor->flags8 | thing->flags8) & MF8_THRUBITS) && actor->ThruBits & thing->ThruBits)
 		{
 			continue;
 		}
@@ -4498,7 +4498,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 	{
 		TData.ThruSpecies = (puffDefaults && (puffDefaults->flags6 & MF6_THRUSPECIES));
 		TData.ThruActors = (puffDefaults && (puffDefaults->flags2 & MF2_THRUACTORS));
-		TData.UseThruBits = true;
+		
 		// [MC] Because this is a one-hit trace event, we need to spawn the puff, get the species
 		// and destroy it. Assume there is no species unless tempuff isn't NULL. We cannot get
 		// a proper species the same way as puffDefaults flags it appears...
@@ -4509,6 +4509,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 		if (tempuff != NULL)
 		{
 			TData.PuffSpecies = tempuff->GetSpecies();
+			TData.UseThruBits = tempuff->flags8 & MF8_THRUBITS;
 			TData.ThruBits = tempuff->ThruBits;
 			tempuff->Destroy();
 		}
@@ -5265,7 +5266,11 @@ void P_RailAttack(FRailParams *p)
 		rail_data.PuffSpecies = (thepuff != NULL) ? thepuff->GetSpecies() : NAME_None;
 
 	if (thepuff)
+	{
 		rail_data.ThruBits = thepuff->ThruBits;
+		if (rail_data.UseThruBits)
+			rail_data.UseThruBits = (thepuff->flags8 & MF8_THRUBITS);
+	}
 
 	Trace(start, source->Sector, vec, p->distance, MF_SHOOTABLE, ML_BLOCKEVERYTHING, source, trace,	flags, ProcessRailHit, &rail_data);
 

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -327,7 +327,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, STOPRAILS, AActor, flags8),
 	DEFINE_FLAG(MF8, FALLDAMAGE, AActor, flags8),
 	DEFINE_FLAG(MF8, ABSVIEWANGLES, AActor, flags8),
-	DEFINE_FLAG(MF8, THRUBITS, AActor, flags8),
+	DEFINE_FLAG(MF8, ALLOWTHRUBITS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -327,6 +327,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, STOPRAILS, AActor, flags8),
 	DEFINE_FLAG(MF8, FALLDAMAGE, AActor, flags8),
 	DEFINE_FLAG(MF8, ABSVIEWANGLES, AActor, flags8),
+	DEFINE_FLAG(MF8, THRUBITS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
ThruBits is now opt-in for convenience with the +THRUBITS flag.

I discovered a flaw with the current system. No matter what, anyone of the same group will pass through each other when, in some cases, it's undesired. For example, I have some monsters that are the same type, but I still want them to collide with one another. This isn't possible because if ThruBits is active, it affects anyone immediately. The only way to disable this behavior is to give them 0 bits, but that means actors meant to pass through them can no longer do so.

With this flag, ThruBits is no longer active until at least one of the two colliding actors has it on. Now I can have my shotgun shells pass through other actors, but not through my super solid minecraft blocks.