### PR TITLE
GL Light Flag Additions

### DIFF
--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -40,7 +40,9 @@ enum LightFlag
 	LF_ATTENUATE = 8,
 	LF_NOSHADOWMAP = 16,
 	LF_DONTLIGHTACTORS = 32,
-	LF_SPOT = 64
+	LF_SPOT = 64,
+	LF_DONTLIGHTOTHERS = 128,
+	LF_DONTLIGHTMAP = 256
 };
 
 typedef TFlags<LightFlag> LightFlags;
@@ -72,6 +74,8 @@ public:
 	void SetDontLightSelf(bool add) { if (add) m_lightFlags |= LF_DONTLIGHTSELF; else m_lightFlags &= ~LF_DONTLIGHTSELF; }
 	void SetAttenuate(bool on) { m_attenuate = on; if (on) m_lightFlags |= LF_ATTENUATE; else m_lightFlags &= ~LF_ATTENUATE; }
 	void SetDontLightActors(bool on) { if (on) m_lightFlags |= LF_DONTLIGHTACTORS; else m_lightFlags &= ~LF_DONTLIGHTACTORS; }
+	void SetDontLightOthers(bool on) { if (on) m_lightFlags |= LF_DONTLIGHTOTHERS; else m_lightFlags &= ~LF_DONTLIGHTOTHERS; }
+	void SetDontLightMap(bool on) { if (on) m_lightFlags |= LF_DONTLIGHTMAP; else m_lightFlags &= ~LF_DONTLIGHTMAP; }
 	void SetNoShadowmap(bool on) { if (on) m_lightFlags |= LF_NOSHADOWMAP; else m_lightFlags &= ~LF_NOSHADOWMAP; }
 	void SetSpot(bool spot) { if (spot) m_lightFlags |= LF_SPOT; else m_lightFlags &= ~LF_SPOT; }
 	void SetSpotInnerAngle(double angle) { m_spotInnerAngle = angle; }
@@ -86,6 +90,7 @@ public:
 		m_pitch = 0.;
 		m_explicitPitch = false;
 	}
+	
 	void SetType(ELightType type) { m_type = type; }
 	void CopyFrom(const FLightDefaults &other)
 	{
@@ -201,7 +206,10 @@ struct FDynamicLight
 
 	bool ShouldLightActor(AActor *check)
 	{
-		return visibletoplayer && IsActive() && (!((*pLightFlags) & LF_DONTLIGHTSELF) || target != check) && !((*pLightFlags) & LF_DONTLIGHTACTORS);
+		return visibletoplayer && IsActive() && 
+				(!((*pLightFlags) & LF_DONTLIGHTSELF) || target != check) &&
+				(!((*pLightFlags) & LF_DONTLIGHTOTHERS) || target == check) && 
+				(!((*pLightFlags) & LF_DONTLIGHTACTORS));
 	}
 
 	void SetOffset(const DVector3 &pos)
@@ -225,6 +233,8 @@ struct FDynamicLight
 	bool DontShadowmap() const { return !!((*pLightFlags) & LF_NOSHADOWMAP); }
 	bool DontLightSelf() const { return !!((*pLightFlags) & (LF_DONTLIGHTSELF|LF_DONTLIGHTACTORS)); }	// dontlightactors implies dontlightself.
 	bool DontLightActors() const { return !!((*pLightFlags) & LF_DONTLIGHTACTORS); }
+	bool DontLightOthers() const { return !!((*pLightFlags) & (LF_DONTLIGHTOTHERS)); }
+	bool DontLightMap() const { return !!((*pLightFlags) & (LF_DONTLIGHTMAP)); }
 	void Deactivate() { m_active = false; }
 	void Activate();
 

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -144,6 +144,8 @@ static const char *LightTags[]=
    "dontlightactors",
    "spot",
    "noshadowmap",
+   "dontlightothers",
+   "dontlightmap",
    nullptr
 };
 
@@ -168,6 +170,8 @@ enum {
    LIGHTTAG_DONTLIGHTACTORS,
    LIGHTTAG_SPOT,
    LIGHTTAG_NOSHADOWMAP,
+   LIGHTTAG_DONTLIGHTOTHERS,
+   LIGHTTAG_DONTLIGHTMAP,
 };
 
 //==========================================================================
@@ -468,6 +472,12 @@ class GLDefsParser
 				case LIGHTTAG_DONTLIGHTACTORS:
 					defaults->SetDontLightActors(ParseInt(sc) != 0);
 					break;
+				case LIGHTTAG_DONTLIGHTOTHERS:
+					defaults->SetDontLightOthers(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTMAP:
+					defaults->SetDontLightMap(ParseInt(sc) != 0);
+					break;
 				case LIGHTTAG_SPOT:
 					{
 						float innerAngle = ParseFloat(sc);
@@ -563,6 +573,12 @@ class GLDefsParser
 					break;
 				case LIGHTTAG_DONTLIGHTACTORS:
 					defaults->SetDontLightActors(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTOTHERS:
+					defaults->SetDontLightOthers(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTMAP:
+					defaults->SetDontLightMap(ParseInt(sc) != 0);
 					break;
 				case LIGHTTAG_SPOT:
 					{
@@ -663,6 +679,12 @@ class GLDefsParser
 				case LIGHTTAG_DONTLIGHTACTORS:
 					defaults->SetDontLightActors(ParseInt(sc) != 0);
 					break;
+				case LIGHTTAG_DONTLIGHTOTHERS:
+					defaults->SetDontLightOthers(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTMAP:
+					defaults->SetDontLightMap(ParseInt(sc) != 0);
+					break;
 				case LIGHTTAG_SPOT:
 					{
 						float innerAngle = ParseFloat(sc);
@@ -761,6 +783,12 @@ class GLDefsParser
 				case LIGHTTAG_DONTLIGHTACTORS:
 					defaults->SetDontLightActors(ParseInt(sc) != 0);
 					break;
+				case LIGHTTAG_DONTLIGHTOTHERS:
+					defaults->SetDontLightOthers(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTMAP:
+					defaults->SetDontLightMap(ParseInt(sc) != 0);
+					break;
 				case LIGHTTAG_SPOT:
 					{
 						float innerAngle = ParseFloat(sc);
@@ -855,6 +883,12 @@ class GLDefsParser
 					break;
 				case LIGHTTAG_DONTLIGHTACTORS:
 					defaults->SetDontLightActors(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTOTHERS:
+					defaults->SetDontLightOthers(ParseInt(sc) != 0);
+					break;
+				case LIGHTTAG_DONTLIGHTMAP:
+					defaults->SetDontLightMap(ParseInt(sc) != 0);
 					break;
 				case LIGHTTAG_SPOT:
 					{

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -161,7 +161,7 @@ void HWFlat::SetupLights(HWDrawInfo *di, FLightNode * node, FDynLightData &light
 	{
 		FDynamicLight * light = node->lightsource;
 
-		if (!light->IsActive())
+		if (!light->IsActive() || light->DontLightMap())
 		{
 			node = node->nextLight;
 			continue;

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -419,7 +419,7 @@ void HWWall::SetupLights(HWDrawInfo *di, FDynLightData &lightdata)
 	// Iterate through all dynamic lights which touch this wall and render them
 	while (node)
 	{
-		if (node->lightsource->IsActive())
+		if (node->lightsource->IsActive() && !node->lightsource->DontLightMap())
 		{
 			iter_dlight++;
 

--- a/wadsrc/static/zscript/actors/shared/dynlights.zs
+++ b/wadsrc/static/zscript/actors/shared/dynlights.zs
@@ -15,6 +15,8 @@ class DynamicLight : Actor
 	flagdef noshadowmap: lightflags, 4;
 	flagdef dontlightactors: lightflags, 5;
 	flagdef spot: lightflags, 6;
+	flagdef dontlightothers: lightflags, 7;
+	flagdef dontlightmap: lightflags, 8;
 
 	enum EArgs
 	{
@@ -35,7 +37,9 @@ class DynamicLight : Actor
 		LF_ATTENUATE = 8,
 		LF_NOSHADOWMAP = 16,
 		LF_DONTLIGHTACTORS = 32,
-		LF_SPOT = 64
+		LF_SPOT = 64,
+		LF_DONTLIGHTOTHERS = 128,
+		LF_DONTLIGHTMAP = 256,
 	};
 
 	enum ELightType


### PR DESCRIPTION
Added the following GL Light flags:

- `DontLightOthers`: Acts as the inverse of `DontLightSelf`, where it won't light actors that aren't the owner.
- `DontLightMap`: The light doesn't affect the map.