### PR TITLE
Add SetSubtitleNumber(int num, str sound) ACS function.

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -4779,6 +4779,7 @@ enum EACSFunctions
 	ACSF_StartSlideshow,
 	ACSF_GetSectorHealth,
 	ACSF_GetLineHealth,
+	ACSF_SetSubtitleNumber,
 
 		// Eternity's
 	ACSF_GetLineX = 300,
@@ -6697,6 +6698,27 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 			}
 			return DoubleToACS(result);
 		}
+
+		case ACSF_SetSubtitleNumber:
+			if (argCount >= 2)
+			{
+				// only players allowed as activator
+				if (activator != nullptr && activator->player != nullptr)
+				{
+					int logNum = args[0];
+					FSoundID sid = 0;
+
+					const char* lookup = Level->Behaviors.LookupString(args[1]);
+					if (lookup != nullptr)
+					{
+						sid = lookup;
+					}
+
+					activator->player->SetSubtitle(logNum, sid);
+				}
+			}
+			break;
+
 		default:
 			break;
 	}


### PR DESCRIPTION
Works exactly like its ZScript counterpart. The activator of the script must be a player.

This is a follow-up to my previous attempt: https://github.com/coelckers/gzdoom/pull/1317

This only deals with the new ACS function. The actual fix to the Strife game script will be sent as a separate PR.