### PR TITLE
Don't let the game start if the saved game passed to -loadgame is inv…

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3158,6 +3158,19 @@ static int D_DoomMain_Internal (void)
 	// Now that we have the IWADINFO, initialize the autoload ini sections.
 	GameConfig->DoAutoloadSetup(iwad_man);
 
+	// Prevent the game from starting if the savegame passed to -loadgame is invalid
+	v = Args->CheckValue("-loadgame");
+	if (v)
+	{
+		FString file(v);
+		FixPathSeperator(file);
+		DefaultExtension(file, "." SAVEGAME_EXT);
+		if (!FileExists(file))
+		{
+			I_FatalError("Cannot find savegame %s", file.GetChars());
+		}
+	}
+
 	// reinit from here
 
 	do


### PR DESCRIPTION
…alid. Often times, especially during a multiplayer game, a player can accidentally pass an invalid save file to load at the command line, which results in the netgame starting anyway before immediately desyncing. This aims to address that.