### PR TITLE
Treat the ACS SpawnDecal function's zoffset arg as a fixed, not an int

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -6054,7 +6054,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
             }
 
 		case ACSF_SpawnDecal:
-			// int SpawnDecal(int tid, str decalname, int flags, fixed angle, int zoffset, int distance)
+			// int SpawnDecal(int tid, str decalname, int flags, fixed angle, fixed zoffset, int distance)
 			// Returns number of decals spawned (not including spreading)
 			{
 				int count = 0;
@@ -6063,7 +6063,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				{
 					int flags = (argCount > 2) ? args[2] : 0;
 					DAngle angle = ACSToAngle((argCount > 3) ? args[3] : 0);
-					int zoffset = (argCount > 4) ? args[4]: 0;
+					double zoffset = (argCount > 4) ? ACSToDouble(args[4]): 0;
 					int distance = (argCount > 5) ? args[5] : 64;
 
 					if (args[0] == 0)


### PR DESCRIPTION
The [wiki](https://zdoom.org/wiki/SpawnDecal) says it is a `fixed` and this allows much more precise placement of decals.

It also says that `distance` should be a `fixed` but I think an `int` is sufficient here.

I imagine this will break existing usage so I can understand if you don't want to change this. It does make a fairly big difference to my own map though.

It's also worth pointing out that it selects the x and y position with double precision so it's a rather odd inconsistency.