### PR TITLE
Add some new optional parameters to A_SprayDecal:

### DIFF
--- a/src/playsim/a_decals.cpp
+++ b/src/playsim/a_decals.cpp
@@ -831,7 +831,7 @@ DBaseDecal *DImpactDecal::CloneSelf (const FDecalTemplate *tpl, double ix, doubl
 //
 //----------------------------------------------------------------------------
 
-void SprayDecal(AActor *shooter, const char *name, double distance, DVector3 offset, DVector3 direction)
+void SprayDecal(AActor *shooter, const char *name, double distance, DVector3 offset, DVector3 direction, bool useBloodColor, uint32_t decalColor)
 {
 	//just in case
 	if (!shooter)
@@ -859,12 +859,14 @@ void SprayDecal(AActor *shooter, const char *name, double distance, DVector3 off
 	else
 		dir = direction;
 
+	uint32_t bloodTrans = useBloodColor ? shooter->BloodTranslation : 0;
+	PalEntry entry = !useBloodColor ? (PalEntry)decalColor : shooter->BloodColor;
 
 	if (Trace(off, shooter->Sector, dir, distance, 0, ML_BLOCKEVERYTHING, shooter, trace, TRACE_NoSky))
 	{
 		if (trace.HitType == TRACE_HitWall)
 		{
-			DImpactDecal::StaticCreate(shooter->Level, name, trace.HitPos, trace.Line->sidedef[trace.Side], NULL);
+			DImpactDecal::StaticCreate(shooter->Level, name, trace.HitPos, trace.Line->sidedef[trace.Side], NULL, entry, bloodTrans);
 		}
 	}
 }

--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -12,7 +12,7 @@ class DBaseDecal;
 struct SpreadInfo;
 
 DBaseDecal *ShootDecal(FLevelLocals *Level, const FDecalTemplate *tpl, sector_t *sec, double x, double y, double z, DAngle angle, double tracedist, bool permanent);
-void SprayDecal(AActor *shooter, const char *name,double distance = 172., DVector3 offset = DVector3(0., 0., 0.), DVector3 direction = DVector3(0., 0., 0.) );
+void SprayDecal(AActor *shooter, const char *name,double distance = 172., DVector3 offset = DVector3(0., 0., 0.), DVector3 direction = DVector3(0., 0., 0.), bool useBloodColor = false, uint32_t decalColor = 0);
 
 class DBaseDecal : public DThinker
 {

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -5005,7 +5005,9 @@ DEFINE_ACTION_FUNCTION(AActor, A_SprayDecal)
 	PARAM_FLOAT(direction_x);
 	PARAM_FLOAT(direction_y);
 	PARAM_FLOAT(direction_z);
-	SprayDecal(self, name, dist, DVector3(offset_x, offset_y, offset_z), DVector3(direction_x, direction_y, direction_z) );
+	PARAM_BOOL(useBloodColor);
+	PARAM_COLOR(decalColor);
+	SprayDecal(self, name, dist, DVector3(offset_x, offset_y, offset_z), DVector3(direction_x, direction_y, direction_z), useBloodColor, decalColor);
 	return 0;
 }
 

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1182,7 +1182,7 @@ class Actor : Thinker native
 	native bool A_SetVisibleRotation(double anglestart = 0, double angleend = 0, double pitchstart = 0, double pitchend = 0, int flags = 0, int ptr = AAPTR_DEFAULT);
 	native void A_SetTranslation(name transname);
 	native bool A_SetSize(double newradius = -1, double newheight = -1, bool testpos = false);
-	native void A_SprayDecal(String name, double dist = 172, vector3 offset = (0, 0, 0), vector3 direction = (0, 0, 0) );
+	native void A_SprayDecal(String name, double dist = 172, vector3 offset = (0, 0, 0), vector3 direction = (0, 0, 0), bool useBloodColor = false, color decalColor = 0);
 	native void A_SetMugshotState(String name);
 	native void CopyBloodColor(Actor other);
 


### PR DESCRIPTION
- useBloodColor: when true, the sprayed decal will be shaded to match the calling actor's blood color.
- decalColor: when defined, the sprayed decal will be shaded to the specified color. Note that this will take precedence over useBloodColor. It is recommended to use only one parameter.

Note that due to how decals work in the engine, the "decalColor" parameter will only properly colorize the decal if the image is grayscale.

Use cases:

1) Prevent modders from abusing TraceBleed to arbitrarily spray colorized blood decals from their actors
2) Allow modders to specify any arbitrary decal shade when spraying them