### PR TITLE
LevelInfo exporting to ZScript

### DIFF
--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1227,6 +1227,113 @@ enum EChangeLevelFlags
 	CHANGELEVEL_PRERAISEWEAPON = 64,
 };
 
+enum ELevelFlags
+{
+	LEVEL_NOINTERMISSION		= 0x00000001,
+	LEVEL_NOINVENTORYBAR		= 0x00000002,	// This effects Doom only, since it's the only one without a standard inventory bar.
+	LEVEL_DOUBLESKY				= 0x00000004,
+	LEVEL_HASFADETABLE			= 0x00000008,	// Level uses Hexen's fadetable mapinfo to get fog
+
+	LEVEL_MAP07SPECIAL			= 0x00000010,
+	LEVEL_BRUISERSPECIAL		= 0x00000020,
+	LEVEL_CYBORGSPECIAL			= 0x00000040,
+	LEVEL_SPIDERSPECIAL			= 0x00000080,
+
+	LEVEL_SPECLOWERFLOOR		= 0x00000100,
+	LEVEL_SPECOPENDOOR			= 0x00000200,
+	LEVEL_SPECLOWERFLOORTOHIGHEST=0x00000300,
+	LEVEL_SPECACTIONSMASK		= 0x00000300,
+
+	LEVEL_MONSTERSTELEFRAG		= 0x00000400,
+	LEVEL_ACTOWNSPECIAL			= 0x00000800,
+	LEVEL_SNDSEQTOTALCTRL		= 0x00001000,
+	LEVEL_FORCETILEDSKY		= 0x00002000,
+
+	LEVEL_CROUCH_NO				= 0x00004000,
+	LEVEL_JUMP_NO				= 0x00008000,
+	LEVEL_FREELOOK_NO			= 0x00010000,
+	LEVEL_FREELOOK_YES			= 0x00020000,
+
+	// The absence of both of the following bits means that this level does not
+	// use falling damage (though damage can be forced with dmflags,.
+	LEVEL_FALLDMG_ZD			= 0x00040000,	// Level uses ZDoom's falling damage
+	LEVEL_FALLDMG_HX			= 0x00080000,	// Level uses Hexen's falling damage
+
+	LEVEL_HEADSPECIAL			= 0x00100000,	// Heretic episode 1/4
+	LEVEL_MINOTAURSPECIAL		= 0x00200000,	// Heretic episode 2/5
+	LEVEL_SORCERER2SPECIAL		= 0x00400000,	// Heretic episode 3
+	LEVEL_SPECKILLMONSTERS		= 0x00800000,
+
+	LEVEL_STARTLIGHTNING		= 0x01000000,	// Automatically start lightning
+	LEVEL_FILTERSTARTS			= 0x02000000,	// Apply mapthing filtering to player starts
+	LEVEL_LOOKUPLEVELNAME		= 0x04000000,	// Level name is the name of a language string
+	LEVEL_USEPLAYERSTARTZ		= 0x08000000,	// Use the Z position of player starts
+
+	LEVEL_SWAPSKIES				= 0x10000000,	// Used by lightning
+	LEVEL_NOALLIES				= 0x20000000,	// i.e. Inside Strife's front base
+	LEVEL_CHANGEMAPCHEAT		= 0x40000000,	// Don't display cluster messages
+	LEVEL_VISITED				= 0x80000000,	// Used for intermission map
+
+	// The flags uint64_t is now split into 2 DWORDs 
+	LEVEL2_RANDOMPLAYERSTARTS	= 0x00000001,	// Select single player starts randomnly (no voodoo dolls)
+	LEVEL2_ALLMAP				= 0x00000002,	// The player picked up a map on this level
+
+	LEVEL2_LAXMONSTERACTIVATION	= 0x00000004,	// Monsters can open doors depending on the door speed
+	LEVEL2_LAXACTIVATIONMAPINFO	= 0x00000008,	// LEVEL_LAXMONSTERACTIVATION is not a default.
+
+	LEVEL2_MISSILESACTIVATEIMPACT=0x00000010,	// Missiles are the activators of SPAC_IMPACT events, not their shooters
+	LEVEL2_NEEDCLUSTERTEXT		= 0x00000020,	// A map with this flag needs to retain its cluster intermission texts when being redefined in UMAPINFO
+
+	LEVEL2_KEEPFULLINVENTORY	= 0x00000040,	// doesn't reduce the amount of inventory items to 1
+
+	LEVEL2_PRERAISEWEAPON		= 0x00000080,	// players should spawn with their weapons fully raised (but not when respawning it multiplayer)
+	LEVEL2_MONSTERFALLINGDAMAGE	= 0x00000100,
+	LEVEL2_CLIPMIDTEX			= 0x00000200,
+	LEVEL2_WRAPMIDTEX			= 0x00000400,
+
+	LEVEL2_CHECKSWITCHRANGE		= 0x00000800,	
+
+	LEVEL2_PAUSE_MUSIC_IN_MENUS	= 0x00001000,
+	LEVEL2_TOTALINFIGHTING		= 0x00002000,
+	LEVEL2_NOINFIGHTING			= 0x00004000,
+
+	LEVEL2_NOMONSTERS			= 0x00008000,
+	LEVEL2_INFINITE_FLIGHT		= 0x00010000,
+
+	LEVEL2_ALLOWRESPAWN			= 0x00020000,
+
+	LEVEL2_FORCETEAMPLAYON		= 0x00040000,
+	LEVEL2_FORCETEAMPLAYOFF		= 0x00080000,
+
+	LEVEL2_CONV_SINGLE_UNFREEZE	= 0x00100000,
+	LEVEL2_NOCLUSTERTEXT		= 0x00200000,	// ignore intermission texts fro clusters. This gets set when UMAPINFO is used to redefine its properties.
+	LEVEL2_DUMMYSWITCHES		= 0x00400000,
+	LEVEL2_HEXENHACK			= 0x00800000,	// Level was defined in a Hexen style MAPINFO
+
+	LEVEL2_SMOOTHLIGHTING		= 0x01000000,	// Level uses the smooth lighting feature.
+	LEVEL2_POLYGRIND			= 0x02000000,	// Polyobjects grind corpses to gibs.
+	LEVEL2_RESETINVENTORY		= 0x04000000,	// Resets player inventory when starting this level (unless in a hub)
+	LEVEL2_RESETHEALTH			= 0x08000000,	// Resets player health when starting this level (unless in a hub)
+
+	LEVEL2_NOSTATISTICS			= 0x10000000,	// This level should not have statistics collected
+	LEVEL2_ENDGAME				= 0x20000000,	// This is an epilogue level that cannot be quit.
+	LEVEL2_NOAUTOSAVEHINT		= 0x40000000,	// tell the game that an autosave for this level does not need to be kept
+	LEVEL2_FORGETSTATE			= 0x80000000,	// forget this map's state in a hub
+	
+	// More flags!
+	LEVEL3_FORCEFAKECONTRAST	= 0x00000001,	// forces fake contrast even with fog enabled
+	LEVEL3_REMOVEITEMS			= 0x00000002,	// kills all INVBAR items on map change.
+	LEVEL3_ATTENUATE			= 0x00000004,	// attenuate lights?
+	LEVEL3_NOLIGHTFADE			= 0x00000008,	// no light fading to black.
+	LEVEL3_NOCOLOREDSPRITELIGHTING = 0x00000010,	// draw sprites only with color-less light
+	LEVEL3_EXITNORMALUSED		= 0x00000020,
+	LEVEL3_EXITSECRETUSED		= 0x00000040,
+	LEVEL3_FORCEWORLDPANNING	= 0x00000080,	// Forces the world panning flag for all textures, even those without it explicitly set.
+	LEVEL3_HIDEAUTHORNAME		= 0x00000100,
+	LEVEL3_PROPERMONSTERFALLINGDAMAGE	= 0x00000200,	// Properly apply falling damage to the monsters
+	LEVEL3_SKYBOXAO				= 0x00000400,	// Apply SSAO to sector skies
+};
+
 // [RH] Compatibility flags.
 enum ECompatFlags
 {

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -320,6 +320,53 @@ struct DropItem native
 	native readonly int Amount;
 }
 
+struct LevelInfo native
+{
+	native readonly int levelnum;
+	native readonly String MapName;
+	native readonly String NextMap;
+	native readonly String NextSecretMap;
+	native readonly String SkyPic1;
+	native readonly String SkyPic2;
+	native readonly String F1Pic;
+	native readonly int cluster;
+	native readonly int partime;
+	native readonly int sucktime;
+	native readonly int flags;
+	native readonly int flags2;
+	native readonly int flags3;
+	native readonly String Music;
+	native readonly String LevelName;
+	native readonly String AuthorName;
+	native readonly int musicorder;
+	native readonly float skyspeed1;
+	native readonly float skyspeed2;
+	native readonly int cdtrack;
+	native readonly double gravity;
+	native readonly double aircontrol;
+	native readonly int airsupply;
+	native readonly int compatflags;
+	native readonly int compatflags2;
+	native readonly name deathsequence;
+	native readonly int fogdensity;
+	native readonly int outsidefogdensity;
+	native readonly int skyfog;
+	native readonly float pixelstretch;
+	native readonly name RedirectType;
+	native readonly String RedirectMapName;
+	native readonly double teamdamage;
+
+	native bool isValid() const;
+	native String LookupLevelName() const;
+
+	native static int GetLevelInfoCount();
+	native static LevelInfo GetLevelInfo(int index);
+	native static LevelInfo FindLevelInfo(String mapname);
+	native static LevelInfo FindLevelByNum(int num);
+	native static bool MapExists(String mapname);
+	native static String MapChecksum(String mapname);
+}
+
 struct LevelLocals native
 {
 	enum EUDMF
@@ -396,7 +443,7 @@ struct LevelLocals native
 	native name deathsequence;
 	native readonly int compatflags;
 	native readonly int compatflags2;
-// level_info_t *info cannot be done yet.
+	native readonly LevelInfo info;
 
 	native String GetUDMFString(int type, int index, Name key);
 	native int GetUDMFInt(int type, int index, Name key);


### PR DESCRIPTION
Exports level_info_t to ZScript (read-only), along with functions for retrieving specific instances (getters are used for the wadlevelinfos array, as trying to expose it directly as a global caused issues).

An extra function to check if a map actually exists was added too, as it would prove VERY useful too (mapinfo entries can be declared for nonexistent maps, after all). As a second bonus there's a function for getting the checksum of any map (like the mapchecksum command), because I know people will ask.

Because I haven't found a way to only selectively export specific bools for the levelinfo flags, I had to leave them as-is (If there's an actual solution for this, I'd rather go with that instead).

Attached here are some sample actors that play around with the provided functionality: [zscript.txt](https://github.com/coelckers/gzdoom/files/6352450/zscript.txt)