### PR TITLE
add "hidepartimes" MAPINFO/GameInfo property

### DIFF
--- a/src/gamedata/gi.cpp
+++ b/src/gamedata/gi.cpp
@@ -76,6 +76,7 @@ DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, berserkpic)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, defaultdropstyle)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, normforwardmove)
 DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, normsidemove)
+DEFINE_FIELD_X(GameInfoStruct, gameinfo_t, mHideParTimes)
 
 const char *GameNames[17] =
 {
@@ -443,6 +444,7 @@ void FMapInfoParser::ParseGameInfo()
 			GAMEINFOKEY_TWODOUBLES(normforwardmove, "normforwardmove")
 			GAMEINFOKEY_TWODOUBLES(normsidemove, "normsidemove")
 			GAMEINFOKEY_BOOL(nomergepickupmsg, "nomergepickupmsg")
+			GAMEINFOKEY_BOOL(mHideParTimes, "hidepartimes")
 
 		else
 		{

--- a/src/gamedata/gi.h
+++ b/src/gamedata/gi.h
@@ -208,6 +208,7 @@ struct gameinfo_t
 	double normsidemove[2];
 	int fullscreenautoaspect = 3;
 	bool nomergepickupmsg;
+	bool mHideParTimes;
 
 	const char *GetFinalePage(unsigned int num) const;
 };

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -107,6 +107,7 @@ extend struct GameInfoStruct
 	native TextureID berserkpic;
 	native double normforwardmove[2];
 	native double normsidemove[2];
+	native bool mHideParTimes;
 }
 
 extend class Object

--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -915,6 +915,13 @@ class StatusScreen abstract play version("2.5")
 			Plrs[i] = wbs.plyr[i];
 			otherkills -= Plrs[i].skills;
 		}
+
+		if (gameinfo.mHideParTimes)
+		{
+			// par time and suck time are not displayed if zero.
+			wbs.partime = 0;
+			wbs.sucktime = 0;
+		}
 		
 		entering.Init(gameinfo.mStatscreenEnteringFont);
 		finished.Init(gameinfo.mStatscreenFinishedFont);


### PR DESCRIPTION
This adds "hidepartimes" MAPINFO/GameInfo property which makes intermission screens hide par time and suck time.
False by default.

Example mod that disables par times:
[nopar.zip](https://github.com/coelckers/gzdoom/files/5597662/nopar.zip)
