### PR TITLE
Modify Shape2D so that it manages its own vertex buffer rather than using the draw list

### DIFF
--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -598,13 +598,11 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	dg.transform.Cells[0][2] += offset.X;
 	dg.transform.Cells[1][2] += offset.Y;
 	dg.shape2D = shape;
-	dg.shape2DBufIndex = shape->bufIndex;
 	dg.shape2DIndexCount = shape->mIndices.Size();
 	if (shape->needsVertexUpload)
 	{
-		if (shape->bufIndex == 0) {
-			shape->buffers.Clear();
-		}
+		shape->bufIndex += 1;
+
 		shape->buffers.Reserve(1);
 		auto buf = &shape->buffers[shape->bufIndex];
 
@@ -626,9 +624,8 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 
 		buf->UploadData(&verts[0], dg.mVertCount, &shape->mIndices[0], shape->mIndices.Size());
 		shape->needsVertexUpload = false;
-
-		shape->bufIndex += 1;
 	}
+	dg.shape2DBufIndex = shape->bufIndex;
 	AddCommand(&dg);
 	offset = osave;
 }

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -34,6 +34,8 @@
 
 #include <stdarg.h>
 #include "templates.h"
+#include "v_2ddrawer.h"
+#include "vectors.h"
 #include "vm.h"
 #include "c_cvars.h"
 #include "v_draw.h"
@@ -107,7 +109,6 @@ IMPLEMENT_CLASS(DShape2D, false, false)
 static void Shape2D_SetTransform(DShape2D* self, DShape2DTransform *transform)
 {
 	self->transform = transform->transform;
-	self->dirty = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, SetTransform, Shape2D_SetTransform)
@@ -120,13 +121,10 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, SetTransform, Shape2D_SetTransform)
 
 static void Shape2D_Clear(DShape2D* self, int which)
 {
-	if (which & C_Verts)
-	{
-		self->mVertices.Clear();
-		self->dirty = true;
-	}
+	if (which & C_Verts) self->mVertices.Clear();
 	if (which & C_Coords) self->mCoords.Clear();
 	if (which & C_Indices) self->mIndices.Clear();
+	self->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, Clear, Shape2D_Clear)
@@ -140,7 +138,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, Clear, Shape2D_Clear)
 static void Shape2D_PushVertex(DShape2D* self, double x, double y)
 {
 	self->mVertices.Push(DVector2(x, y));
-	self->dirty = true;
+	self->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushVertex, Shape2D_PushVertex)
@@ -155,6 +153,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushVertex, Shape2D_PushVertex)
 static void Shape2D_PushCoord(DShape2D* self, double u, double v)
 {
 	self->mCoords.Push(DVector2(u, v));
+	self->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushCoord, Shape2D_PushCoord)
@@ -171,6 +170,7 @@ static void Shape2D_PushTriangle(DShape2D* self, int a, int b, int c)
 	self->mIndices.Push(a);
 	self->mIndices.Push(b);
 	self->mIndices.Push(c);
+	self->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushTriangle, Shape2D_PushTriangle)
@@ -181,6 +181,10 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushTriangle, Shape2D_PushTriangle)
 	PARAM_INT(c);
 	Shape2D_PushTriangle(self, a, b, c);
 	return 0;
+}
+
+DShape2D::~DShape2D() {
+	delete this->buf;
 }
 
 //==========================================================================
@@ -556,26 +560,32 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	if (!img->isHardwareCanvas() && parms.TranslationId != -1)
 		dg.mTranslationId = parms.TranslationId;
 
-	if (shape->dirty) {
-		if (shape->mVertices.Size() != shape->mTransformedVertices.Size())
-			shape->mTransformedVertices.Resize(shape->mVertices.Size());
-		for (int i = 0; i < dg.mVertCount; i++) {
-			shape->mTransformedVertices[i] = (shape->transform * DVector3(shape->mVertices[i], 1.0)).XY();
-		}
-		shape->dirty = false;
-	}
-
 	auto osave = offset;
 	if (parms.nooffset) offset = { 0,0 };
 
-	double minx = 16383, miny = 16383, maxx = -16384, maxy = -16384;
-	for ( int i=0; i<dg.mVertCount; i++ )
-	{
-		if ( shape->mTransformedVertices[i].X < minx ) minx = shape->mTransformedVertices[i].X;
-		if ( shape->mTransformedVertices[i].Y < miny ) miny = shape->mTransformedVertices[i].Y;
-		if ( shape->mTransformedVertices[i].X > maxx ) maxx = shape->mTransformedVertices[i].X;
-		if ( shape->mTransformedVertices[i].Y > maxy ) maxy = shape->mTransformedVertices[i].Y;
+	if (shape->needsVertexUpload) {
+		shape->minx = 16383;
+		shape->miny = 16383;
+		shape->maxx = -16384;
+		shape->maxy = -16384;
+		for ( int i=0; i<dg.mVertCount; i++ )
+		{
+			if ( shape->mVertices[i].X < shape->minx ) shape->minx = shape->mVertices[i].X;
+			if ( shape->mVertices[i].Y < shape->miny ) shape->miny = shape->mVertices[i].Y;
+			if ( shape->mVertices[i].X > shape->maxx ) shape->maxx = shape->mVertices[i].X;
+			if ( shape->mVertices[i].Y > shape->maxy ) shape->maxy = shape->mVertices[i].Y;
+		}
 	}
+	auto tCorners = {
+		(shape->transform * DVector3(shape->minx, shape->miny, 1.0)).XY(),
+		(shape->transform * DVector3(shape->minx, shape->maxy, 1.0)).XY(),
+		(shape->transform * DVector3(shape->maxx, shape->miny, 1.0)).XY(),
+		(shape->transform * DVector3(shape->maxx, shape->maxy, 1.0)).XY()
+	};
+	double minx = std::min_element(tCorners.begin(), tCorners.end(), [] (auto d0, auto d1) { return d0.X < d1.X; })->X;
+	double maxx = std::max_element(tCorners.begin(), tCorners.end(), [] (auto d0, auto d1) { return d0.X < d1.X; })->X;
+	double miny = std::min_element(tCorners.begin(), tCorners.end(), [] (auto d0, auto d1) { return d0.Y < d1.Y; })->Y;
+	double maxy = std::max_element(tCorners.begin(), tCorners.end(), [] (auto d0, auto d1) { return d0.Y < d1.Y; })->Y;
 	if (minx < (double)parms.lclip || miny < (double)parms.uclip || maxx >(double)parms.rclip || maxy >(double)parms.dclip)
 	{
 		dg.mScissor[0] = parms.lclip + int(offset.X);
@@ -587,23 +597,34 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	else
 		memset(dg.mScissor, 0, sizeof(dg.mScissor));
 
-	dg.mVertIndex = (int)mVertices.Reserve(dg.mVertCount);
-	TwoDVertex *ptr = &mVertices[dg.mVertIndex];
-	for ( int i=0; i<dg.mVertCount; i++ )
-		Set(&ptr[i], shape->mTransformedVertices[i].X, shape->mTransformedVertices[i].Y, 0, shape->mCoords[i].X, shape->mCoords[i].Y, vertexcolor);
-	dg.mIndexIndex = mIndices.Size();
-	dg.mIndexCount += shape->mIndices.Size();
-	for ( int i=0; i<int(shape->mIndices.Size()); i+=3 )
+	dg.useTransform = true;
+	dg.transform = shape->transform;
+	dg.transform.Cells[0][2] += offset.X;
+	dg.transform.Cells[1][2] += offset.Y;
+	dg.shape2D = shape;
+	if (shape->needsVertexUpload)
 	{
-		// [MK] bail out if any indices are out of bounds
-		for ( int j=0; j<3; j++ )
+		delete shape->buf;
+		shape->buf = new F2DVertexBuffer;
+
+		auto verts = TArray<TwoDVertex>(dg.mVertCount, true);
+		for ( int i=0; i<dg.mVertCount; i++ )
+			verts[i].Set(shape->mVertices[i].X, shape->mVertices[i].Y, 0, shape->mCoords[i].X, shape->mCoords[i].Y, vertexcolor);
+
+		for ( int i=0; i<int(shape->mIndices.Size()); i+=3 )
 		{
-			if ( shape->mIndices[i+j] < 0 )
-				ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "Triangle %u index %u is negative: %i\n", i/3, j, shape->mIndices[i+j]);
-			if ( shape->mIndices[i+j] >= dg.mVertCount )
-				ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "Triangle %u index %u: %u, max: %u\n", i/3, j, shape->mIndices[i+j], dg.mVertCount-1);
+			// [MK] bail out if any indices are out of bounds
+			for ( int j=0; j<3; j++ )
+			{
+				if ( shape->mIndices[i+j] < 0 )
+					ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "Triangle %u index %u is negative: %i\n", i/3, j, shape->mIndices[i+j]);
+				if ( shape->mIndices[i+j] >= dg.mVertCount )
+					ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "Triangle %u index %u: %u, max: %u\n", i/3, j, shape->mIndices[i+j], dg.mVertCount-1);
+			}
 		}
-		AddIndices(dg.mVertIndex, 3, shape->mIndices[i], shape->mIndices[i+1], shape->mIndices[i+2]);
+
+		shape->buf->UploadData(&verts[0], dg.mVertCount, &shape->mIndices[0], shape->mIndices.Size());
+		shape->needsVertexUpload = false;
 	}
 	AddCommand(&dg);
 	offset = osave;
@@ -1013,4 +1034,16 @@ void F2DDrawer::Clear()
 		mIsFirstPass = true;
 	}
 	screenFade = 1.f;
+}
+
+F2DVertexBuffer::F2DVertexBuffer() {
+	mVertexBuffer = screen->CreateVertexBuffer();
+	mIndexBuffer = screen->CreateIndexBuffer();
+
+	static const FVertexBufferAttribute format[] = {
+		{ 0, VATTR_VERTEX, VFmt_Float3, (int)myoffsetof(F2DDrawer::TwoDVertex, x) },
+		{ 0, VATTR_TEXCOORD, VFmt_Float2, (int)myoffsetof(F2DDrawer::TwoDVertex, u) },
+		{ 0, VATTR_COLOR, VFmt_Byte4, (int)myoffsetof(F2DDrawer::TwoDVertex, color0) }
+	};
+	mVertexBuffer->SetFormat(1, 3, sizeof(F2DDrawer::TwoDVertex), format);
 }

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -183,11 +183,6 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushTriangle, Shape2D_PushTriangle)
 	return 0;
 }
 
-DShape2D::~DShape2D() {
-	for (auto b : this->buffers) delete b;
-	this->buffers.Clear();
-}
-
 //==========================================================================
 //
 //
@@ -608,11 +603,10 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	if (shape->needsVertexUpload)
 	{
 		if (shape->bufIndex == 0) {
-			for (auto b : shape->buffers) delete b;
 			shape->buffers.Clear();
 		}
-		shape->buffers.Push(new F2DVertexBuffer);
-		auto buf = shape->buffers[shape->bufIndex];
+		shape->buffers.Reserve(1);
+		auto buf = &shape->buffers[shape->bufIndex];
 
 		auto verts = TArray<TwoDVertex>(dg.mVertCount, true);
 		for ( int i=0; i<dg.mVertCount; i++ )

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -559,7 +559,8 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	auto osave = offset;
 	if (parms.nooffset) offset = { 0,0 };
 
-	if (shape->needsVertexUpload) {
+	if (shape->needsVertexUpload)
+	{
 		shape->minx = 16383;
 		shape->miny = 16383;
 		shape->maxx = -16384;
@@ -1036,7 +1037,8 @@ void F2DDrawer::Clear()
 	screenFade = 1.f;
 }
 
-F2DVertexBuffer::F2DVertexBuffer() {
+F2DVertexBuffer::F2DVertexBuffer()
+{
 	mVertexBuffer = screen->CreateVertexBuffer();
 	mIndexBuffer = screen->CreateIndexBuffer();
 

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -44,8 +44,6 @@ public:
 		transform.Identity();
 	}
 
-	~DShape2D();
-
 	TArray<int> mIndices;
 	TArray<DVector2> mVertices;
 	TArray<DVector2> mCoords;
@@ -57,7 +55,7 @@ public:
 
 	DMatrix3x3 transform;
 
-	TArray<F2DVertexBuffer*> buffers;
+	TArray<F2DVertexBuffer> buffers;
 	bool needsVertexUpload = true;
 	int bufIndex = 0;
 };

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -57,8 +57,9 @@ public:
 
 	DMatrix3x3 transform;
 
-	F2DVertexBuffer* buf;
+	TArray<F2DVertexBuffer*> buffers;
 	bool needsVertexUpload = true;
+	int bufIndex = 0;
 };
 
 struct F2DPolygons
@@ -149,6 +150,8 @@ public:
 		DMatrix3x3 transform;
 
 		DShape2D* shape2D;
+		int shape2DBufIndex;
+		int shape2DIndexCount;
 
 		RenderCommand()
 		{

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -57,7 +57,7 @@ public:
 
 	TArray<F2DVertexBuffer> buffers;
 	bool needsVertexUpload = true;
-	int bufIndex = 0;
+	int bufIndex = -1;
 };
 
 struct F2DPolygons

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "tarray.h"
 #include "vectors.h"
 #include "matrix.h"
 #include "hw_material.h"

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tarray.h"
 #include "vectors.h"
 #include "matrix.h"
 #include "hw_material.h"

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -176,7 +176,7 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 
 		if (cmd.shape2D != nullptr)
 		{
-			state.SetVertexBuffer(cmd.shape2D->buffers[cmd.shape2DBufIndex]);
+			state.SetVertexBuffer(&cmd.shape2D->buffers[cmd.shape2DBufIndex]);
 			state.DrawIndexed(DT_Triangles, 0, cmd.shape2DIndexCount);
 			state.SetVertexBuffer(&vb);
 			if (cmd.shape2D->bufIndex > 1) {

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -179,10 +179,12 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 			state.SetVertexBuffer(&cmd.shape2D->buffers[cmd.shape2DBufIndex]);
 			state.DrawIndexed(DT_Triangles, 0, cmd.shape2DIndexCount);
 			state.SetVertexBuffer(&vb);
-			if (cmd.shape2D->bufIndex > 1) {
+			if (cmd.shape2D->bufIndex > 0 && cmd.shape2DBufIndex == cmd.shape2D->bufIndex)
+			{
 				cmd.shape2D->needsVertexUpload = true;
+				cmd.shape2D->buffers.Clear();
+				cmd.shape2D->bufIndex = -1;
 			}
-			cmd.shape2D->bufIndex = 0;
 		}
 		else
 		{

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -129,19 +129,23 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 
 		state.AlphaFunc(Alpha_GEqual, 0.f);
 
-		if (cmd.useTransform) {
+		if (cmd.useTransform)
+		{
 			FLOATTYPE m[16] = {
 				0.0, 0.0, 0.0, 0.0,
 				0.0, 0.0, 0.0, 0.0,
 				0.0, 0.0, 1.0, 0.0,
 				0.0, 0.0, 0.0, 1.0
 			};
-			for (size_t i = 0; i < 2; i++) {
-				for (size_t j = 0; j < 2; j++) {
+			for (size_t i = 0; i < 2; i++)
+			{
+				for (size_t j = 0; j < 2; j++)
+				{
 					m[4 * j + i] = (FLOATTYPE) cmd.transform.Cells[i][j];
 				}
 			}
-			for (size_t i = 0; i < 2; i++) {
+			for (size_t i = 0; i < 2; i++)
+			{
 				m[4 * 3 + i] = (FLOATTYPE) cmd.transform.Cells[i][2];
 			}
 			state.mModelMatrix.loadMatrix(m);

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -176,9 +176,13 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 
 		if (cmd.shape2D != nullptr)
 		{
-			state.SetVertexBuffer(cmd.shape2D->buf);
-			state.DrawIndexed(DT_Triangles, 0, cmd.shape2D->mIndices.Size());
+			state.SetVertexBuffer(cmd.shape2D->buffers[cmd.shape2DBufIndex]);
+			state.DrawIndexed(DT_Triangles, 0, cmd.shape2DIndexCount);
 			state.SetVertexBuffer(&vb);
+			if (cmd.shape2D->bufIndex > 1) {
+				cmd.shape2D->needsVertexUpload = true;
+			}
+			cmd.shape2D->bufIndex = 0;
 		}
 		else
 		{

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -43,51 +43,6 @@
 #include "r_videoscale.h"
 #include "v_draw.h"
 
-
-//===========================================================================
-// 
-// Vertex buffer for 2D drawer
-//
-//===========================================================================
-
-class F2DVertexBuffer
-{
-	IVertexBuffer *mVertexBuffer;
-	IIndexBuffer *mIndexBuffer;
-
-
-public:
-
-	F2DVertexBuffer()
-	{
-		mVertexBuffer = screen->CreateVertexBuffer();
-		mIndexBuffer = screen->CreateIndexBuffer();
-
-		static const FVertexBufferAttribute format[] = {
-			{ 0, VATTR_VERTEX, VFmt_Float3, (int)myoffsetof(F2DDrawer::TwoDVertex, x) },
-			{ 0, VATTR_TEXCOORD, VFmt_Float2, (int)myoffsetof(F2DDrawer::TwoDVertex, u) },
-			{ 0, VATTR_COLOR, VFmt_Byte4, (int)myoffsetof(F2DDrawer::TwoDVertex, color0) }
-		};
-		mVertexBuffer->SetFormat(1, 3, sizeof(F2DDrawer::TwoDVertex), format);
-	}
-	~F2DVertexBuffer()
-	{
-		delete mIndexBuffer;
-		delete mVertexBuffer;
-	}
-
-	void UploadData(F2DDrawer::TwoDVertex *vertices, int vertcount, int *indices, int indexcount)
-	{
-		mVertexBuffer->SetData(vertcount * sizeof(*vertices), vertices, false);
-		mIndexBuffer->SetData(indexcount * sizeof(unsigned int), indices, false);
-	}
-
-	std::pair<IVertexBuffer *, IIndexBuffer *> GetBufferObjects() const
-	{
-		return std::make_pair(mVertexBuffer, mIndexBuffer);
-	}
-};
-
 //===========================================================================
 // 
 // Draws the 2D stuff. This is the version for OpenGL 3 and later.
@@ -174,6 +129,25 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 
 		state.AlphaFunc(Alpha_GEqual, 0.f);
 
+		if (cmd.useTransform) {
+			FLOATTYPE m[16] = {
+				0.0, 0.0, 0.0, 0.0,
+				0.0, 0.0, 0.0, 0.0,
+				0.0, 0.0, 1.0, 0.0,
+				0.0, 0.0, 0.0, 1.0
+			};
+			for (size_t i = 0; i < 2; i++) {
+				for (size_t j = 0; j < 2; j++) {
+					m[4 * j + i] = (FLOATTYPE) cmd.transform.Cells[i][j];
+				}
+			}
+			for (size_t i = 0; i < 2; i++) {
+				m[4 * 3 + i] = (FLOATTYPE) cmd.transform.Cells[i][2];
+			}
+			state.mModelMatrix.loadMatrix(m);
+			state.EnableModelMatrix(true);
+		}
+
 		if (cmd.mTexture != nullptr && cmd.mTexture->isValid())
 		{
 			auto flags = cmd.mTexture->GetUseType() >= ETextureType::Special? UF_None : cmd.mTexture->GetUseType() == ETextureType::FontChar? UF_Font : UF_Texture;
@@ -200,26 +174,36 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 			state.EnableTexture(false);
 		}
 
-		switch (cmd.mType)
+		if (cmd.shape2D != nullptr)
 		{
-		default:
-		case F2DDrawer::DrawTypeTriangles:
-			state.DrawIndexed(DT_Triangles, cmd.mIndexIndex, cmd.mIndexCount);
-			break;
+			state.SetVertexBuffer(cmd.shape2D->buf);
+			state.DrawIndexed(DT_Triangles, 0, cmd.shape2D->mIndices.Size());
+			state.SetVertexBuffer(&vb);
+		}
+		else
+		{
+			switch (cmd.mType)
+			{
+			default:
+			case F2DDrawer::DrawTypeTriangles:
+				state.DrawIndexed(DT_Triangles, cmd.mIndexIndex, cmd.mIndexCount);
+				break;
 
-		case F2DDrawer::DrawTypeLines:
-			state.Draw(DT_Lines, cmd.mVertIndex, cmd.mVertCount);
-			break;
+			case F2DDrawer::DrawTypeLines:
+				state.Draw(DT_Lines, cmd.mVertIndex, cmd.mVertCount);
+				break;
 
-		case F2DDrawer::DrawTypePoints:
-			state.Draw(DT_Points, cmd.mVertIndex, cmd.mVertCount);
-			break;
+			case F2DDrawer::DrawTypePoints:
+				state.Draw(DT_Points, cmd.mVertIndex, cmd.mVertCount);
+				break;
 
+			}
 		}
 		state.SetObjectColor(0xffffffff);
 		state.SetObjectColor2(0);
 		state.SetAddColor(0);
 		state.EnableTextureMatrix(false);
+		state.EnableModelMatrix(false);
 		state.SetEffect(EFF_NONE);
 
 	}


### PR DESCRIPTION
Currently in GZDoom if Shape2Ds get particularly large (to draw very complex things like a textured minimap, for example), they start slowing down the game quite a lot as the entire vertex data will be reuploaded every frame when it could just as well be kept on the GPU and only updated when necessary. This pull request does that by giving Shape2Ds an array of F2DVertexBuffers which they then update only if the cache has been marked as dirty. If a shape is used and modified multiple times in one frame, it'll use multiple vertex buffers (this effectively reverts it to the old performance, but this is hard to avoid and also a non-idiomatic use of Shape2D anyway). Otherwise if a shape is drawn once per frame without changing vertex data, it won't reupload anything, which has led to Shape2Ds in some of my mods going from halving the FPS to having barely any effect on it, so this has improved performance a lot.

This pull request also modifies Shape2DTransform so that it uploads the transform onto the GPU as a model matrix, further decreasing the amount of required reuploads.

I've asked around the community and used my own code to verify that this doesn't break backwards compatibility or cause any crashes, so it should be solid at this point.