### PR TITLE
fix keyboard repeat events not being sent to menus with TranslateKeyboardEvents 

### DIFF
--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -637,7 +637,8 @@ bool M_Responder (event_t *ev)
 			{
 				// We do our own key repeat handling but still want to eat the
 				// OS's repeated keys.
-				return true;
+				if (CurrentMenu->TranslateKeyboardEvents()) return true;
+				else return CurrentMenu->CallResponder(ev);
 			}
 			else if (ev->subtype == EV_GUI_BackButtonDown || ev->subtype == EV_GUI_BackButtonUp)
 			{


### PR DESCRIPTION
This fixes this bug report: https://forum.zdoom.org/viewtopic.php?f=2&t=70576