### PR TITLE
Fix AbsorbDamage not handling destroyed items correctly

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3242,8 +3242,11 @@ bool AActor::AdjustReflectionAngle (AActor *thing, DAngle &angle)
 
 int AActor::AbsorbDamage(int damage, FName dmgtype, AActor *inflictor, AActor *source, int flags)
 {
-	for (AActor *item = Inventory; item != nullptr; item = item->Inventory)
+	AActor *next;
+	for (AActor *item = Inventory; item != nullptr; item = next)
 	{
+		// [Player701] Remember the next item now in case the current item is destroyed later
+		next = item->Inventory;
 		IFVIRTUALPTRNAME(item, NAME_Inventory, AbsorbDamage)
 		{
 			VMValue params[7] = { item, damage, dmgtype.GetIndex(), &damage, inflictor, source, flags };


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?f=2&t=70653) for details. If an item has an AbsorbDamage override that may destroy said item (i.e. the item has absorbed too much damage and "expired"), any following items in the inventory chain will not absorb any damage. This is probably not intended behavior, so here is a fix (remember the pointer to the next item before calling AbsorbDamage in case the item is destroyed and unlinked later).