### PR TITLE
- add try-catch to catch unhandled Vulkan exception. 

### DIFF
--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -63,6 +63,8 @@
 #include "v_draw.h"
 #include "templates.h"
 
+#include "common/rendering/vulkan/system/vk_device.h"
+
 EXTERN_CVAR(Int, menu_resolution_custom_width)
 EXTERN_CVAR(Int, menu_resolution_custom_height)
 
@@ -300,19 +302,27 @@ void V_OutputResized (int width, int height)
 
 bool IVideo::SetResolution ()
 {
-	DFrameBuffer *buff = CreateFrameBuffer();
-
-	if (buff == NULL)	// this cannot really happen
+	try
 	{
+		DFrameBuffer *buff = CreateFrameBuffer();
+
+		if (buff == NULL)	// this cannot really happen
+		{
+			return false;
+		}
+
+		screen = buff;
+		screen->InitializeState();
+
+		V_UpdateModeSize(screen->GetWidth(), screen->GetHeight());
+
+		return true;
+	}
+	catch (const CVulkanError& e)
+	{
+		I_FatalError("Vulkan Error: %s\n", e.what());
 		return false;
 	}
-
-	screen = buff;
-	screen->InitializeState();
-
-	V_UpdateModeSize(screen->GetWidth(), screen->GetHeight());
-
-	return true;
 }
 
 //


### PR DESCRIPTION
https://github.com/drfrag666/gzdoom/issues/20#issuecomment-813518676

There's probably a better way to do this, but this is an attempt to address this issue none-the-less.

An unhandled exception occurs if running Vulkan outside of X11 from within Linux where if the video mode is not set correctly it crashes instead of gracefully erroring out. This likely occurs in more than just the Vulkan backend, but I would need to see the crashes in the others in order to address them properly as well.