### PR TITLE
Made Strife NPC's dialog voice audible for all players.

### DIFF
--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -392,13 +392,15 @@ void P_StartConversation (AActor *npc, AActor *pc, bool facetalker, bool saveang
 		}
 	}
 
+	// [Nash] Play voice clip from the actor so that positional audio can be heard by all players
+	if (CurNode->SpeakerVoice != 0) S_Sound(npc, CHAN_VOICE, CHANF_NOPAUSE, CurNode->SpeakerVoice, 1, ATTN_NORM);
+
 	// The rest is only done when the conversation is actually displayed.
 	if (pc->player == Level->GetConsolePlayer())
 	{
 		if (CurNode->SpeakerVoice != 0)
 		{
 			I_SetMusicVolume (dlg_musicvolume);
-			S_Sound (npc, CHAN_VOICE, CHANF_NOPAUSE, CurNode->SpeakerVoice, 1, ATTN_NORM);
 		}
 		M_StartControlPanel(false, true);
 


### PR DESCRIPTION
After an actual online coop session playtest (with my work-in-progress Strife Coop Patch Project which aims to make the entire campaign coop-friendly; more on that on the forum)... we found that it's quite an awkward experience that only the player who's talking to an NPC can hear the voice. This removes the ConsolePlayer restriction and makes the voice audible for every player.