### PR TITLE
Print name of OS on POSIX systems when using SDL.

### DIFF
--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -50,7 +50,7 @@
 #include "engineerrors.h"
 #include "i_system.h"
 #include "i_interface.h"
-#include "v_text.h"
+#include "printf.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -96,11 +96,11 @@ static int GetCrashInfo (char *buffer, char *end)
 void I_DetectOS()
 {
 #if !defined (__APPLE__)
-	auto unameInfo = new utsname;
-	int unameRes = uname(unameInfo);
+	utsname unameInfo;
+	int unameRes = uname(&unameInfo);
 	if (unameRes != -1)
 	{
-		Printf("OS: %s %s on %s\n", &unameInfo->sysname[0], &unameInfo->release[0],&unameInfo->machine[0]);
+		Printf("OS: %s %s on %s\n", unameInfo.sysname, unameInfo.release, unameInfo.machine);
 	}
 #endif
 }

--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -49,6 +49,7 @@
 #include "engineerrors.h"
 #include "i_system.h"
 #include "i_interface.h"
+#include "v_text.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -93,7 +94,14 @@ static int GetCrashInfo (char *buffer, char *end)
 
 void I_DetectOS()
 {
-	// The POSIX version never implemented this.
+#if !defined (__APPLE__)
+	auto unameInfo = new utsname;
+	int unameRes = uname(unameInfo);
+	if (unameRes != -1)
+	{
+		Printf("OS: %s %s on %s\n", &unameInfo->sysname[0], &unameInfo->release[0],&unameInfo->machine[0]);
+	}
+#endif
 }
 
 void I_StartupJoysticks();

--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -40,6 +40,7 @@
 #include <new>
 #include <sys/param.h>
 #include <locale.h>
+#include <sys/utsname.h>
 
 #include "engineerrors.h"
 #include "m_argv.h"

--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -95,14 +95,12 @@ static int GetCrashInfo (char *buffer, char *end)
 
 void I_DetectOS()
 {
-#if !defined (__APPLE__)
 	utsname unameInfo;
 	int unameRes = uname(&unameInfo);
 	if (unameRes != -1)
 	{
 		Printf("OS: %s %s on %s\n", unameInfo.sysname, unameInfo.release, unameInfo.machine);
 	}
-#endif
 }
 
 void I_StartupJoysticks();


### PR DESCRIPTION
This intentionally excludes macOS since the uname function returns wrong name.