### PR TITLE
Sprite shadows - 4th take...

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -459,7 +459,9 @@ enum ActorRenderFlag
 
 	RF_SPRITEFLIP		= 0x08000000,	// sprite flipped on x-axis
 	RF_ZDOOMTRANS		= 0x10000000,	// is not normally transparent in Vanilla Doom
+	RF_CASTSPRITESHADOW = 0x20000000,	// actor will cast a sprite shadow
 	RF_NOINTERPOLATEVIEW = 0x40000000,	// don't interpolate the view next frame if this actor is a camera.
+	RF_NOSPRITESHADOW = 0x80000000,		// actor will not cast a sprite shadow
 };
 
 // This translucency value produces the closest match to Heretic's TINTTAB.

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -49,6 +49,8 @@
 
 CVAR(Bool, gl_multithread, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
+EXTERN_CVAR(Float, r_actorspriteshadowdist)
+
 thread_local bool isWorkerThread;
 ctpl::thread_pool renderPool(1);
 bool inited = false;
@@ -547,6 +549,18 @@ void HWDrawInfo::RenderThings(subsector_t * sub, sector_t * sector)
 		if (CurrentMapSections[thing->subsector->mapsection])
 		{
 			HWSprite sprite;
+
+			// [Nash] draw sprite shadow
+			if (R_ShouldDrawSpriteShadow(thing))
+			{
+				double dist = (thing->Pos() - vp.Pos).LengthSquared();
+				double check = r_actorspriteshadowdist;
+				if (dist <= check * check)
+				{
+					sprite.Process(this, thing, sector, in_area, false, true);
+				}
+			}
+
 			sprite.Process(this, thing, sector, in_area, false);
 		}
 	}
@@ -566,6 +580,18 @@ void HWDrawInfo::RenderThings(subsector_t * sub, sector_t * sector)
 		}
 
 		HWSprite sprite;
+
+		// [Nash] draw sprite shadow
+		if (R_ShouldDrawSpriteShadow(thing))
+		{
+			double dist = (thing->Pos() - vp.Pos).LengthSquared();
+			double check = r_actorspriteshadowdist;
+			if (dist <= check * check)
+			{
+				sprite.Process(this, thing, sector, in_area, true, true);
+			}
+		}
+
 		sprite.Process(this, thing, sector, in_area, true);
 	}
 }

--- a/src/rendering/hwrenderer/scene/hw_drawstructs.h
+++ b/src/rendering/hwrenderer/scene/hw_drawstructs.h
@@ -385,7 +385,7 @@ public:
 
 	void CreateVertices(HWDrawInfo *di);
 	void PutSprite(HWDrawInfo *di, bool translucent);
-	void Process(HWDrawInfo *di, AActor* thing,sector_t * sector, area_t in_area, int thruportal = false);
+	void Process(HWDrawInfo *di, AActor* thing,sector_t * sector, area_t in_area, int thruportal = false, bool isSpriteShadow = false);
 	void ProcessParticle (HWDrawInfo *di, particle_t *particle, sector_t *sector);//, int shade, int fakeside)
 
 	void DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent);

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -105,6 +105,21 @@ CUSTOM_CVAR(Float, r_quakeintensity, 1.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 	else if (self > 1.f) self = 1.f;
 }
 
+CUSTOM_CVARD(Int, r_actorspriteshadow, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "render actor sprite shadows. 0 = off, 1 = default, 2 = always on")
+{
+	if (self < 0)
+		self = 0;
+	else if (self > 2)
+		self = 2;
+}
+CUSTOM_CVARD(Float, r_actorspriteshadowdist, 1500.0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "how far sprite shadows should be rendered")
+{
+	if (self < 0.f)
+		self = 0.f;
+	else if (self > 8192.f)
+		self = 8192.f;
+}
+
 int 			viewwindowx;
 int 			viewwindowy;
 int				viewwidth;
@@ -1049,5 +1064,31 @@ CUSTOM_CVAR(Float, maxviewpitch, 90.f, CVAR_ARCHIVE | CVAR_SERVERINFO)
 	{
 		// [SP] Update pitch limits to the netgame/gamesim.
 		players[consoleplayer].SendPitchLimits();
+	}
+}
+
+//==========================================================================
+//
+// R_ShouldDrawSpriteShadow
+//
+//==========================================================================
+
+bool R_ShouldDrawSpriteShadow(AActor *thing)
+{
+	switch (r_actorspriteshadow)
+	{
+	case 1:
+		return (thing->renderflags & RF_CASTSPRITESHADOW);
+
+	case 2:
+		if (thing->renderflags & RF_CASTSPRITESHADOW)
+		{
+			return true;
+		}
+		return (thing->renderflags & RF_CASTSPRITESHADOW) || (!(thing->renderflags & RF_NOSPRITESHADOW) && ((thing->flags3 & MF3_ISMONSTER) || thing->player != nullptr));
+
+	default:
+	case 0:
+		return false;
 	}
 }

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -135,5 +135,6 @@ double R_ClampVisibility(double vis);
 extern void R_FreePastViewers ();
 extern void R_ClearPastViewer (AActor *actor);
 
+bool R_ShouldDrawSpriteShadow(AActor *thing);
 
 #endif

--- a/src/rendering/swrenderer/scene/r_opaque_pass.cpp
+++ b/src/rendering/swrenderer/scene/r_opaque_pass.cpp
@@ -79,6 +79,8 @@ extern uint32_t r_renderercaps;
 
 double model_distance_cull = 1e16;
 
+EXTERN_CVAR(Float, r_actorspriteshadowdist)
+
 namespace
 {
 	double sprite_distance_cull = 1e16;
@@ -965,6 +967,25 @@ namespace swrenderer
 					else
 					{
 						RenderSprite::Project(Thread, thing, sprite.pos, sprite.tex, sprite.spriteScale, sprite.renderflags, fakeside, fakefloor, fakeceiling, sec, thinglightlevel, foggy, thingColormap);
+
+						// [Nash] draw sprite shadow
+						if (R_ShouldDrawSpriteShadow(thing))
+						{
+							double dist = (thing->Pos() - Thread->Viewport->viewpoint.Pos).LengthSquared();
+							double distCheck = r_actorspriteshadowdist;
+							if (dist <= distCheck * distCheck)
+							{
+								// squash Y scale
+								DVector2 shadowScale = sprite.spriteScale;
+								shadowScale.Y *= 0.15;
+
+								// snap to floor Z
+								DVector3 shadowPos = sprite.pos;
+								shadowPos.Z = thing->floorz;
+
+								RenderSprite::Project(Thread, thing, shadowPos, sprite.tex, shadowScale, sprite.renderflags, fakeside, fakefloor, fakeceiling, sec, thinglightlevel, foggy, thingColormap, true);
+							}
+						}
 					}
 				}
 			}

--- a/src/rendering/swrenderer/things/r_sprite.cpp
+++ b/src/rendering/swrenderer/things/r_sprite.cpp
@@ -74,7 +74,7 @@ EXTERN_CVAR(Int, gl_texture_hqresize_targets)
 
 namespace swrenderer
 {
-	void RenderSprite::Project(RenderThread *thread, AActor *thing, const DVector3 &pos, FSoftwareTexture *tex, const DVector2 &spriteScale, int renderflags, WaterFakeSide fakeside, F3DFloor *fakefloor, F3DFloor *fakeceiling, sector_t *current_sector, int lightlevel, bool foggy, FDynamicColormap *basecolormap)
+	void RenderSprite::Project(RenderThread *thread, AActor *thing, const DVector3 &pos, FSoftwareTexture *tex, const DVector2 &spriteScale, int renderflags, WaterFakeSide fakeside, F3DFloor *fakefloor, F3DFloor *fakeceiling, sector_t *current_sector, int lightlevel, bool foggy, FDynamicColormap *basecolormap, bool isSpriteShadow)
 	{
 		auto viewport = thread->Viewport.get();
 
@@ -195,7 +195,14 @@ namespace swrenderer
 
 		bool fullbright = !vis->foggy && ((renderflags & RF_FULLBRIGHT) || (thing->flags5 & MF5_BRIGHT));
 		bool fadeToBlack = (vis->RenderStyle.Flags & STYLEF_FadeToBlack) != 0;
-		
+
+		if (isSpriteShadow)
+		{
+			vis->RenderStyle = LegacyRenderStyles[STYLE_TranslucentStencil];
+			vis->FillColor = 0;
+			vis->Alpha *= 0.5;
+		}
+
 		if (r_dynlights && gl_light_sprites)
 		{
 			float lit_red = 0;

--- a/src/rendering/swrenderer/things/r_sprite.h
+++ b/src/rendering/swrenderer/things/r_sprite.h
@@ -7,7 +7,7 @@ namespace swrenderer
 	class RenderSprite : public VisibleSprite
 	{
 	public:
-		static void Project(RenderThread *thread, AActor *thing, const DVector3 &pos, FSoftwareTexture *tex, const DVector2 &spriteScale, int renderflags, WaterFakeSide fakeside, F3DFloor *fakefloor, F3DFloor *fakeceiling, sector_t *current_sector, int lightlevel, bool foggy, FDynamicColormap *basecolormap);
+		static void Project(RenderThread *thread, AActor *thing, const DVector3 &pos, FSoftwareTexture *tex, const DVector2 &spriteScale, int renderflags, WaterFakeSide fakeside, F3DFloor *fakefloor, F3DFloor *fakeceiling, sector_t *current_sector, int lightlevel, bool foggy, FDynamicColormap *basecolormap, bool isSpriteShadow = false);
 
 	protected:
 		void Render(RenderThread *thread, short *cliptop, short *clipbottom, int minZ, int maxZ, Fake3DTranslucent clip3DFloor) override;

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -351,6 +351,8 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF, DONTINTERPOLATE, AActor, renderflags),
 	DEFINE_FLAG(RF, SPRITEFLIP, AActor, renderflags),
 	DEFINE_FLAG(RF, ZDOOMTRANS, AActor, renderflags),
+	DEFINE_FLAG(RF, CASTSPRITESHADOW, AActor, renderflags),
+	DEFINE_FLAG(RF, NOSPRITESHADOW, AActor, renderflags),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -945,6 +945,7 @@ OptionMenu "VideoOptions" protected
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
 	StaticText " "
+	Option "$DSPLYMNU_SPRITESHADOW",			"r_actorspriteshadow", "SpriteShadowModes"
 	Option "$DSPLYMNU_CUSTOMINVERTMAP",			"cl_customizeinvulmap", "OnOff"
 	ColorPicker "$DSPLYMNU_CUSTOMINVERTC1",		"cl_custominvulmapcolor1"
 	ColorPicker "$DSPLYMNU_CUSTOMINVERTC2",		"cl_custominvulmapcolor2"
@@ -2822,4 +2823,11 @@ OptionMenu "vkoptions"
 	StaticText ""
 	TextField "$VKMNU_DEVICE",			vk_device
 	Option "$VKMNU_HDR",				"vk_hdr", "OnOff"
+}
+
+OptionValue "SpriteShadowModes"
+{
+	0, "$OPTVAL_OFF"
+	1, "$OPTVAL_DEFAULT"
+	2, "$OPTVAL_SPRSHADALWAYS"
 }


### PR DESCRIPTION
Remade the entire PR with fewer commits. Hopefully this is it...

New language strings:

```
DSPLYMNU_SPRITESHADOW = "Actor shadows";
OPTVAL_SPRSHADALWAYS = "Monsters and players";
```

Example files:

[SpriteShadowTestMod.zip](https://github.com/coelckers/gzdoom/files/5366098/SpriteShadowTestMod.zip)
Explicitly enables sprite shadows for Zombiemen, and force the Imps to never draw shadows

[SpriteShadowEnabler.zip](https://github.com/coelckers/gzdoom/files/5366100/SpriteShadowEnabler.zip)
An event handler-based mod that simply enables shadows for all living things