### PR TITLE
Expose changing sidedef wallpart flags to zscript

### DIFF
--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1320,6 +1320,17 @@ struct side_t
 		textures[which].yScale *= delta;
 	}
 
+	int GetTextureFlags(int which)
+	{
+		return textures[which].flags;
+	}
+
+	void ChangeTextureFlags(int which, int And, int Or)
+	{
+		textures[which].flags &= ~And;
+		textures[which].flags |= Or;
+	}
+
 	void SetSpecialColor(int which, int slot, int r, int g, int b, bool useown = true)
 	{
 		textures[which].SpecialColors[slot] = PalEntry(255, r, g, b);

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -1399,6 +1399,33 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, SetXOffset, SetXOffset)
 	 ACTION_RETURN_POINTER(self->V2());
  }
 
+ static int GetTextureFlags(side_t* self, int tier)
+ {
+	 return self->GetTextureFlags(tier);
+ }
+
+ DEFINE_ACTION_FUNCTION_NATIVE(_Side, GetTextureFlags, GetTextureFlags)
+ {
+	 PARAM_SELF_STRUCT_PROLOGUE(side_t);
+	 PARAM_INT(tier);
+	 ACTION_RETURN_INT(self->GetTextureFlags(tier));
+}
+
+ static void ChangeTextureFlags(side_t* self, int tier, int And, int Or)
+ {
+	 self->ChangeTextureFlags(tier, And, Or);
+ }
+
+ DEFINE_ACTION_FUNCTION_NATIVE(_Side, ChangeTextureFlags, ChangeTextureFlags)
+ {
+	 PARAM_SELF_STRUCT_PROLOGUE(side_t);
+	 PARAM_INT(tier);
+	 PARAM_INT(a);
+	 PARAM_INT(o);
+	 ChangeTextureFlags(self, tier, a, o);
+	 return 0;
+ }
+
  static void SetSideSpecialColor(side_t *self, int tier, int position, int color, int useown)
  {
 	 if (tier >= 0 && tier < 3 && position >= 0 && position < 2)

--- a/wadsrc/static/zscript/mapdata.zs
+++ b/wadsrc/static/zscript/mapdata.zs
@@ -62,6 +62,14 @@ struct Side native play
 		WALLF_LIGHT_FOG      = 128,	// This wall's Light is used even in fog.
 	};
 
+	enum EPartFlags
+	{
+		NoGradient = 1,
+		FlipGradient = 2,
+		ClampGradient = 4,
+		UseOwnSpecialColors = 8,
+		UseOwnAdditiveColor = 16,
+	};
 
 	native readonly Sector sector;			// Sector the SideDef is facing.
 	//DBaseDecal*	AttachedDecals;	// [RH] Decals bound to the wall
@@ -83,6 +91,8 @@ struct Side native play
 	native void SetTextureYScale(int which, double scale);
 	native double GetTextureYScale(int which);
 	native void MultiplyTextureYScale(int which, double delta);
+	native int GetTextureFlags(int tier);
+	native void ChangeTextureFlags(int tier, int And, int Or);
 	native void SetSpecialColor(int tier, int position, Color scolor, bool useowncolor = true);
 	native Color GetAdditiveColor(int tier);
 	native void SetAdditiveColor(int tier, Color color);


### PR DESCRIPTION
This will allow access to side_t::texture flags through ZScript, giving additional control over what already exists in Side.SetSpecialColor.