### PR TITLE
- fix alpha (and other parameter properties) not reuploading the buffer on Shape2D

### DIFF
--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -565,6 +565,7 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 		if (!shape->uploadedOnce) {
 			shape->bufIndex = -1;
 			shape->buffers.Clear();
+			shape->lastCommand = -1;
 		}
 		delete shape->lastParms;
 		shape->lastParms = new DrawParms(parms);

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -562,7 +562,10 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	}
 	else if (shape->lastParms->vertexColorChange(parms)) {
 		shape->needsVertexUpload = true;
-		if (!shape->uploadedOnce) shape->bufIndex = -1;
+		if (!shape->uploadedOnce) {
+			shape->bufIndex = -1;
+			shape->buffers.Clear();
+		}
 		delete shape->lastParms;
 		shape->lastParms = new DrawParms(parms);
 	}

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -527,6 +527,10 @@ void F2DDrawer::AddTexture(FGameTexture* img, DrawParms& parms)
 	offset = osave;
 }
 
+DShape2D::~DShape2D() {
+	delete lastParms;
+}
+
 //==========================================================================
 //
 //
@@ -552,6 +556,16 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 
 	dg.mTranslationId = 0;
 	SetStyle(img, parms, vertexcolor, dg);
+
+	if (shape->lastParms == nullptr) {
+		shape->lastParms = new DrawParms(parms);
+	}
+	else if (shape->lastParms->vertexColorChange(parms)) {
+		shape->needsVertexUpload = true;
+		if (!shape->uploadedOnce) shape->bufIndex = -1;
+		delete shape->lastParms;
+		shape->lastParms = new DrawParms(parms);
+	}
 
 	if (!img->isHardwareCanvas() && parms.TranslationId != -1)
 		dg.mTranslationId = parms.TranslationId;
@@ -605,6 +619,7 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 		shape->bufIndex += 1;
 
 		shape->buffers.Reserve(1);
+
 		auto buf = &shape->buffers[shape->bufIndex];
 
 		auto verts = TArray<TwoDVertex>(dg.mVertCount, true);
@@ -625,9 +640,14 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 
 		buf->UploadData(&verts[0], dg.mVertCount, &shape->mIndices[0], shape->mIndices.Size());
 		shape->needsVertexUpload = false;
+		shape->uploadedOnce = true;
 	}
 	dg.shape2DBufIndex = shape->bufIndex;
-	AddCommand(&dg);
+	dg.shapeLastCmd = true;
+	if (shape->lastCommand != -1)
+		mData[shape->lastCommand].shapeLastCmd = false;
+	auto c = AddCommand(&dg);
+	shape->lastCommand = c;
 	offset = osave;
 }
 

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -58,6 +58,12 @@ public:
 	TArray<F2DVertexBuffer> buffers;
 	bool needsVertexUpload = true;
 	int bufIndex = -1;
+	int lastCommand = -1;
+
+	bool uploadedOnce = false;
+	DrawParms* lastParms;
+
+	~DShape2D();
 };
 
 struct F2DPolygons
@@ -150,6 +156,7 @@ public:
 		DShape2D* shape2D;
 		int shape2DBufIndex;
 		int shape2DIndexCount;
+		bool shapeLastCmd;
 
 		RenderCommand()
 		{

--- a/src/common/2d/v_draw.h
+++ b/src/common/2d/v_draw.h
@@ -206,6 +206,17 @@ struct DrawParms
 	double patchscalex, patchscaley;
 	double rotateangle;
 	IntRect viewport;
+
+	bool vertexColorChange(const DrawParms& other) {
+		return
+			this->Alpha         != other.Alpha         ||
+			this->fillcolor     != other.fillcolor     ||
+			this->colorOverlay  != other.colorOverlay  ||
+			this->color         != other.color         ||
+			this->style.Flags   != other.style.Flags   ||
+			this->style.BlendOp != other.style.BlendOp ||
+			this->desaturate    != other.desaturate;
+	}
 };
 
 struct Va_List

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -183,12 +183,14 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 			state.SetVertexBuffer(&cmd.shape2D->buffers[cmd.shape2DBufIndex]);
 			state.DrawIndexed(DT_Triangles, 0, cmd.shape2DIndexCount);
 			state.SetVertexBuffer(&vb);
-			if (cmd.shape2D->bufIndex > 0 && cmd.shape2DBufIndex == cmd.shape2D->bufIndex)
+			if (cmd.shape2D->bufIndex > 0 && cmd.shapeLastCmd)
 			{
 				cmd.shape2D->needsVertexUpload = true;
 				cmd.shape2D->buffers.Clear();
+				cmd.shape2D->lastCommand = -1;
 				cmd.shape2D->bufIndex = -1;
 			}
+			cmd.shape2D->uploadedOnce = false;
 		}
 		else
 		{


### PR DESCRIPTION
This fixes https://forum.zdoom.org/viewtopic.php?f=2&t=71159#p1178455 by tracking whether parameter properties that modify the vertexcolor (which is put into the vertex buffer) have changed, needing a vertex buffer reupload. It also fixes a bug where if a shape was drawn, modified, then drawn without modification more than once the engine would crash due to it clearing an array before it was done with it.