### PR TITLE
Account for KEEPDEPLETED flag when destroying items with InterHubAmount of 0 upon leaving a level

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2023,7 +2023,7 @@ class PlayerPawn : Actor
 				next = item.Inv;
 				if (item.InterHubAmount < 1)
 				{
-					item.Destroy ();
+					item.DepleteOrDestroy ();
 				}
 				item = next;
 			}


### PR DESCRIPTION
I have a couple of items in my mod that I want for them to maintain their presence in the inventory even if the player has 0 samples of them. I also want the player to lose all of the samples of these items upon traveling to a map that doesn't belong to the same hub as this one.

I managed to do that by setting the INVENTORY.KEEPDEPLETED flag on the items and giving them an InterHubAmount of 0. The problem is, GZDoom outright removes the items from the inventory regardless of whether they have the KEEPDEPLETED flag or not. So I made this PR to rectify that.