### PR TITLE
HUD model tweaks

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -183,7 +183,7 @@ void RenderModel(FModelRenderer *renderer, float x, float y, float z, FSpriteMod
 void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, float ofsX, float ofsY)
 {
 	AActor * playermo = players[consoleplayer].camera;
-	FSpriteModelFrame *smf = FindModelFrame(playermo->player->ReadyWeapon->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
+	FSpriteModelFrame *smf = FindModelFrame(psp->Caller->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
 
 	// [BB] No model found for this sprite, so we can't render anything.
 	if (smf == nullptr)
@@ -216,7 +216,7 @@ void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, float ofsX, float o
 	renderer->BeginDrawHUDModel(playermo->RenderStyle, objectToWorldMatrix, orientation < 0);
 	uint32_t trans = psp->GetTranslation() != 0 ? psp->GetTranslation() : 0;
 	if ((psp->Flags & PSPF_PLAYERTRANSLATED)) trans = psp->Owner->mo->Translation;
-	RenderFrameModels(renderer, playermo->Level, smf, psp->GetState(), psp->GetTics(), playermo->player->ReadyWeapon->GetClass(), trans);
+	RenderFrameModels(renderer, playermo->Level, smf, psp->GetState(), psp->GetTics(), psp->Caller->GetClass(), trans);
 	renderer->EndDrawHUDModel(playermo->RenderStyle);
 }
 
@@ -738,12 +738,17 @@ bool IsHUDModelForPlayerAvailable (player_t * player)
 	if (player == nullptr || player->ReadyWeapon == nullptr)
 		return false;
 
-	DPSprite *psp = player->FindPSprite(PSP_WEAPON);
+	// [MK] allow the Strife burning hands to be a model...
+	DPSprite *psp = player->FindPSprite(PSP_STRIFEHANDS);
+
+	// [MK] ...otherwise, check for the weapon psprite as per usual
+	if (psp == nullptr)
+		psp = player->FindPSprite(PSP_WEAPON);
 
 	if (psp == nullptr)
 		return false;
 
-	FSpriteModelFrame *smf = FindModelFrame(player->ReadyWeapon->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
+	FSpriteModelFrame *smf = FindModelFrame(psp->Caller->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
 	return ( smf != nullptr );
 }
 

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -735,20 +735,14 @@ FSpriteModelFrame * FindModelFrame(const PClass * ti, int sprite, int frame, boo
 
 bool IsHUDModelForPlayerAvailable (player_t * player)
 {
-	if (player == nullptr || player->ReadyWeapon == nullptr)
+	if (player == nullptr || player->psprites == nullptr)
 		return false;
 
-	// [MK] allow the Strife burning hands to be a model...
-	DPSprite *psp = player->FindPSprite(PSP_STRIFEHANDS);
-
-	// [MK] ...otherwise, check for the weapon psprite as per usual
-	if (psp == nullptr)
-		psp = player->FindPSprite(PSP_WEAPON);
-
-	if (psp == nullptr)
-		return false;
-
-	FSpriteModelFrame *smf = FindModelFrame(psp->Caller->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
-	return ( smf != nullptr );
+	// [MK] check that at least one psprite uses models
+	for (DPSprite *psp = player->psprites; psp != nullptr && psp->GetID() < PSP_TARGETCENTER; psp = psp->GetNext())
+	{
+		FSpriteModelFrame *smf = FindModelFrame(psp->Caller->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
+		if ( smf != nullptr ) return true;
+	}
+	return false;
 }
-

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -614,7 +614,7 @@ void HWDrawInfo::PreparePlayerSprites(sector_t * viewsector, area_t in_area)
 	for (DPSprite *psp = player->psprites; psp != nullptr && psp->GetID() < PSP_TARGETCENTER; psp = psp->GetNext())
 	{
 		if (!psp->GetState()) continue;
-		FSpriteModelFrame *smf = playermo->player->ReadyWeapon ? FindModelFrame(playermo->player->ReadyWeapon->GetClass(), psp->GetSprite(), psp->GetFrame(), false) : nullptr;
+		FSpriteModelFrame *smf = FindModelFrame(psp->Caller->GetClass(), psp->GetSprite(), psp->GetFrame(), false);
 		// This is an 'either-or' proposition. This maybe needs some work to allow overlays with weapon models but as originally implemented this just won't work.
 		if (smf && !hudModelStep) continue;
 		if (!smf && hudModelStep) continue;


### PR DESCRIPTION
What this does:
 - Look up HUD models by referencing the psprite's caller, rather than player's ReadyWeapon (this allows other owned inventory to use models without having to define their frames in every single weapon's MODELDEF).
 - Additionally allow Strife hands psprite to be a model (IsHUDModelForPlayerAvailable will check the PSP_STRIFEHANDS psprite first if it exists).

The only shortcoming from this at least is that if there's neither a PSP_STRIFEHANDS or PSP_WEAPON psprite active, models still won't be used. I'd have to look into that later, but I decided to submit this as-is because I couldn't get an example wad done in time and the branch is starting to grow stale.