### PR TITLE
fix rendering of one-sided line portals in the hardware renderer

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -801,19 +801,19 @@ inline FLevelLocals *line_t::GetLevel() const
 }
 inline FLinePortal *line_t::getPortal() const
 {
-	return portalindex >= GetLevel()->linePortals.Size() ? (FLinePortal*)nullptr : &GetLevel()->linePortals[portalindex];
+	return portalindex == UINT_MAX && portalindex >= GetLevel()->linePortals.Size() ? (FLinePortal*)nullptr : &GetLevel()->linePortals[portalindex];
 }
 
 // returns true if the portal is crossable by actors
 inline bool line_t::isLinePortal() const
 {
-	return portalindex >= GetLevel()->linePortals.Size() ? false : !!(GetLevel()->linePortals[portalindex].mFlags & PORTF_PASSABLE);
+	return portalindex == UINT_MAX && portalindex >= GetLevel()->linePortals.Size() ? false : !!(GetLevel()->linePortals[portalindex].mFlags & PORTF_PASSABLE);
 }
 
 // returns true if the portal needs to be handled by the renderer
 inline bool line_t::isVisualPortal() const
 {
-	return portalindex >= GetLevel()->linePortals.Size() ? false : !!(GetLevel()->linePortals[portalindex].mFlags & PORTF_VISIBLE);
+	return portalindex == UINT_MAX && portalindex >= GetLevel()->linePortals.Size() ? false : !!(GetLevel()->linePortals[portalindex].mFlags & PORTF_VISIBLE);
 }
 
 inline line_t *line_t::getPortalDestination() const

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -142,15 +142,21 @@ void HWDrawInfo::WorkerThread()
 
 			front = hw_FakeFlat(job->sub->sector, in_area, false);
 			auto seg = job->seg;
-			if (seg->backsector)
+			auto backsector = seg->backsector;
+			if (!backsector && seg->linedef->isVisualPortal() && seg->sidedef == seg->linedef->sidedef[0]) // For one-sided portals use the portal's destination sector as backsector.
 			{
-				if (front->sectornum == seg->backsector->sectornum || (seg->sidedef->Flags & WALLF_POLYOBJ))
+				auto portal = seg->linedef->getPortal();
+				backsector = portal->mDestination->frontsector;
+			}
+			if (backsector)
+			{
+				if (front->sectornum == backsector->sectornum || ((seg->sidedef->Flags & WALLF_POLYOBJ) && !seg->linedef->isVisualPortal()))
 				{
 					back = front;
 				}
 				else
 				{
-					back = hw_FakeFlat(seg->backsector, in_area, true);
+					back = hw_FakeFlat(backsector, in_area, true);
 				}
 			}
 			else back = nullptr;


### PR DESCRIPTION
Testing yesterday's implementation of the Line_QuickPortal type revealed an inconsistency with Eternity - in Eternity the upper and lower textures of a one-sided portal line will be rendered if the portal's destination sector doesn't have matching floor and ceiling heights.

This PR adds the same functionality to GZDoom's hardware renderer. I tried doing it for the software renderer as well but wasn't really able to make sense of its portal code and find the proper place to add this change.

There is one caveat where I am not sure what was intended. The middle texture of a portal line was rendered, but in all cases I checked it did not work properly, it always creates z-fighting and visual corruption, so I disabled this case unconditionally, not just for one-sided lines where it is required to do so.

I also added a small optimization to the portal checker inlines in line_t. They always read the size from the LinePortals array, even if the passed index was UINT_MAX, meaning no portal being present. This most common case is now being checked directly, avoiding the memory access to read the size.