### PR TITLE
Allow ACS SpawnDecal zoffset and distance args to be fixed point

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -569,6 +569,8 @@ FRandom pr_acs ("ACS");
 // SpawnDecal flags
 #define SDF_ABSANGLE		1
 #define SDF_PERMANENT		2
+#define SDF_FIXED_ZOFF		4
+#define SDF_FIXED_DISTANCE	8
 
 // GetArmorInfo
 enum
@@ -6054,7 +6056,7 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
             }
 
 		case ACSF_SpawnDecal:
-			// int SpawnDecal(int tid, str decalname, int flags, fixed angle, int zoffset, int distance)
+			// int SpawnDecal(int tid, str decalname, int flags, fixed angle, int|fixed zoffset, int|fixed distance)
 			// Returns number of decals spawned (not including spreading)
 			{
 				int count = 0;
@@ -6063,8 +6065,8 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				{
 					int flags = (argCount > 2) ? args[2] : 0;
 					DAngle angle = ACSToAngle((argCount > 3) ? args[3] : 0);
-					int zoffset = (argCount > 4) ? args[4]: 0;
-					int distance = (argCount > 5) ? args[5] : 64;
+					double zoffset = (argCount > 4) ? ((flags & SDF_FIXED_ZOFF) ? ACSToDouble(args[4]) : args[4]) : 0;
+					double distance = (argCount > 5) ? ((flags & SDF_FIXED_DISTANCE) ? ACSToDouble(args[5]) : args[5]) : 64;
 
 					if (args[0] == 0)
 					{


### PR DESCRIPTION
The [wiki](https://zdoom.org/wiki/SpawnDecal) currently says they should be fixed point but the code currently treats them as integers. Given that they are placed with double precision horizontally, it is odd that the same precision cannot be applied vertically. Changing this would break existing maps so add two flags to support both types.

This is an alternative to #1355. The lack of response there made me think that perhaps you didn't want to break existing maps. Please choose whichever solution you think is best. I don't mind!