### PR TITLE
Add a way for PowerIronFeet to prevent leaky damage

### DIFF
--- a/src/common/engine/namedef.h
+++ b/src/common/engine/namedef.h
@@ -27,6 +27,10 @@ xx(Spray)
 xx(Ghost)
 xx(Reflective)
 
+// Iron Feet types
+//xx(Normal)	// defined below
+xx(Full)
+
 // Invisibility types
 xx(Additive)
 xx(Cumulative)

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -428,7 +428,6 @@ void P_PlayerInSpecialSector (player_t *player, sector_t * sector)
 	}
 
 	// Has hit ground.
-	AActor *ironfeet;
 
 	auto Level = sector->Level;
 
@@ -442,14 +441,22 @@ void P_PlayerInSpecialSector (player_t *player, sector_t * sector)
 		// Allow subclasses. Better would be to implement it as armor and let that reduce
 		// the damage as part of the normal damage procedure. Unfortunately, I don't have
 		// different damage types yet, so that's not happening for now.
-		for (ironfeet = player->mo->Inventory; ironfeet != NULL; ironfeet = ironfeet->Inventory)
+		// [MK] account for subclasses that may have "Full" protection (i.e.: prevent leaky damage)
+		int ironfeet = 0;
+		for (auto i = player->mo->Inventory; i != NULL; i = i->Inventory)
 		{
-			if (ironfeet->IsKindOf(NAME_PowerIronFeet))
-				break;
+			if (i->IsKindOf(NAME_PowerIronFeet))
+			{
+				FName mode = i->NameVar(NAME_Mode);
+				if ( ironfeet < 2 && mode == NAME_Full )
+					ironfeet = 2;
+				else if ( ironfeet < 1 && mode == NAME_Normal )
+					ironfeet = 1;
+			}
 		}
 
 		if (sector->Flags & SECF_ENDGODMODE) player->cheats &= ~CF_GODMODE;
-		if ((ironfeet == NULL || pr_playerinspecialsector() < sector->leakydamage))
+		if ((ironfeet == 0 || (ironfeet < 2 && pr_playerinspecialsector() < sector->leakydamage)))
 		{
 			if (sector->Flags & SECF_HAZARD)
 			{

--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -763,6 +763,7 @@ class PowerIronFeet : Powerup
 	{
 		Powerup.Duration -60;
 		Powerup.Color "00 ff 00", 0.125;
+		Powerup.Mode "Normal";
 	}
 	
 	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)


### PR DESCRIPTION
The modes are "Normal" (the default) and "Full" (no leaks). In the case where there are separate subclasses of the powerup in the inventory, the highest mode detected takes priority.

I made sure to test that it works, of course. No other issues have popped up from this change.