### PR TITLE
Don't make the switch that reveals the computer core in Strife MAP15 …

### DIFF
--- a/wadsrc/static/xlat/strife.txt
+++ b/wadsrc/static/xlat/strife.txt
@@ -321,7 +321,7 @@ RetailOnly		= 121
 207 = USE|REP,		Door_Animated (tag, 4, 3*35)
 214 = USE|REP,		Plat_DownWaitUpStayLip (tag, 8, 1050, 0, 1)
 229 = USE|REP,		ACS_ExecuteWithResult (0, 229, tag)
-233 = USE|REP,		ACS_ExecuteWithResult (0, 233, tag)
+233 = USE,			ACS_ExecuteWithResult (0, 233, tag)
 234 = USE|REP,		ACS_ExecuteWithResult (0, 234, tag)
 
 sector bitmask 0xf000 clear;


### PR DESCRIPTION
…to be repeatable.

In Strife, MAP15, at coords (6722, 98) there is a switch you can press to reveal the computer core (and additionally play a Blackbird voice clip if you have the Communicator item, which you should have, if the game is played without cheating anyway).

For some reason XLAT, this line is made repeatable, which means players can repeatedly flip the switch, which will cause

A) Blackbird's voice clip to play repeatedly
B) Keep lowering a texture-less ceiling geometry which will eventually block the player from being able to shoot the computer core (in addition to looking glitchy because the linedefs have no textures assigned)