### PR TITLE
Fix behaviour of VelIntercept's oldvel parameter

### DIFF
--- a/src/playsim/p_things.cpp
+++ b/src/playsim/p_things.cpp
@@ -171,7 +171,7 @@ void InterceptDefaultAim(AActor *mobj, AActor *targ, DVector3 aim, double speed)
 
 // [MC] Was part of P_Thing_Projectile, now its own function for use in ZScript.
 // Aims mobj at targ based on speed and targ's velocity.
-static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch = false, bool oldvel = false, bool leadtarget = true)
+static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch = false, bool oldvel = false, bool resetvel = false, bool leadtarget = true)
 {
 	if (targ == nullptr || mobj == nullptr)	return;
 
@@ -199,7 +199,7 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 			if (targ->Vel.X == 0 && targ->Vel.Y == 0)
 			{
 				InterceptDefaultAim(mobj, targ, aim, speed);
-				if (oldvel)
+				if (resetvel)
 				{
 					mobj->Vel = prevel;
 				}
@@ -225,6 +225,10 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 		// And make the projectile follow that vector at the desired speed.
 		mobj->Vel = aimvec * (speed / dist);
 		mobj->AngleFromVel();
+		if (oldvel)
+		{
+			mobj->Vel = prevel;
+		}
 		if (aimpitch) // [MC] Ripped right out of A_FaceMovementDirection
 		{
 			const DVector2 velocity = mobj->Vel.XY();
@@ -235,7 +239,7 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 	{
 		InterceptDefaultAim(mobj, targ, aim, speed);
 	}
-	if (oldvel)
+	if (resetvel)
 	{
 		mobj->Vel = prevel;
 	}
@@ -248,8 +252,9 @@ DEFINE_ACTION_FUNCTION(AActor, VelIntercept)
 	PARAM_FLOAT(speed);
 	PARAM_BOOL(aimpitch);
 	PARAM_BOOL(oldvel);
+	PARAM_BOOL(resetvel);
 	if (speed < 0)	speed = self->Speed;
-	VelIntercept(targ, self, speed, aimpitch, oldvel);
+	VelIntercept(targ, self, speed, aimpitch, oldvel, resetvel);
 	return 0;
 }
 
@@ -335,7 +340,7 @@ bool FLevelLocals::EV_Thing_Projectile (int tid, AActor *source, int type, const
 
 					if (targ != nullptr)
 					{
-						VelIntercept(targ, mobj, speed, false, false, leadTarget);
+						VelIntercept(targ, mobj, speed, false, false, false, leadTarget);
 
 						if (mobj->flags2 & MF2_SEEKERMISSILE)
 						{

--- a/src/playsim/p_things.cpp
+++ b/src/playsim/p_things.cpp
@@ -175,6 +175,7 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 {
 	if (targ == nullptr || mobj == nullptr)	return;
 
+	DVector3 prevel = mobj->Vel;
 	DVector3 aim = mobj->Vec3To(targ);
 	aim.Z += targ->Height / 2;
 
@@ -198,6 +199,10 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 			if (targ->Vel.X == 0 && targ->Vel.Y == 0)
 			{
 				InterceptDefaultAim(mobj, targ, aim, speed);
+				if (oldvel)
+				{
+					mobj->Vel = prevel;
+				}
 				return;
 			}
 		}
@@ -207,7 +212,6 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 		double a = g_acos(clamp(ydotx / targspeed / dist, -1.0, 1.0));
 		double multiplier = double(pr_leadtarget.Random2())*0.1 / 255 + 1.1;
 		double sinb = -clamp(targspeed*multiplier * g_sin(a) / speed, -1.0, 1.0);
-		DVector3 prevel = mobj->Vel;
 		// Use the cross product of two of the triangle's sides to get a
 		// rotation vector.
 		DVector3 rv(tvel ^ aim);
@@ -221,10 +225,6 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 		// And make the projectile follow that vector at the desired speed.
 		mobj->Vel = aimvec * (speed / dist);
 		mobj->AngleFromVel();
-		if (oldvel)
-		{
-			mobj->Vel = prevel;
-		}
 		if (aimpitch) // [MC] Ripped right out of A_FaceMovementDirection
 		{
 			const DVector2 velocity = mobj->Vel.XY();
@@ -234,6 +234,10 @@ static void VelIntercept(AActor *targ, AActor *mobj, double speed, bool aimpitch
 	else
 	{
 		InterceptDefaultAim(mobj, targ, aim, speed);
+	}
+	if (oldvel)
+	{
+		mobj->Vel = prevel;
 	}
 }
 

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -751,7 +751,7 @@ class Actor : Thinker native
 	native clearscope vector2 Vec2Angle(double length, double angle, bool absolute = false) const;
 	native clearscope vector2 Vec2Offset(double x, double y, bool absolute = false) const;
 	native clearscope vector3 Vec2OffsetZ(double x, double y, double atz, bool absolute = false) const;
-	native void VelIntercept(Actor targ, double speed = -1, bool aimpitch = true, bool oldvel = false);
+	native void VelIntercept(Actor targ, double speed = -1, bool aimpitch = true, bool oldvel = false, bool resetvel = false);
 	native void VelFromAngle(double speed = 1e37, double angle = 1e37);
 	native void Vel3DFromAngle(double speed, double angle, double pitch);
 	native void Thrust(double speed = 1e37, double angle = 1e37);


### PR DESCRIPTION
Previously Vel would be reset only if the target was moving. This change ensures that Vel is always reset, as seems to be the intent of the oldvel parameter.

Here's a simplified zscript example showing the problematic behaviour this is intended to address:

```
class LeadingImp : DoomImp replaces DoomImp
{
        States
        {
                Melee:
                Missile:
                        TROO EF 4 Fast A_FaceTarget;
                        TROO G 3 Fast A_LeadTroopAttack;
                        Goto See;
        }
        void A_LeadTroopAttack()
        {
        if (target)
                {
                        VelIntercept(target, 10, true, true);
                        A_SpawnProjectile("DoomImpBall", 32, 0, angle, CMF_ABSOLUTEANGLE|CMF_ABSOLUTEPITCH, pitch);
                }
        }
}
```

I expect in this case that the monster keeps its old velocity when firing projectiles, but by standing still during this action you can observe them lunge forward instead.