### PR TITLE
Fix typo with name in copyright

### DIFF
--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -4,7 +4,7 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2009 Randy Heit
-** Copyright 2009 CHristoph Oelckers
+** Copyright 2009 Christoph Oelckers
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The first 'h' in Christopher is capitalized when it shouldn't be