### PR TITLE
This IWADINFO option was never released with an official version, ... remove?

### DIFF
--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -184,13 +184,6 @@ void FIWadManager::ParseIWadInfo(const char *fn, const char *data, int datasize,
 					if (sc.Number) iwad->flags |= GI_IGNORETITLEPATCHES;
 					else iwad->flags &= ~GI_IGNORETITLEPATCHES;
 				}
-				else if (sc.Compare("FixUnityStatusBar"))
-				{
-				sc.MustGetStringName("=");
-				sc.MustGetNumber();
-				if (sc.Number) iwad->flags |= GI_FIXUNITYSBAR;
-				else iwad->flags &= ~GI_FIXUNITYSBAR;
-				}
 				else if (sc.Compare("Load"))
 				{
 					sc.MustGetStringName("=");

--- a/src/gamedata/gi.h
+++ b/src/gamedata/gi.h
@@ -50,7 +50,6 @@ enum
 	GI_COMPATPOLY1			= 0x00000040,	// Hexen's MAP36 needs old polyobject drawing
 	GI_COMPATPOLY2			= 0x00000080,	// so does HEXDD's MAP47
 	GI_IGNORETITLEPATCHES	= 0x00000200,	// Ignore the map name graphics when not runnning in English language
-	GI_FIXUNITYSBAR			= 0x00000400,	// Center the status bar if it's too wide for a 320 screen
 };
 
 #include "gametype.h"

--- a/wadsrc_extra/static/iwadinfo.txt
+++ b/wadsrc_extra/static/iwadinfo.txt
@@ -351,7 +351,6 @@ IWad
 	Load = "extras.wad", "soundtrack"
 	BannerColors = "00 7c 00", "a8 a8 a8"
 	IgnoreTitlePatches = 1
-	FixUnityStatusBar = 1
 }
 
 IWad
@@ -366,7 +365,6 @@ IWad
 	MustContain = "SMOOSHED", "ANIMDEFS", "LANGUAGE", "MAPINFO", "ENDOOM", "M_DOOM", "TITLEPIC", "TEXTURES"
 	BannerColors = "a8 00 00", "a8 a8 a8"
 	IgnoreTitlePatches = 1
-	FixUnityStatusBar = 1
 }
 
 IWad
@@ -442,7 +440,6 @@ IWad
 	MustContain = "MAP01", "REDTNT2", "DMAPINFO"
 	BannerColors = "00 7c 00", "a8 a8 a8"
 	IgnoreTitlePatches = 1
-	FixUnityStatusBar = 1
 }
 
 IWad
@@ -471,7 +468,6 @@ IWad
 	MustContain = "MAP01", "CAMO1", "DMAPINFO"
 	BannerColors = "00 7c 00", "a8 a8 a8"
 	IgnoreTitlePatches = 1
-	FixUnityStatusBar = 1
 }
 
 IWad
@@ -516,7 +512,6 @@ IWad
 	BannerColors = "00 7c 00", "a8 a8 a8"
 	IgnoreTitlePatches = 1
 	Load = "nerveunity.wad", "extras.wad", "soundtrack"
-	FixUnityStatusBar = 1
 }
 
 IWad


### PR DESCRIPTION
- remove the IWADINFO definition to fix an un-offsetted status bar, since it's done unconditionally now