### PR TITLE
Fix for the bug: "RandomSpawner spawning a RandomSpawner spawning a missile"

### DIFF
--- a/wadsrc/static/zscript/actors/shared/randomspawner.zs
+++ b/wadsrc/static/zscript/actors/shared/randomspawner.zs
@@ -227,7 +227,7 @@ class RandomSpawner : Actor
 				}
 				newmobj.AddZ(SpawnPoint.Z);
 			}
-			if (newmobj.bMissile)
+			if (newmobj.bMissile && !(newmobj is 'RandomSpawner'))
 				newmobj.CheckMissileSpawn(0);
 			// Bouncecount is used to count how many recursions we're in.
 			if (newmobj is 'RandomSpawner')


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?f=2&t=70813) and [here](https://forum.zdoom.org/viewtopic.php?p=1174644#p1174644) for details.

**TL;DR:** If a RandomSpawner wants to spawn another RandomSpawner that decides to spawn a missile, it will call CheckMissileRange for the second spawner, which could result in that spawner being erroneously destroyed before the missile can appear. Proposing to fix this by adding a second check before calling CheckMissileRange to ensure that the newly-spawned object is not another RandomSpawner.