### PR TITLE
Fixed incorrect extension of overridden function prototype

### DIFF
--- a/src/common/objects/dobjtype.cpp
+++ b/src/common/objects/dobjtype.cpp
@@ -706,6 +706,9 @@ int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction 
 						if (!(parentfunc->Variants[0].ArgFlags[a] & VARF_Optional)) return -1;
 					}
 
+
+					proto = variant->Proto = NewPrototype(proto->ReturnTypes, proto->ArgumentTypes);
+
 					// Todo: extend the prototype
 					for (unsigned a = proto->ArgumentTypes.Size(); a < vproto->ArgumentTypes.Size(); a++)
 					{


### PR DESCRIPTION
Prototype of overridden function with optional argument(s) missing could extend unrelated prototype of previously defined function when their arguments and return value(s) match

https://forum.zdoom.org/viewtopic.php?t=71340