### PR TITLE
Do not keep impact decal that fails to stick to a wall

### DIFF
--- a/src/playsim/a_decals.cpp
+++ b/src/playsim/a_decals.cpp
@@ -755,6 +755,7 @@ DImpactDecal *DImpactDecal::StaticCreate (FLevelLocals *Level, const FDecalTempl
 
 		if (!decal->StickToWall (wall, pos.X, pos.Y, ffloor).isValid())
 		{
+			decal->Destroy();
 			return NULL;
 		}
 		decal->CheckMax();


### PR DESCRIPTION
Such invisible decals were not taken into account when calculating their total number
Changing `cl_maxdecals` CVAR may not work as expected because of limit counter's inconsistent value

https://forum.zdoom.org/viewtopic.php?t=70457