### PR TITLE
Fix "Player left the game" strings not printing

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1790,7 +1790,7 @@ void G_DoPlayerPop(int playernum)
 {
 	playeringame[playernum] = false;
 
-	FString message = GStrings(deathmatch? "TXT_LEFTWITHFRAGS" : "TXT_LEFTTHEGAME");
+	FString message = GStrings(deathmatch ? "TXT_LEFTWITHFRAGS" : "TXT_LEFTTHEGAME");
 	message.Substitute("%s", players[playernum].userinfo.GetName());
 	message.Substitute("%d", FStringf("%d", players[playernum].fragcount));
 


### PR DESCRIPTION
I haven't been seeing the "X left the game" strings printed in netgames, I think this should fix it