### PR TITLE
Add an option to draw shadows for all things

### DIFF
--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -105,12 +105,12 @@ CUSTOM_CVAR(Float, r_quakeintensity, 1.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 	else if (self > 1.f) self = 1.f;
 }
 
-CUSTOM_CVARD(Int, r_actorspriteshadow, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "render actor sprite shadows. 0 = off, 1 = default, 2 = always on")
+CUSTOM_CVARD(Int, r_actorspriteshadow, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "render actor sprite shadows. 0 = off, 1 = default, 2 = monsters and players, 3 = everything (can be slow)")
 {
 	if (self < 0)
 		self = 0;
-	else if (self > 2)
-		self = 2;
+	else if (self > 3)
+		self = 3;
 }
 CUSTOM_CVARD(Float, r_actorspriteshadowdist, 1500.0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "how far sprite shadows should be rendered")
 {
@@ -1077,18 +1077,25 @@ bool R_ShouldDrawSpriteShadow(AActor *thing)
 {
 	switch (r_actorspriteshadow)
 	{
-	case 1:
+	case 1: // default
 		return (thing->renderflags & RF_CASTSPRITESHADOW);
 
-	case 2:
+	case 2: // monsters and players
 		if (thing->renderflags & RF_CASTSPRITESHADOW)
 		{
 			return true;
 		}
 		return (thing->renderflags & RF_CASTSPRITESHADOW) || (!(thing->renderflags & RF_NOSPRITESHADOW) && ((thing->flags3 & MF3_ISMONSTER) || thing->player != nullptr));
 
+	case 3: // everything (can be slow)
+		if (thing->renderflags & RF_CASTSPRITESHADOW)
+		{
+			return true;
+		}
+		return (thing->renderflags & RF_CASTSPRITESHADOW) || (!(thing->renderflags & RF_NOSPRITESHADOW));
+
 	default:
-	case 0:
+	case 0: // off
 		return false;
 	}
 }


### PR DESCRIPTION
The impact of this option is mainly visible with items and projectiles.

It can have a performance impact on large maps, so user discretion is advised. Nonetheless, it helps items and projectiles feel more "grounded" and improves depth pereception.

There are situations where it looks weird, such as rocket particle trails casting shadows and glowing projectiles (plasma, BFG) casting shadows. Is there a way to disable shadow casting just for those?
Additionally, bullet particle puffs will cast shadows, but I think it looks kind of nice.

## Preview

With `r_actorspriteshadow 2`, none of the items below would cast a shadow. With `r_actorspriteshadow 3`, they will:

![Screenshot_Doom_20210523_212153](https://user-images.githubusercontent.com/180032/119273961-abed8980-bc0d-11eb-8d49-0ce45b9a6b44.png)

![Screenshot_Doom_20210523_212025](https://user-images.githubusercontent.com/180032/119273957-a98b2f80-bc0d-11eb-92e2-ba48c8213677.png)

![Screenshot_Doom_20210523_212033](https://user-images.githubusercontent.com/180032/119273958-aabc5c80-bc0d-11eb-90fa-0835462d5e20.png)

![Screenshot_Doom_20210523_212040](https://user-images.githubusercontent.com/180032/119273959-aabc5c80-bc0d-11eb-9555-a679c7f2f768.png)

![Screenshot_Doom_20210523_212043](https://user-images.githubusercontent.com/180032/119273960-ab54f300-bc0d-11eb-9d8a-511a44024d5c.png)