### PR TITLE
Fix player not being able to talk to a Strife NPC during netplay, if …

### DIFF
--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -153,6 +153,22 @@ int FLevelLocals::FindNode (const FStrifeDialogueNode *node)
 
 //============================================================================
 //
+// ClearConversationStuff
+//
+// Clear the conversation pointers on the player
+//
+//============================================================================
+
+static void ClearConversationStuff(player_t* player)
+{
+	player->ConversationFaceTalker = false;
+	player->ConversationNPC = nullptr;
+	player->ConversationPC = nullptr;
+	player->ConversationNPCAngle = 0.;
+}
+
+//============================================================================
+//
 // CheckStrifeItem
 //
 // Checks if you have an item. A NULL itemtype is always considered to be
@@ -471,6 +487,7 @@ static void HandleReply(player_t *player, bool isconsole, int nodenum, int reply
 		if (!(npc->flags8 & MF8_DONTFACETALKER))
 			npc->Angles.Yaw = player->ConversationNPCAngle;
 		npc->flags5 &= ~MF5_INCONVERSATION;
+		if (gameaction != ga_slideshow) ClearConversationStuff(player);
 		return;
 	}
 
@@ -488,6 +505,7 @@ static void HandleReply(player_t *player, bool isconsole, int nodenum, int reply
 			if (!(npc->flags8 & MF8_DONTFACETALKER))
 				npc->Angles.Yaw = player->ConversationNPCAngle;
 			npc->flags5 &= ~MF5_INCONVERSATION;
+			if (gameaction != ga_slideshow) ClearConversationStuff(player);
 			return;
 		}
 	}
@@ -626,10 +644,7 @@ static void HandleReply(player_t *player, bool isconsole, int nodenum, int reply
 	if (gameaction != ga_slideshow)
 	{
 		npc->flags5 &= ~MF5_INCONVERSATION;
-		player->ConversationFaceTalker = false;
-		player->ConversationNPC = nullptr;
-		player->ConversationPC = nullptr;
-		player->ConversationNPCAngle = 0.;
+		ClearConversationStuff(player);
 	}
 
 	if (isconsole)
@@ -673,10 +688,7 @@ void P_ConversationCommand (int netcode, int pnum, uint8_t **stream)
 		}
 		if (netcode == DEM_CONVNULL)
 		{
-			player->ConversationFaceTalker = false;
-			player->ConversationNPC = nullptr;
-			player->ConversationPC = nullptr;
-			player->ConversationNPCAngle = 0.;
+			ClearConversationStuff(player);
 		}
 	}
 }


### PR DESCRIPTION
…another player talked to that NPC first.

The ConversationNPC and ConversationPC fields were not cleared if the conversation was closed by selecting the goodbye option, or if the conversation was closed from the item checks.

https://forum.zdoom.org/viewtopic.php?f=2&t=53655