### PR TITLE
Fix IfItem amount not being checked

### DIFF
--- a/src/maploader/usdf.cpp
+++ b/src/maploader/usdf.cpp
@@ -294,8 +294,7 @@ class USDFParser : public UDMFParserBase
 				check.Item = CheckInventoryActorType(key);
 				break;
 
-			case NAME_Count:
-				// Not yet implemented in the engine. Todo later
+			case NAME_Amount:
 				check.Amount = CheckInt(key);
 				break;
 			}


### PR DESCRIPTION
ParseIfItem was checking for the wrong field name, causing the 'Amount' field to be ignored.