### PR TITLE
Disable AO for skybox portals (redux)

### DIFF
--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1653,6 +1653,7 @@ MapFlagHandlers[] =
 	{ "nocoloredspritelighting",		MITYPE_SETFLAG3,	LEVEL3_NOCOLOREDSPRITELIGHTING, 0 },
 	{ "forceworldpanning",				MITYPE_SETFLAG3,	LEVEL3_FORCEWORLDPANNING, 0 },
 	{ "propermonsterfallingdamage",			MITYPE_SETFLAG3,	LEVEL3_PROPERMONSTERFALLINGDAMAGE, 0 },
+	{ "enableskyboxao",				MITYPE_SETFLAG3,	LEVEL3_SKYBOXAO, 0 },
 	{ "nobotnodes",						MITYPE_IGNORE,	0, 0 },		// Skulltag option: nobotnodes
 	{ "compat_shorttex",				MITYPE_COMPATFLAG, COMPATF_SHORTTEX, 0 },
 	{ "compat_stairs",					MITYPE_COMPATFLAG, COMPATF_STAIRINDEX, 0 },

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -251,6 +251,7 @@ enum ELevelFlags : unsigned int
 	LEVEL3_FORCEWORLDPANNING	= 0x00000080,	// Forces the world panning flag for all textures, even those without it explicitly set.
 	LEVEL3_HIDEAUTHORNAME		= 0x00000100,
 	LEVEL3_PROPERMONSTERFALLINGDAMAGE	= 0x00000200,	// Properly apply falling damage to the monsters
+	LEVEL3_SKYBOXAO				= 0x00000400,	// Apply SSAO to sector skies
 };
 
 

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -672,7 +672,7 @@ void HWDrawInfo::DrawScene(int drawmode)
 	}
 	else if (drawmode == DM_PORTAL && ssao_portals_available > 0)
 	{
-		applySSAO = true;
+		applySSAO = (mCurrentPortal->AllowSSAO() || Level->flags3&LEVEL3_SKYBOXAO);
 		ssao_portals_available--;
 	}
 

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -718,6 +718,7 @@ void HWSkyboxPortal::Shutdown(HWDrawInfo *di, FRenderState &rstate)
 }
 
 const char *HWSkyboxPortal::GetName() { return "Skybox"; }
+bool HWSkyboxPortal::AllowSSAO() { return false; }	// [MK] sector skyboxes don't allow SSAO by default
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -77,6 +77,7 @@ public:
     virtual line_t *ClipLine() { return nullptr; }
 	virtual void * GetSource() const = 0;	// GetSource MUST be implemented!
 	virtual const char *GetName() = 0;
+	virtual bool AllowSSAO() { return true; }
 	virtual bool IsSky() { return false; }
 	virtual bool NeedCap() { return true; }
 	virtual bool NeedDepthBuffer() { return true; }
@@ -258,6 +259,7 @@ protected:
 	virtual void * GetSource() const { return portal; }
 	virtual bool IsSky() { return true; }
 	virtual const char *GetName();
+	virtual bool AllowSSAO() override;
 
 public:
 


### PR DESCRIPTION
Remake of #998 (mainly because there have been many internal changes ever since)

Rather than shoddily using GetName, I implemented an AllowSSAO virtual into the HWPortal class, which defaults for true but is overriden by HWSkyboxPortal to return false. In a way, it's the same thing as before, just... cleaner? (I really have no idea, I'm no C++ expert)

Reuploading the example here: [skyboxao_m.zip](https://github.com/coelckers/gzdoom/files/5753625/skyboxao_m.zip)
Two identical maps, but one has the MAPINFO flag that forces sector sky AO back on.