### PR TITLE
Fix some crashes in the Shape2D VBO code due to unsound pointer usage

### DIFF
--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -565,7 +565,7 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 		if (!shape->uploadedOnce) {
 			shape->bufIndex = -1;
 			shape->buffers.Clear();
-			shape->lastCommand = nullptr;
+			shape->lastCommand = -1;
 		}
 		delete shape->lastParms;
 		shape->lastParms = new DrawParms(parms);
@@ -647,12 +647,9 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 		shape->uploadedOnce = true;
 	}
 	dg.shape2DBufIndex = shape->bufIndex;
-	dg.shapeLastCmd = true;
-	if (shape->lastCommand != nullptr) {
-		shape->lastCommand->shapeLastCmd = false;
-	}
-	auto c = AddCommand(&dg);
-	shape->lastCommand = &mData[c];
+	shape->lastCommand += 1;
+	dg.shape2DCommandCounter = shape->lastCommand;
+	AddCommand(&dg);
 	offset = osave;
 }
 

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -125,7 +125,7 @@ public:
 		DShape2D* shape2D;
 		int shape2DBufIndex;
 		int shape2DIndexCount;
-		bool shapeLastCmd;
+		int shape2DCommandCounter;
 
 		RenderCommand()
 		{
@@ -262,7 +262,7 @@ public:
 	TArray<F2DVertexBuffer> buffers;
 	bool needsVertexUpload = true;
 	int bufIndex = -1;
-	F2DDrawer::RenderCommand* lastCommand = nullptr;
+	int lastCommand = -1;
 
 	bool uploadedOnce = false;
 	DrawParms* lastParms;

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -183,12 +183,15 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 			state.SetVertexBuffer(&cmd.shape2D->buffers[cmd.shape2DBufIndex]);
 			state.DrawIndexed(DT_Triangles, 0, cmd.shape2DIndexCount);
 			state.SetVertexBuffer(&vb);
-			if (cmd.shape2D->bufIndex > 0 && cmd.shapeLastCmd)
+			if (cmd.shape2DCommandCounter == cmd.shape2D->lastCommand)
 			{
-				cmd.shape2D->needsVertexUpload = true;
-				cmd.shape2D->buffers.Clear();
-				cmd.shape2D->lastCommand = nullptr;
-				cmd.shape2D->bufIndex = -1;
+				cmd.shape2D->lastCommand = -1;
+				if (cmd.shape2D->bufIndex > 0)
+				{
+					cmd.shape2D->needsVertexUpload = true;
+					cmd.shape2D->buffers.Clear();
+					cmd.shape2D->bufIndex = -1;
+				}
 			}
 			cmd.shape2D->uploadedOnce = false;
 		}


### PR DESCRIPTION
To track which Shape2D draw was the last one, I was previously keeping a boolean on each command which indicated whether it was the last, and setting that to false via a pointer to that element. I kinda forgot here that you shouldn't take long-lived pointers to elements inside a dynamic array, as they will move around in memory as element count grows. So this replaces it with a much simpler counter based system that should have been used in the first place.