### PR TITLE
Fix i_timescale callback recursing into itself when changed in a netgame

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -200,7 +200,7 @@ const char* iwad_folders[13] = { "flats/", "textures/", "hires/", "sprites/", "v
 const char* iwad_reserved[12] = { "mapinfo", "zmapinfo", "gameinfo", "sndinfo", "sbarinfo", "menudef", "gldefs", "animdefs", "decorate", "zscript", "iwadinfo", "maps/" };
 
 
-CUSTOM_CVAR(Float, i_timescale, 1.0f, CVAR_NOINITCALL)
+CUSTOM_CVAR(Float, i_timescale, 1.0f, CVAR_NOINITCALL | CVAR_VIRTUAL)
 {
 	if (netgame)
 	{


### PR DESCRIPTION
Changing i_timescale in a netgame would cause its callback to recurse
into itself infinitely. CVAR_VIRTUAL prevents this.