### PR TITLE
Add implicit cast to deal with goto *p for EDG compilers

### DIFF
--- a/src/common/scripting/vm/vmexec.h
+++ b/src/common/scripting/vm/vmexec.h
@@ -40,7 +40,7 @@
 static int ExecScriptFunc(VMFrameStack *stack, VMReturn *ret, int numret)
 {
 #if COMPGOTO
-	static const void * const ops[256] =
+	static void * const ops[256] =
 	{
 #define xx(op,sym,mode,alt,kreg,ktype) &&op,
 #include "vmops.h"


### PR DESCRIPTION
While building GZDoom on Elbrus C/C++ compiler (`lcc`), I got the message like this: 
```
lcc: "/export/home/molchan_i/gzdoom/src/common/scripting/vm/vmexec.cpp", line 66: error #1101:
          in "goto *expr", expr must have type "void *"
  #define NEXTOP        do { pc++; unsigned op = pc->op; a = pc->a; goto *ops[op]; } while(0)
                                                                          ^
 in expansion of macro "NEXTOP" at line 945 of
           "/export/home/molchan_i/gzdoom/src/common/scripting/vm/vmexec.h"
                NEXTOP;
                ^
```
Compiler developers said that it should be common for all EDG-based compilers (in other words, who have a front end from [Edison Design Group](https://www.edg.com/)), like Intel C Compiler (`icc`) or some other compilers. So probably that's the problem with the code, not with the compiler.

Well, even regarding GCC, [here](https://gcc.gnu.org/onlinedocs/gcc/Labels-as-Values.html), one may see that "Any expression of type `void *` is allowed." But `ops[op]` is of type `const void * const`, which may or may not cast automatically (implicitly) to `void *`. GCC seems to be allowing this; but EDG-based compilers, like LCC, and, probably, ICC and others don't allow (by the way, they, at least LCC, allow it for `const void *` and `void * const`). So, when explicit cast is added there, everything seems to be OK.

Tested on x86_64 GCC and e2k (Elbrus) LCC, no drawbacks found.