### PR TITLE
Line_QuickPortal must check the partner line's special.

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -151,7 +151,7 @@ struct FLevelLocals
 
 private:
 	bool ShouldDoIntermission(cluster_info_t* nextcluster, cluster_info_t* thiscluster);
-	line_t *FindPortalDestination(line_t *src, int tag);
+	line_t *FindPortalDestination(line_t *src, int tag, int matchtype = -1);
 	void BuildPortalBlockmap();
 	void UpdatePortal(FLinePortal *port);
 	void CollectLinkedPortals();

--- a/src/maploader/specials.cpp
+++ b/src/maploader/specials.cpp
@@ -124,7 +124,7 @@ void MapLoader::SpawnLinePortal(line_t* line)
 	{
 		int type = (line->special != Line_QuickPortal) ? line->args[2] : line->args[0] == 0 ? PORTT_LINKED : PORTT_VISUAL;
 		int tag = (line->special == Line_QuickPortal) ? Level->tagManager.GetFirstLineID(line) : line->args[0];
-		dst = Level->FindPortalDestination(line, tag);
+		dst = Level->FindPortalDestination(line, tag, line->special == Line_QuickPortal? Line_QuickPortal : -1);
 
 		line->portalindex = Level->linePortals.Reserve(1);
 		FLinePortal *port = &Level->linePortals.Last();

--- a/src/playsim/portal.cpp
+++ b/src/playsim/portal.cpp
@@ -175,7 +175,7 @@ void FLinePortalTraverse::AddLineIntercepts(int bx, int by)
 //
 //============================================================================
 
-line_t *FLevelLocals::FindPortalDestination(line_t *src, int tag)
+line_t *FLevelLocals::FindPortalDestination(line_t *src, int tag, int matchtype)
 {
 	if (tag)
 	{
@@ -184,7 +184,7 @@ line_t *FLevelLocals::FindPortalDestination(line_t *src, int tag)
 
 		while ((lineno = it.Next()) >= 0)
 		{
-			if (&lines[lineno] != src)
+			if (&lines[lineno] != src && (matchtype == -1 || matchtype == lines[lineno].special))
 			{
 				return &lines[lineno];
 			}


### PR DESCRIPTION
Apologies for not reading the specification correctly. Portals of this type should only be paired with linedefs having the same special, not merely the same line ID.
