### PR TITLE
Use misc2 param for MBF's A_Spawn dehacked codepointer as spawnheight, not distance

### DIFF
--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -640,8 +640,8 @@ static void CreateSpawnFunc(FunctionCallEmitter &emitters, int value1, int value
 		I_Error("No class found for dehackednum %d!\n", value1+1);
 	}
 	emitters.AddParameterPointerConst(InfoNames[value1-1]);	// itemtype
-	emitters.AddParameterFloatConst(value2);				// distance
-	emitters.AddParameterFloatConst(0);						// height
+	emitters.AddParameterFloatConst(0);						// distance
+	emitters.AddParameterFloatConst(value2);				// height
 	emitters.AddParameterIntConst(0);						// useammo
 	emitters.AddParameterIntConst(0);						// transfer_translation
 }


### PR DESCRIPTION
Another quick DEH fixup -- MBF's A_Spawn codepointer uses misc2 as Z height, rather than XY distance ( see [here](https://soulsphere.org/projects/boomref/mbfedit.html#A_Spawn) for reference ). Noticed the inconsistency in a WIP project of mine and this patch makes it match PRBoom, Eternity, etc.