### PR TITLE
AddListMenu

### DIFF
--- a/src/common/menu/menu.h
+++ b/src/common/menu/menu.h
@@ -93,6 +93,7 @@ public:
 	bool mAnimatedTransition;
 	int mVirtWidth;
 	int mVirtHeight;
+	bool mCustomSizeSet;
 
 	void Reset();
 };


### PR DESCRIPTION
This PR implements an ```AddListMenu``` directive for MENUDEF to allow extending existing list menus without redefining them from scratch.

**Proposed syntax:**

```
AddListMenu "MenuName" [<before|after> "SubMenuName"]
{
    ...
}
```

**Explanation:**

Works exactly like ```AddOptionMenu``` but applies to list menus, and optionally allows inserting items before or after a specific menu item. The menu item to insert new items before/after is looked up by the value of its ```mAction``` field, which in list menus normally corresponds to a submenu name. If the requested item is not found, no error is thrown, and extension proceeds as normal by adding new items to the end of the list. This is necessary to avoid potential backwards compatibility issues.

**Justification:**

Primarily for mods that would like to add their own menu items to the main menu but without redefining the menu entirely. Specifying an insertion point allows thematical grouping of items, e.g. to allow "Mod Options" follow the normal "Options" and not be put after "Quit Game" where it would look somewhat out of place. 

**Technical:**

This implementation is perhaps the simplest one possible here, but it is hampered by the fact that selectable ```ListMenuItem```s get their Y-coordinates precomputed during parsing. However, it is still possible to change these coordinates once the items have already been added, and this is exactly what I'm doing here. Selectable items are shifted downwards on insertion, others are not affected.

The algorithm that determines if a menu is eligible for non-clean scaling should still work as before (but [this bug](https://forum.zdoom.org/viewtopic.php?f=2&t=70393) has been fixed).

This submission also fixes a bug that could result in GZDoom crashing due to null pointer dereference if parsing an ```AddOptionMenu``` directive that specified a name of a non-existent menu. If this PR is rejected, I will submit a separate bug report / PR to fix this issue.

**Example:**

The proposed changes have been tested in basic scenarios. Here's an example MENUDEF that adds a new item after "Options":

```
AddListMenu "MainMenu" after "OptionsMenu"
{
    TextItem "My Mod Options", "m", "OptionsMenu" // <-- placeholder to replace with real mod options menu name
}
```

Feel free to run more tests and/or review the code for potential bugs.