### PR TITLE
Add clampangle function

### DIFF
--- a/src/common/utility/vectors.h
+++ b/src/common/utility/vectors.h
@@ -1418,6 +1418,31 @@ inline TAngle<T> absangle(const TAngle<T> &a1, double a2)
 	return fabs((a1 - a2).Normalized180());
 }
 
+// Angles need special handling
+template<typename T>
+TAngle<T> clampangle(const TAngle<T> &ang, const TAngle<T> &min, const TAngle<T> &max)
+{
+	TAngle<T> maxdiff = deltaangle(ang, max);
+	TAngle<T> mindiff = deltaangle(min, ang);
+	if (mindiff < 0 && maxdiff < 0)
+	{
+		if (mindiff < maxdiff)
+		{
+			return max;
+		}
+		return min;
+	}
+	if (maxdiff < 0)
+	{
+		return max;
+	}
+	else if (mindiff < 0)
+	{
+		return min;
+	}
+	return ang.Normalized180();
+}
+
 inline TAngle<double> VecToAngle(double x, double y)
 {
 	return g_atan2(y, x) * (180.0 / pi::pi());

--- a/src/common/utility/vectors.h
+++ b/src/common/utility/vectors.h
@@ -1428,17 +1428,17 @@ TAngle<T> clampangle(const TAngle<T> &ang, const TAngle<T> &min, const TAngle<T>
 	{
 		if (mindiff < maxdiff)
 		{
-			return max;
+			return max.Normalized180();
 		}
-		return min;
+		return min.Normalized180();
 	}
 	if (maxdiff < 0)
 	{
-		return max;
+		return max.Normalized180();
 	}
 	else if (mindiff < 0)
 	{
-		return min;
+		return min.Normalized180();
 	}
 	return ang.Normalized180();
 }

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -240,6 +240,21 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, absangle, absangleDbl)	// should this be g
 	ACTION_RETURN_FLOAT(absangle(DAngle(a1), DAngle(a2)).Degrees);
 }
 
+// Angles need special handling
+static double clampangleDbl(double ang, double min, double max)
+{
+	return clampangle(DAngle(ang), DAngle(min), DAngle(max)).Degrees;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(AActor, clampangle, clampangleDbl)	// should this be global?
+{
+	PARAM_PROLOGUE;
+	PARAM_FLOAT(ang);
+	PARAM_FLOAT(min);
+	PARAM_FLOAT(max);
+	ACTION_RETURN_FLOAT(clampangle(DAngle(ang), DAngle(min), DAngle(max)).Degrees);
+}
+
 static double Distance2DSquared(AActor *self, AActor *other)
 {
 	return self->Distance2DSquared(PARAM_NULLCHECK(other, other));

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -429,6 +429,7 @@ class Actor : Thinker native
 	// 'parked' global functions.
 	native clearscope static double deltaangle(double ang1, double ang2);
 	native clearscope static double absangle(double ang1, double ang2);
+	native clearscope static double clampangle(double angle, double min, double max);
 	native clearscope static Vector2 AngleToVector(double angle, double length = 1);
 	native clearscope static Vector2 RotateVector(Vector2 vec, double angle);
 	native clearscope static double Normalize180(double ang);


### PR DESCRIPTION
This is a new function for ZScript which clamps an angle between a minimum and maximum. Angles need special handling, and since deltaangle and absangle were engine features, I figured I should add this as well.