### PR TITLE
SDL: Set icon of created window on startup

### DIFF
--- a/src/posix/zdoom.xpm
+++ b/src/posix/zdoom.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char * zdoom_xpm[] = {
+static const char * zdoom_xpm[] = {
 "256 256 8354 2",
 "  	c None",
 ". 	c #161616",


### PR DESCRIPTION
This PR makes GZDoom have an actual icon when a window is created when using the SDL backend.