### PR TITLE
Fix camera texture aspect ratio in hardware renderer

### DIFF
--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -343,7 +343,7 @@ sector_t* RenderView(player_t* player)
 					screen->RenderTextureView(camtex, [=](IntRect& bounds)
 						{
 							FRenderViewpoint texvp;
-							float ratio = camtex->aspectRatio;
+							float ratio = camtex->aspectRatio / Level->info->pixelstretch;
 							RenderViewpoint(texvp, camera, &bounds, fov, ratio, ratio, false, false);
 						});
 				});


### PR DESCRIPTION
It wasn't respecting the map's pixel ratio setting. This wouldn't have been very noticeable with the default pixel ratio of 1.2 but it was very obvious with 1.8.

I suspect this isn't great for performance. You may want to do it in a more optimal way.