### PR TITLE
Fix ScriptCall missing default arguments

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -5261,7 +5261,7 @@ int DLevelScript::SwapActorTeleFog(AActor *activator, int tid)
 			if (rettype == TypeSInt32 || rettype == TypeBool || rettype == TypeColor || rettype == TypeName || rettype == TypeSound)
 			{
 				VMReturn ret(&retval);
-				VMCall(func, &params[0], params.Size(), &ret, 1);
+				VMCallWithDefaults(func, params, &ret, 1);
 				if (rettype == TypeName)
 				{
 					retval = GlobalACSStrings.AddString(FName(ENamedName(retval)).GetChars());


### PR DESCRIPTION
There was one VMCall in DLevelScript::ScriptCall that didn't use default arguments. This was causing assertion failures in the GZDoom debug build when trying to run Wolfenstein: Blade of Agony (commit [08ef2b42eef8abdea737c6b9bb0d490206a592c8](https://github.com/Realm667/WolfenDoom/commit/08ef2b42eef8abdea737c6b9bb0d490206a592c8)) on any map that wasn't TITLEMAP, because [ACSTools.FindInventoryClass](https://github.com/Realm667/WolfenDoom/blob/master/scripts/libraries/acstools.txt#L166) returns a boolean, and it has a default argument.