### PR TITLE
Add installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,9 +25,7 @@ steps is applicable to other operating systems as well.
       - libbzip2 (possibly static)
       - libjpeg (possibly static)
       - libgme or game-music-emu (possibly static)
-      - libglew (for GZDoom 1.x)
-      - FMOD Ex 4.36.x or later or FMOD Studio (for GZDoom 1.x and
-        2.x) Runtime
+      - FMOD Ex 4.36.x or later
       - gxmessage (optional - needed to show the crash log in a
         window)
       - kdialog (optional - for KDE users)
@@ -43,11 +41,12 @@ steps is applicable to other operating systems as well.
 1a. Make sure ZMusic is installed, either through your package manager
     or by building it yourself.
 
-	$ git clone --depth 1 -b 1.1.6 https://github.com/coelckers/ZMusic.git
+	$ git clone https://github.com/coelckers/ZMusic.git
 	$ cd ZMusic
 	$ mkdir build
 	$ cd build
 	$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=`pwd`/../build_install ..
+        $ make -j
 
 2.  Build GZDoom.
 

--- a/INSTALL
+++ b/INSTALL
@@ -46,19 +46,21 @@ steps is applicable to other operating systems as well.
 	$ mkdir build
 	$ cd build
 	$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=`pwd`/../build_install ..
-        $ make -j
+        $ make -j 4
 
 2.  Build GZDoom.
 
     If you built ZMusic yourself, set CMAKE_PREFIX_PATH to the full
     path of the build_install directory set above, otherwise remove
-    the option entirely.
+    the option entirely. The "-j 4" flag sets how many jobs to run
+    simultaneously. Set it too low and it will take needlessly long
+    time to build. Set it too high and you might run out of RAM.
 
 	$ cd GZDoom
 	$ mkdir build
 	$ cd build
 	$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=../ZMusic/build/build_install/ ..
-	$ make -j
+	$ make -j 4
 
 3.  If all works you should have a executable program in build/gzdoom.
 

--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,77 @@
+GZDoom installation Guide
+
+This file contains instructions for building GZDoom. Currently this
+guide only contains instructions for Gnu/Linux but it is possible the
+steps is applicable to other operating systems as well.
+
+1.  Install the required dependencies. Depending on your distro they
+    may have different package names. These are:
+
+    Required
+      - gcc 4.8 or later
+      - make
+      - cmake 2.8.7 or later
+      - SDL 2.0.2 or later
+      - libGL and libGLU (SDL or libSDL pull in libGLU) or any other
+        GL implementation provider.
+      - ZMusic (See below)
+    Recommended
+      - GTK3 or GTK2
+      - git (needed in order to download the source and compile in
+        commit meta data)
+      - nasm 0.98.39 or later (x86-32 only)
+    Optional
+      - zlib (GZDoom has a copy of it and will be statically compiled
+        in if not found)
+      - libbzip2 (possibly static)
+      - libjpeg (possibly static)
+      - libgme or game-music-emu (possibly static)
+      - SDL 1.2.8 or later 1.2.x versions (for GZDoom 1.x)
+      - libglew (for GZDoom 1.x)
+      - FMOD Ex 4.36.x or later or FMOD Studio (for GZDoom 1.x and
+        2.x) Runtime
+      - gxmessage (optional - needed to show the crash log in a
+        window)
+      - kdialog (optional - for KDE users)
+      - fluidsynth (optional - for MIDI playback)
+
+    In addition to or instead of FMOD, OpenAL can be used for sound in
+    which case the following are required:
+
+      - libopenal
+      - libmpg123
+      - libsndfile
+
+1a. Make sure ZMusic is installed, either through your package manager
+    or by building it yourself.
+
+	$ git clone --depth 1 -b 1.1.6 https://github.com/coelckers/ZMusic.git
+	$ cd ZMusic
+	$ mkdir build
+	$ cd build
+	$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=`pwd`/../build_install ..
+
+2.  Build GZDoom.
+
+    If you acquired GZDOOM through git you may want to checkout the
+    stable version, which as of time of writing is 4.5.0:
+
+	$ git checkout g4.5.0
+
+    If you built ZMusic yourself, set CMAKE_PREFIX_PATH to the full
+    path of the build_install directory set above, otherwise remove
+    the option entirely.
+
+	$ cd GZDoom
+	$ mkdir build
+	$ cd build
+	$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=../ZMusic/build/build_install/ ..
+	$ make
+
+3.  If all works you should have a executable program in build/gzdoom.
+
+	$ build/gzdoom
+
+4.  (Optional) You may want to move GZDoom to its installation directories.
+
+	# make install

--- a/INSTALL
+++ b/INSTALL
@@ -8,10 +8,10 @@ steps is applicable to other operating systems as well.
     may have different package names. These are:
 
     Required
-      - gcc 4.8 or later
+      - gcc 7.x or later
       - make
-      - cmake 2.8.7 or later
-      - SDL 2.0.2 or later
+      - cmake 3.1 or later
+      - SDL 2.0.6 or later
       - libGL and libGLU (SDL or libSDL pull in libGLU) or any other
         GL implementation provider.
       - ZMusic (See below)
@@ -19,14 +19,12 @@ steps is applicable to other operating systems as well.
       - GTK3 or GTK2
       - git (needed in order to download the source and compile in
         commit meta data)
-      - nasm 0.98.39 or later (x86-32 only)
     Optional
       - zlib (GZDoom has a copy of it and will be statically compiled
         in if not found)
       - libbzip2 (possibly static)
       - libjpeg (possibly static)
       - libgme or game-music-emu (possibly static)
-      - SDL 1.2.8 or later 1.2.x versions (for GZDoom 1.x)
       - libglew (for GZDoom 1.x)
       - FMOD Ex 4.36.x or later or FMOD Studio (for GZDoom 1.x and
         2.x) Runtime
@@ -53,11 +51,6 @@ steps is applicable to other operating systems as well.
 
 2.  Build GZDoom.
 
-    If you acquired GZDOOM through git you may want to checkout the
-    stable version, which as of time of writing is 4.5.0:
-
-	$ git checkout g4.5.0
-
     If you built ZMusic yourself, set CMAKE_PREFIX_PATH to the full
     path of the build_install directory set above, otherwise remove
     the option entirely.
@@ -66,7 +59,7 @@ steps is applicable to other operating systems as well.
 	$ mkdir build
 	$ cd build
 	$ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=../ZMusic/build/build_install/ ..
-	$ make
+	$ make -j
 
 3.  If all works you should have a executable program in build/gzdoom.
 

--- a/README.md
+++ b/README.md
@@ -18,5 +18,4 @@ Special thanks to Coraline of the EDGE team for allowing us to use her [README.m
 
 ## How to build GZDoom
 
-To build GZDoom, please see the [wiki](https://zdoom.org/wiki/) and see the "Programmer's Corner" on the bottom-right corner of the page to build for your platform.
-
+For instructions on how to build GZDoom, please see the file INSTALL.


### PR DESCRIPTION
I think that it is important that build instructions is part of the repo itself. I had some issues with the instructions on the wiki, and had more success with [these](https://forum.zdoom.org/viewtopic.php?t=67477#p1137774) instructions. I added them to their own file and added what was missing from the wiki.