### PR TITLE
Fix MAPINFO definitions for "enableskyboxao"

### DIFF
--- a/wadsrc/static/mapinfo/chex.txt
+++ b/wadsrc/static/mapinfo/chex.txt
@@ -76,6 +76,10 @@ gameinfo
 	messageboxclass = "MessageBoxMenu"
 	normforwardmove = 0x19, 0x32
 	normsidemove = 0x18, 0x28
+}
+
+gamedefaults
+{
 	enableskyboxao
 }
 

--- a/wadsrc/static/mapinfo/doomcommon.txt
+++ b/wadsrc/static/mapinfo/doomcommon.txt
@@ -77,6 +77,10 @@ gameinfo
 	messageboxclass = "MessageBoxMenu"
 	normforwardmove = 0x19, 0x32
 	normsidemove = 0x18, 0x28
+}
+
+gamedefaults
+{
 	enableskyboxao
 }
 

--- a/wadsrc/static/mapinfo/heretic.txt
+++ b/wadsrc/static/mapinfo/heretic.txt
@@ -75,6 +75,10 @@ gameinfo
 	messageboxclass = "MessageBoxMenu"
 	normforwardmove = 0x19, 0x32
 	normsidemove = 0x18, 0x28
+}
+
+gamedefaults
+{
 	enableskyboxao
 }
 

--- a/wadsrc/static/mapinfo/hexen.txt
+++ b/wadsrc/static/mapinfo/hexen.txt
@@ -73,7 +73,6 @@ gameinfo
 	messageboxclass = "MessageBoxMenu"
 	normforwardmove = 0x19, 0x32
 	normsidemove = 0x18, 0x28
-	enableskyboxao
 }
 
 DoomEdNums
@@ -513,6 +512,7 @@ gamedefaults
 	noautosequences
 	missilesactivateimpactlines
 	monsterfallingdamage
+	enableskyboxao
 }
 
 // There is also support for showing a clus5msg after cluster 5, but

--- a/wadsrc/static/mapinfo/mindefaults.txt
+++ b/wadsrc/static/mapinfo/mindefaults.txt
@@ -61,6 +61,10 @@ gameinfo
 	statscreen_contentfont = "*BigFont"
 	statscreen_authorFont = "*SmallFont"
 	messageboxclass = "MessageBoxMenu"
+}
+
+gamedefaults
+{
 	enableskyboxao
 }
 

--- a/wadsrc/static/mapinfo/strife.txt
+++ b/wadsrc/static/mapinfo/strife.txt
@@ -75,7 +75,6 @@ gameinfo
 	messageboxclass = "MessageBoxMenu"
 	normforwardmove = 0x19, 0x32
 	normsidemove = 0x18, 0x28
-	enableskyboxao
 }
 
 DoomEdNums
@@ -613,6 +612,7 @@ gamedefaults
 	nointermission
 	clipmidtextures
 	noinfighting
+	enableskyboxao
 }
 
 map MAP01 LOOKUP "TXT_STRIFE_MAP01"


### PR DESCRIPTION
enableskyboxao is a map flag, so it goes in the "gamedefaults", "defaultmap", or "map" section. I decided to put it in the gamedefaults section for each game.