### PR TITLE
Fixed incorrect extension of overridden function prototype

### DIFF
--- a/src/common/objects/dobjtype.cpp
+++ b/src/common/objects/dobjtype.cpp
@@ -706,13 +706,17 @@ int PClass::FindVirtualIndex(FName name, PFunction::Variant *variant, PFunction 
 						if (!(parentfunc->Variants[0].ArgFlags[a] & VARF_Optional)) return -1;
 					}
 
-					// Todo: extend the prototype
+					// Extend the prototype
+					TArray<PType*> argumentTypes = proto->ArgumentTypes;
+
 					for (unsigned a = proto->ArgumentTypes.Size(); a < vproto->ArgumentTypes.Size(); a++)
 					{
-						proto->ArgumentTypes.Push(vproto->ArgumentTypes[a]);
+						argumentTypes.Push(vproto->ArgumentTypes[a]);
 						variant->ArgFlags.Push(parentfunc->Variants[0].ArgFlags[a]);
 						variant->ArgNames.Push(NAME_None);
 					}
+
+					variant->Proto = NewPrototype(proto->ReturnTypes, argumentTypes);
 				}
 				return i;
 			}

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -2486,6 +2486,8 @@ void ZCCCompiler::CompileFunction(ZCC_StructWork *c, ZCC_FuncDeclarator *f, bool
 							{
 								newfunc->ArgFlags.Push(sym->Variants[0].ArgFlags[i]);
 							}
+
+							newfunc->Proto = sym->Variants[0].Proto;
 						}
 					}
 				}


### PR DESCRIPTION
Prototype of overridden function with optional argument(s) missing could extend unrelated prototype of previously defined function when their arguments and return value(s) match

https://forum.zdoom.org/viewtopic.php?t=71340