### PR TITLE
Expose Print Levels to ZScript

### DIFF
--- a/src/common/console/c_console.h
+++ b/src/common/console/c_console.h
@@ -66,9 +66,8 @@ void C_NewModeAdjust (void);
 void C_Ticker (void);
 
 void AddToConsole (int printlevel, const char *string);
-int PrintString (int printlevel, const char *string);
-int PrintStringHigh (const char *string);
-int VPrintf (int printlevel, const char *format, va_list parms) GCCFORMAT(2);
+int PrintString (int printlevel, int printflags, const char *string);
+int VPrintf (int printlevel, int printstrings, const char *format, va_list parms) GCCFORMAT(3);
 
 void C_DrawConsole ();
 void C_ToggleConsole (void);

--- a/src/common/console/c_consolebuffer.cpp
+++ b/src/common/console/c_consolebuffer.cpp
@@ -69,7 +69,7 @@ FConsoleBuffer::FConsoleBuffer()
 //
 //==========================================================================
 
-void FConsoleBuffer::AddText(int printlevel, const char *text)
+void FConsoleBuffer::AddText(int printlevel, int printflags, const char *text)
 {
 	FString build = TEXTCOLOR_TAN;
 	
@@ -86,9 +86,9 @@ void FConsoleBuffer::AddText(int printlevel, const char *text)
 		mLastLineNeedsUpdate = true;
 	}
 	
-	if (printlevel >= 0 && printlevel != PRINT_HIGH)
+	if (printflags > 0 || (printlevel >= 0 && printlevel != PRINT_HIGH))
 	{
-		if (printlevel == 200) build = TEXTCOLOR_GREEN;
+		if (printflags & PRINTF_BOLD) build = TEXTCOLOR_GREEN;
 		else if (printlevel < PRINTLEVELS) build.Format("%c%c", TEXTCOLOR_ESCAPE, PrintColors[printlevel]+'A');
 	}
 	

--- a/src/common/console/c_consolebuffer.h
+++ b/src/common/console/c_consolebuffer.h
@@ -64,7 +64,7 @@ class FConsoleBuffer
 	
 public:
 	FConsoleBuffer();
-	void AddText(int printlevel, const char *string);
+	void AddText(int printlevel, int printflags, const char *string);
 	void FormatText(FFont *formatfont, int displaywidth);
 	void ResizeBuffer(unsigned newsize);
 	void Clear()

--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -1557,7 +1557,7 @@ CCMD (toggle)
 			auto msg = var->GetToggleMessage(val.Bool);
 			if (msg.IsNotEmpty())
 			{
-				Printf(PRINT_NOTIFY, "%s\n", msg.GetChars());
+				Printf(PRINT_DEFAULT, PRINTF_NOTIFY, "%s\n", msg.GetChars());
 			}
 			else Printf ("\"%s\" = \"%s\"\n", var->GetName(),
 				val.Bool ? "true" : "false");

--- a/src/common/console/c_dispatch.cpp
+++ b/src/common/console/c_dispatch.cpp
@@ -769,7 +769,7 @@ void C_SetAlias (const char *name, const char *cmd)
 	{
 		if (!alias->IsAlias ())
 		{
-			//Printf (PRINT_BOLD, "%s is a command and cannot be an alias.\n", name);
+			//Printf (PRINT_DEFAULT, PRINTF_BOLD, "%s is a command and cannot be an alias.\n", name);
 			return;
 		}
 		delete alias;

--- a/src/common/console/c_enginecmds.cpp
+++ b/src/common/console/c_enginecmds.cpp
@@ -237,7 +237,7 @@ UNSAFE_CCMD (dir)
 		do
 		{
 			if (I_FindAttr (&c_file) & FA_DIREC)
-				Printf (PRINT_BOLD, "%s <dir>\n", I_FindName (&c_file));
+				Printf (PRINT_DEFAULT, PRINTF_BOLD, "%s <dir>\n", I_FindName (&c_file));
 			else
 				Printf ("%s\n", I_FindName (&c_file));
 		} while (I_FindNext (file, &c_file) == 0);

--- a/src/common/console/c_notifybufferbase.h
+++ b/src/common/console/c_notifybufferbase.h
@@ -16,7 +16,7 @@ class FNotifyBufferBase
 {
 public:
 	virtual ~FNotifyBufferBase() = default;
-	virtual void AddString(int printlevel, FString source) = 0;
+	virtual void AddString(int printlevel, int printflags, FString source) = 0;
 	virtual void Shift(int maxlines);
 	virtual void Clear();
 	virtual void Tick();

--- a/src/common/engine/printf.h
+++ b/src/common/engine/printf.h
@@ -49,20 +49,26 @@ extern "C" int myvsnprintf(char* buffer, size_t count, const char* format, va_li
 #define TEXTCOLOR_CHAT			"\034*"
 #define TEXTCOLOR_TEAMCHAT		"\034!"
 
-// game print flags
+// Game print levels
 enum
 {
-	PRINT_LOW,		// pickup messages
-	PRINT_MEDIUM,	// death messages
-	PRINT_HIGH,		// critical messages
-	PRINT_CHAT,		// chat messages
-	PRINT_TEAMCHAT,	// chat messages from a teammate
-	PRINT_LOG,		// only to logfile
-	PRINT_BOLD = 200,				// What Printf_Bold used
-	PRINT_TYPES = 1023,		// Bitmask.
-	PRINT_NONOTIFY = 1024,	// Flag - do not add to notify buffer
-	PRINT_NOLOG = 2048,		// Flag - do not print to log file
-	PRINT_NOTIFY = 4096,	// Flag - add to game-native notify display - messages without this only go to the generic notification buffer.
+	PRINT_DEFAULT,		// Default to PRINT_LOW
+	PRINT_LOW = 0,		// pickup messages
+	PRINT_MEDIUM,		// death messages
+	PRINT_HIGH,			// critical messages
+	PRINT_CHAT,			// chat messages
+	PRINT_TEAMCHAT,		// chat messages from a teammate
+};
+
+// Print flags
+enum
+{
+	PRINTF_DEFAULT,
+	PRINTF_BOLD = 200,		// What Printf_Bold used
+	PRINTF_LOGONLY = 512,	// Flag - Only print to logfile// Flag - Only print to logfile
+	PRINTF_NONOTIFY = 1024,	// Flag - do not add to notify buffer
+	PRINTF_NOLOG = 2048,	// Flag - do not print to log file
+	PRINTF_NOTIFY = 4096,	// Flag - add to game-native notify display - messages without this only go to the generic notification buffer.
 };
 
 enum
@@ -81,9 +87,11 @@ void I_FatalError(const char* fmt, ...) ATTRIBUTE((format(printf, 1, 2)));
 // This really could need some cleanup - the main problem is that it'd create
 // lots of potential for merge conflicts.
 
-int PrintString (int iprintlevel, const char *outline);
+int PrintString (int printlevel, int printflags, const char *outline);
 int VPrintf(int printlevel, const char* format, va_list parms);
+int VPrintf(int printlevel, int printflags, const char* format, va_list parms);
 int Printf (int printlevel, const char *format, ...) ATTRIBUTE((format(printf,2,3)));
+int Printf (int printlevel, int printflags, const char* format, ...) ATTRIBUTE((format(printf, 3, 4)));
 int Printf (const char *format, ...) ATTRIBUTE((format(printf,1,2)));
 int DPrintf (int level, const char *format, ...) ATTRIBUTE((format(printf,2,3)));
 

--- a/src/common/engine/sc_man.cpp
+++ b/src/common/engine/sc_man.cpp
@@ -1389,6 +1389,7 @@ void FScriptPosition::Message (int severity, const char *message, ...) const
 	const char *type = "";
 	const char *color;
 	int level = PRINT_HIGH;
+	int flags = PRINTF_DEFAULT;
 
 	switch (severity)
 	{
@@ -1418,7 +1419,7 @@ void FScriptPosition::Message (int severity, const char *message, ...) const
 	case MSG_DEBUGLOG:
 	case MSG_LOG:
 		type = "message";
-		level = PRINT_LOG;
+		flags = PRINTF_LOGONLY;
 		color = "";
 		break;
 
@@ -1427,7 +1428,7 @@ void FScriptPosition::Message (int severity, const char *message, ...) const
 			FileName.GetChars(), ScriptLine, composed.GetChars());
 		return;
 	}
-	Printf (level, "%sScript %s, \"%s\" line %d:\n%s%s\n",
+	Printf (level, flags, "%sScript %s, \"%s\" line %d:\n%s%s\n",
 		color, type, FileName.GetChars(), ScriptLine, color, composed.GetChars());
 }
 

--- a/src/common/rendering/gl_load/gl_interface.cpp
+++ b/src/common/rendering/gl_load/gl_interface.cpp
@@ -218,10 +218,10 @@ void gl_PrintStartupLog()
 	Printf ("GL_RENDERER: %s\n", glGetString(GL_RENDERER));
 	Printf ("GL_VERSION: %s (%s profile)\n", glGetString(GL_VERSION), (v & GL_CONTEXT_CORE_PROFILE_BIT)? "Core" : "Compatibility");
 	Printf ("GL_SHADING_LANGUAGE_VERSION: %s\n", glGetString(GL_SHADING_LANGUAGE_VERSION));
-	Printf (PRINT_LOG, "GL_EXTENSIONS:");
+	Printf (PRINT_DEFAULT, PRINTF_LOGONLY, "GL_EXTENSIONS:");
 	for (unsigned i = 0; i < m_Extensions.Size(); i++)
 	{
-		Printf(PRINT_LOG, " %s", m_Extensions[i].GetChars());
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, " %s", m_Extensions[i].GetChars());
 	}
 
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &v);

--- a/src/common/rendering/vulkan/system/vk_framebuffer.cpp
+++ b/src/common/rendering/vulkan/system/vk_framebuffer.cpp
@@ -688,12 +688,12 @@ void VulkanFrameBuffer::PrintStartupLog()
 	Printf("Vulkan device type: %s\n", deviceType.GetChars());
 	Printf("Vulkan version: %s (api) %s (driver)\n", apiVersion.GetChars(), driverVersion.GetChars());
 
-	Printf(PRINT_LOG, "Vulkan extensions:");
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Vulkan extensions:");
 	for (const VkExtensionProperties &p : device->PhysicalDevice.Extensions)
 	{
-		Printf(PRINT_LOG, " %s", p.extensionName);
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, " %s", p.extensionName);
 	}
-	Printf(PRINT_LOG, "\n");
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n");
 
 	const auto &limits = props.limits;
 	Printf("Max. texture size: %d\n", limits.maxImageDimension2D);

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -663,7 +663,7 @@ void ZCCCompiler::MessageV(ZCC_TreeNode *node, const char *txtcolor, const char 
 	composed.Format("%s%s, line %d: ", txtcolor, node->SourceName->GetChars(), node->SourceLoc);
 	composed.VAppendFormat(msg, argptr);
 	composed += '\n';
-	PrintString(PRINT_HIGH, composed);
+	PrintString(PRINT_HIGH, PRINTF_DEFAULT, composed);
 }
 
 //==========================================================================

--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -989,6 +989,18 @@ DEFINE_ACTION_FUNCTION(_Console, Printf)
 	return 0;
 }
 
+DEFINE_ACTION_FUNCTION(_Console, PrintString)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(printlevel);
+	PARAM_INT(printflags);
+	PARAM_VA_POINTER(va_reginfo)
+
+	FString s = FStringFormat(VM_ARGS_NAMES, 2);
+	Printf(printlevel, printflags, "%s\n", s.GetChars());
+	return 0;
+}
+
 DEFINE_GLOBAL_NAMED(mus_playing, musplaying);
 DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, name);
 DEFINE_FIELD_X(MusPlayingInfo, MusPlayingInfo, baseorder);

--- a/src/console/c_notifybuffer.cpp
+++ b/src/console/c_notifybuffer.cpp
@@ -45,7 +45,7 @@
 struct FNotifyBuffer : public FNotifyBufferBase
 {
 public:
-	void AddString(int printlevel, FString source) override;
+	void AddString(int printlevel, int printflags, FString source) override;
 	void Clear() override;
 	void Draw() override;
 
@@ -83,7 +83,7 @@ void FNotifyBuffer::Clear()
 
 }
 
-void FNotifyBuffer::AddString(int printlevel, FString source)
+void FNotifyBuffer::AddString(int printlevel, int printflags, FString source)
 {
 	if (!show_messages ||
 		source.IsEmpty() ||
@@ -97,7 +97,7 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 	{
 		IFVIRTUALPTR(StatusBar, DBaseStatusBar, ProcessNotify)
 		{
-			VMValue params[] = { (DObject*)StatusBar, printlevel, &source };
+			VMValue params[] = { (DObject*)StatusBar, printlevel, &source, printflags};
 			int rv;
 			VMReturn ret(&rv);
 			VMCall(func, params, countof(params), &ret, 1);
@@ -107,7 +107,7 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 
 	int width = DisplayWidth / active_con_scaletext(twod, generic_ui);
 	FFont *font = generic_ui ? NewSmallFont : AlternativeSmallFont;
-	FNotifyBufferBase::AddString(printlevel & PRINT_TYPES, font, source, width, con_notifytime, con_notifylines);
+	FNotifyBufferBase::AddString(printlevel, font, source, width, con_notifytime, con_notifylines);
 }
 
 void FNotifyBuffer::Draw()

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1303,7 +1303,7 @@ void D_DoomLoop ()
 		{
 			if (error.GetMessage ())
 			{
-				Printf (PRINT_BOLD, "\n%s\n", error.GetMessage());
+				Printf (PRINT_DEFAULT, PRINTF_BOLD, "\n%s\n", error.GetMessage());
 			}
 			D_ErrorCleanup ();
 		}
@@ -3139,7 +3139,7 @@ static int D_DoomMain_Internal (void)
 		}
 	}
 
-	if (!batchrun) Printf(PRINT_LOG, "%s version %s\n", GAMENAME, GetVersionString());
+	if (!batchrun) Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%s version %s\n", GAMENAME, GetVersionString());
 
 	D_DoomInit();
 

--- a/src/g_dumpinfo.cpp
+++ b/src/g_dumpinfo.cpp
@@ -192,30 +192,30 @@ CCMD(dumpportals)
 			auto p = Level->portalGroups[i];
 			double xdisp = p->mDisplacement.X;
 			double ydisp = p->mDisplacement.Y;
-			Printf(PRINT_LOG, "Portal #%d, %s, displacement = (%f,%f)\n", i, p->plane == 0 ? "floor" : "ceiling",
+			Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Portal #%d, %s, displacement = (%f,%f)\n", i, p->plane == 0 ? "floor" : "ceiling",
 				   xdisp, ydisp);
-			Printf(PRINT_LOG, "Coverage:\n");
+			Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Coverage:\n");
 			for (auto &sub : Level->subsectors)
 			{
 				auto port = sub.render_sector->GetPortalGroup(p->plane);
 				if (port == p)
 				{
-					Printf(PRINT_LOG, "\tSubsector %d (%d):\n\t\t", sub.Index(), sub.render_sector->sectornum);
+					Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\tSubsector %d (%d):\n\t\t", sub.Index(), sub.render_sector->sectornum);
 					for (unsigned k = 0; k < sub.numlines; k++)
 					{
-						Printf(PRINT_LOG, "(%.3f,%.3f), ", sub.firstline[k].v1->fX() + xdisp, sub.firstline[k].v1->fY() + ydisp);
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "(%.3f,%.3f), ", sub.firstline[k].v1->fX() + xdisp, sub.firstline[k].v1->fY() + ydisp);
 					}
-					Printf(PRINT_LOG, "\n\t\tCovered by subsectors:\n");
+					Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n\t\tCovered by subsectors:\n");
 					FPortalCoverage *cov = &sub.portalcoverage[p->plane];
 					for (int l = 0; l < cov->sscount; l++)
 					{
 						subsector_t *csub = &Level->subsectors[cov->subsectors[l]];
-						Printf(PRINT_LOG, "\t\t\t%5d (%4d): ", cov->subsectors[l], csub->render_sector->sectornum);
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\t\t\t%5d (%4d): ", cov->subsectors[l], csub->render_sector->sectornum);
 						for (unsigned m = 0; m < csub->numlines; m++)
 						{
-							Printf(PRINT_LOG, "(%.3f,%.3f), ", csub->firstline[m].v1->fX(), csub->firstline[m].v1->fY());
+							Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "(%.3f,%.3f), ", csub->firstline[m].v1->fX(), csub->firstline[m].v1->fY());
 						}
-						Printf(PRINT_LOG, "\n");
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n");
 					}
 				}
 			}

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2906,7 +2906,7 @@ void G_DoPlayDemo (void)
 		}
 		else
 		{
-			//Printf (PRINT_BOLD, "%s", eek);
+			//Printf (PRINTF_BOLD, "%s", eek);
 			gameaction = ga_nothing;
 		}
 	}

--- a/src/g_statusbar/hudmessages.cpp
+++ b/src/g_statusbar/hudmessages.cpp
@@ -915,7 +915,7 @@ void C_MidPrint(FFont* font, const char* msg, bool bold)
 	if (msg != nullptr)
 	{
 		auto color = (EColorRange)PrintColors[bold ? PRINTLEVELS + 1 : PRINTLEVELS];
-		Printf(PRINT_HIGH | PRINT_NONOTIFY, TEXTCOLOR_ESCAPESTR "%c%s\n%s\n%s\n", color, console_bar, msg, console_bar);
+		Printf(PRINT_HIGH, PRINTF_NONOTIFY, TEXTCOLOR_ESCAPESTR "%c%s\n%s\n%s\n", color, console_bar, msg, console_bar);
 
 		StatusBar->AttachMessage(Create<DHUDMessage>(font, msg, 1.5f, 0.375f, 0, 0, color, con_midtime), MAKE_ID('C', 'N', 'T', 'R'));
 	}

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -2033,7 +2033,7 @@ static int PatchPars (int dummy)
 		{
 			while ('\0' != *str)
 			{
-				if (isspace((unsigned char)*str))
+				if (*str != '\r' && isspace((unsigned char)*str))
 				{
 					return str;
 				}

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -2541,7 +2541,7 @@ static bool DoDehPatch()
 	{
 		if (PatchFile[25] < '3' && (PatchFile[25] < '2' || PatchFile[27] < '3'))
 		{
-			Printf (PRINT_BOLD, "\"%s\" is an old and unsupported DeHackEd patch\n", PatchName.GetChars());
+			Printf (PRINT_DEFAULT, PRINTF_BOLD, "\"%s\" is an old and unsupported DeHackEd patch\n", PatchName.GetChars());
 			PatchName = "";
 			delete[] PatchFile;
 			return false;
@@ -2560,7 +2560,7 @@ static bool DoDehPatch()
 		}
 		if (!cont || dversion == -1 || pversion == -1)
 		{
-			Printf (PRINT_BOLD, "\"%s\" is not a DeHackEd patch file\n", PatchName.GetChars());
+			Printf (PRINT_DEFAULT, PRINTF_BOLD, "\"%s\" is not a DeHackEd patch file\n", PatchName.GetChars());
 			PatchName = "";
 			delete[] PatchFile;
 			return false;

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -401,7 +401,7 @@ void FTextureAnimator::ParseAnim (FScanner &sc, ETextureType usetype)
 		}
 		else
 		{
-			Printf (PRINT_BOLD, "ANIMDEFS: Can't find %s\n", sc.String);
+			Printf (PRINT_DEFAULT, PRINTF_BOLD, "ANIMDEFS: Can't find %s\n", sc.String);
 		}
 	}
 

--- a/src/p_conversation.cpp
+++ b/src/p_conversation.cpp
@@ -716,7 +716,7 @@ static void TerminalResponse (const char *str)
 
 		if (StatusBar != NULL)
 		{
-			Printf(PRINT_NONOTIFY, "%s\n", str);
+			Printf(PRINT_DEFAULT, PRINTF_NONOTIFY, "%s\n", str);
 			// The message is positioned a bit above the menu choices, because
 			// merchants can tell you something like this but continue to show
 			// their dialogue screen. I think most other conversations use this

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -643,37 +643,37 @@ CCMD(dumpgeometry)
 		Printf("Geometry for %s\n", Level->MapName.GetChars());
 		for (auto &sector : Level->sectors)
 		{
-			Printf(PRINT_LOG, "Sector %d\n", sector.sectornum);
+			Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Sector %d\n", sector.sectornum);
 			for (int j = 0; j<sector.subsectorcount; j++)
 			{
 				subsector_t * sub = sector.subsectors[j];
 				
-				Printf(PRINT_LOG, "    Subsector %d - real sector = %d - %s\n", int(sub->Index()), sub->sector->sectornum, sub->hacked & 1 ? "hacked" : "");
+				Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "    Subsector %d - real sector = %d - %s\n", int(sub->Index()), sub->sector->sectornum, sub->hacked & 1 ? "hacked" : "");
 				for (uint32_t k = 0; k<sub->numlines; k++)
 				{
 					seg_t * seg = sub->firstline + k;
 					if (seg->linedef)
 					{
-						Printf(PRINT_LOG, "      (%4.4f, %4.4f), (%4.4f, %4.4f) - seg %d, linedef %d, side %d",
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "      (%4.4f, %4.4f), (%4.4f, %4.4f) - seg %d, linedef %d, side %d",
 							seg->v1->fX(), seg->v1->fY(), seg->v2->fX(), seg->v2->fY(),
 							seg->Index(), seg->linedef->Index(), seg->sidedef != seg->linedef->sidedef[0]);
 					}
 					else
 					{
-						Printf(PRINT_LOG, "      (%4.4f, %4.4f), (%4.4f, %4.4f) - seg %d, miniseg",
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "      (%4.4f, %4.4f), (%4.4f, %4.4f) - seg %d, miniseg",
 							seg->v1->fX(), seg->v1->fY(), seg->v2->fX(), seg->v2->fY(), seg->Index());
 					}
 					if (seg->PartnerSeg)
 					{
 						subsector_t * sub2 = seg->PartnerSeg->Subsector;
-						Printf(PRINT_LOG, ", back sector = %d, real back sector = %d", sub2->render_sector->sectornum, seg->PartnerSeg->frontsector->sectornum);
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, ", back sector = %d, real back sector = %d", sub2->render_sector->sectornum, seg->PartnerSeg->frontsector->sectornum);
 					}
 					else if (seg->backsector)
 					{
-						Printf(PRINT_LOG, ", back sector = %d (no partnerseg)", seg->backsector->sectornum);
+						Printf(PRINT_DEFAULT, PRINTF_LOGONLY, ", back sector = %d (no partnerseg)", seg->backsector->sectornum);
 					}
 					
-					Printf(PRINT_LOG, "\n");
+					Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n");
 				}
 			}
 		}

--- a/src/p_states.cpp
+++ b/src/p_states.cpp
@@ -1078,11 +1078,11 @@ void DumpStateHelper(FStateLabels *StateList, const FString &prefix)
 			const PClassActor *owner = FState::StaticFindStateOwner(StateList->Labels[i].State);
 			if (owner == NULL)
 			{
-				Printf(PRINT_LOG, "%s%s: invalid\n", prefix.GetChars(), StateList->Labels[i].Label.GetChars());
+				Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%s%s: invalid\n", prefix.GetChars(), StateList->Labels[i].Label.GetChars());
 			}
 			else
 			{
-				Printf(PRINT_LOG, "%s%s: %s\n", prefix.GetChars(), StateList->Labels[i].Label.GetChars(), FState::StaticGetStateName(StateList->Labels[i].State).GetChars());
+				Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%s%s: %s\n", prefix.GetChars(), StateList->Labels[i].Label.GetChars(), FState::StaticGetStateName(StateList->Labels[i].State).GetChars());
 			}
 		}
 		if (StateList->Labels[i].Children != NULL)
@@ -1097,9 +1097,9 @@ CCMD(dumpstates)
 	for (unsigned int i = 0; i < PClassActor::AllActorClasses.Size(); ++i)
 	{
 		PClassActor *info = PClassActor::AllActorClasses[i];
-		Printf(PRINT_LOG, "State labels for %s\n", info->TypeName.GetChars());
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "State labels for %s\n", info->TypeName.GetChars());
 		DumpStateHelper(info->GetStateLabels(), "");
-		Printf(PRINT_LOG, "----------------------------\n");
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "----------------------------\n");
 	}
 }
 

--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -748,7 +748,7 @@ void AActor::AttachLight(unsigned int count, const FLightDefaults *lightdef)
 		AttachedLights.Push(light);
 	}
 	lightdef->ApplyProperties(light);
-	light->Pos = Pos();
+	light->UpdateLocation();
 }
 
 //==========================================================================

--- a/src/playsim/fragglescript/t_func.cpp
+++ b/src/playsim/fragglescript/t_func.cpp
@@ -575,7 +575,7 @@ void FParser::SF_Include(void)
 
 void FParser::SF_Input(void)
 {
-	Printf(PRINT_BOLD,"input() function not available in Doom\n");
+	Printf(PRINT_DEFAULT, PRINTF_BOLD,"input() function not available in Doom\n");
 }
 
 //==========================================================================

--- a/src/playsim/fragglescript/t_prepro.cpp
+++ b/src/playsim/fragglescript/t_prepro.cpp
@@ -281,7 +281,7 @@ char *DFsScript::ProcessFindChar(char *datap, char find)
 			
 			if (labelname.Len() == 0)
 			{
-				Printf(PRINT_BOLD,"Script %d: ':' encountrered in incorrect position!\n",scriptnum);
+				Printf(PRINT_DEFAULT, PRINTF_BOLD,"Script %d: ':' encountrered in incorrect position!\n",scriptnum);
 			}
 
 			DFsVariable *newlabel = NewVariable(labelname, svt_label);

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -8758,7 +8758,7 @@ scriptwait:
 					if (type & HUDMSG_LOG)
 					{
 						int consolecolor = color >= CR_BRICK && color <= CR_YELLOW ? color + 'A' : '-';
-						Printf(PRINT_NONOTIFY, "\n" TEXTCOLOR_ESCAPESTR "%c%s\n%s\n%s\n", consolecolor, console_bar, work.GetChars(), console_bar);
+						Printf(PRINT_DEFAULT, PRINTF_NONOTIFY, "\n" TEXTCOLOR_ESCAPESTR "%c%s\n%s\n%s\n", consolecolor, console_bar, work.GetChars(), console_bar);
 					}
 				}
 			}
@@ -9774,7 +9774,7 @@ scriptwait:
 				static bool StrlenInvalidPrintedAlready = false;
 				if (!StrlenInvalidPrintedAlready)
 				{
-					Printf(PRINT_BOLD, "Warning: ACS function strlen called with invalid string argument.\n");
+					Printf(PRINT_DEFAULT, PRINTF_BOLD, "Warning: ACS function strlen called with invalid string argument.\n");
 					StrlenInvalidPrintedAlready = true;
 				}
 				STACK(1) = 0;
@@ -10441,13 +10441,13 @@ int P_StartScript (FLevelLocals *Level, AActor *who, line_t *where, int script, 
 				// make sure only net scripts are run.
 				if (!(scriptdata->Flags & SCRIPTF_Net))
 				{
-					Printf(PRINT_BOLD, "%s tried to puke %s (\n",
+					Printf(PRINT_DEFAULT, PRINTF_BOLD, "%s tried to puke %s (\n",
 						who->player->userinfo.GetName(), ScriptPresentation(script).GetChars());
 					for (int i = 0; i < argcount; ++i)
 					{
-						Printf(PRINT_BOLD, "%d%s", args[i], i == argcount-1 ? "" : ", ");
+						Printf(PRINT_DEFAULT, PRINTF_BOLD, "%d%s", args[i], i == argcount-1 ? "" : ", ");
 					}
-					Printf(PRINT_BOLD, ")\n");
+					Printf(PRINT_DEFAULT, PRINTF_BOLD, ")\n");
 					return false;
 				}
 			}

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -610,7 +610,7 @@ void P_GiveSecret(FLevelLocals *Level, AActor *actor, bool printmessage, bool pl
 				C_MidPrint(nullptr, GStrings["SECRETMESSAGE"]);
 				if (showsecretsector && sectornum >= 0) 
 				{
-					Printf(PRINT_NONOTIFY, "Secret found in sector %d\n", sectornum);
+					Printf(PRINT_DEFAULT, PRINTF_NONOTIFY, "Secret found in sector %d\n", sectornum);
 				}
 			}
 			if (playsound) S_Sound (CHAN_AUTO, CHANF_UI, "misc/secret", 1, ATTN_NORM);

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -429,7 +429,7 @@ void player_t::SetLogText (const char *text)
 	if (mo && mo->CheckLocalView())
 	{
 		// Print log text to console
-		Printf(PRINT_NONOTIFY, TEXTCOLOR_GOLD "%s\n", LogText[0] == '$' ? GStrings(text + 1) : text);
+		Printf(PRINT_DEFAULT, PRINTF_NONOTIFY, TEXTCOLOR_GOLD "%s\n", LogText[0] == '$' ? GStrings(text + 1) : text);
 	}
 }
 

--- a/src/r_data/r_sections.cpp
+++ b/src/r_data/r_sections.cpp
@@ -837,7 +837,7 @@ void PrintSections(FLevelLocals *Level)
 	{
 		auto &section = container.allSections[i];
 
-		Printf(PRINT_LOG, "\n\nStart of section %d sector %d, mapsection %d, bounds=(%2.3f, %2.3f, %2.3f, %2.3f)\n", i, section.sector->Index(), section.mapsection,
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n\nStart of section %d sector %d, mapsection %d, bounds=(%2.3f, %2.3f, %2.3f, %2.3f)\n", i, section.sector->Index(), section.mapsection,
 			section.bounds.left, section.bounds.top, section.bounds.right, section.bounds.bottom);
 
 		for (unsigned j = 0; j < section.segments.Size(); j++)
@@ -845,7 +845,7 @@ void PrintSections(FLevelLocals *Level)
 			auto &seg = section.segments[j];
 			if (j > 0 && seg.start != section.segments[j - 1].end)
 			{
-				Printf(PRINT_LOG, "\n");
+				Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n");
 			}
 			FString partnerstring;
 			if (seg.partner)
@@ -859,17 +859,17 @@ void PrintSections(FLevelLocals *Level)
 			}
 			if (seg.sidedef)
 			{
-				Printf(PRINT_LOG, "segment for sidedef %d (line %d) from (%2.6f, %2.6f) to (%2.6f, %2.6f)%s\n", 
+				Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "segment for sidedef %d (line %d) from (%2.6f, %2.6f) to (%2.6f, %2.6f)%s\n", 
 					seg.sidedef->Index(), seg.sidedef->linedef->Index(), seg.start->fX(), seg.start->fY(), seg.end->fX(), seg.end->fY(), partnerstring.GetChars());
 			}
 			else
 			{
-				Printf(PRINT_LOG, "segment for seg from (%2.6f, %2.6f) to (%2.6f, %2.6f)%s\n", 
+				Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "segment for seg from (%2.6f, %2.6f) to (%2.6f, %2.6f)%s\n", 
 					seg.start->fX(), seg.start->fY(), seg.end->fX(), seg.end->fY(), partnerstring.GetChars());
 			}
 		}
 	}
-	Printf(PRINT_LOG, "%d sectors, %d subsectors, %d sections\n\n", Level->sectors.Size(), Level->subsectors.Size(), container.allSections.Size());
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%d sectors, %d subsectors, %d sections\n\n", Level->sectors.Size(), Level->subsectors.Size(), container.allSections.Size());
 }
 
 

--- a/src/r_data/sprites.cpp
+++ b/src/r_data/sprites.cpp
@@ -612,7 +612,7 @@ void R_InitSkins (void)
 			strncpy (key, sc.String, sizeof(key)-1);
 			if (!sc.GetString() || sc.String[0] != '=')
 			{
-				Printf (PRINT_BOLD, "Bad format for skin %d: %s\n", (int)i, key);
+				Printf (PRINT_DEFAULT, PRINTF_BOLD, "Bad format for skin %d: %s\n", (int)i, key);
 				break;
 			}
 			sc.GetString ();
@@ -624,7 +624,7 @@ void R_InitSkins (void)
 					if (Skins[i].Name.CompareNoCase(Skins[j].Name) == 0)
 					{
 						Skins[i].Name.Format("skin%u", i);
-						Printf (PRINT_BOLD, "Skin %s duplicated as %s\n", Skins[j].Name.GetChars(), Skins[i].Name.GetChars());
+						Printf (PRINT_DEFAULT, PRINTF_BOLD, "Skin %s duplicated as %s\n", Skins[j].Name.GetChars(), Skins[i].Name.GetChars());
 						break;
 					}
 				}
@@ -861,7 +861,7 @@ void R_InitSkins (void)
 
 				if (spr == 0 && maxframe <= 0)
 				{
-					Printf (PRINT_BOLD, "Skin %s (#%u) has no frames. Removing.\n", Skins[i].Name.GetChars(), i);
+					Printf (PRINT_DEFAULT, PRINTF_BOLD, "Skin %s (#%u) has no frames. Removing.\n", Skins[i].Name.GetChars(), i);
 					remove = true;
 					break;
 				}

--- a/src/rendering/hwrenderer/hw_vertexbuilder.cpp
+++ b/src/rendering/hwrenderer/hw_vertexbuilder.cpp
@@ -273,16 +273,16 @@ static void CreateIndexedFlatVertices(FFlatVertexBuffer* fvb, TArray<sector_t>& 
 	/*
 	for (auto &vert : verts)
 	{
-		Printf(PRINT_LOG, "Sector %d\n", i);
-		Printf(PRINT_LOG, "%d vertices, %d indices\n", vert.vertices.Size(), vert.indices.Size());
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Sector %d\n", i);
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%d vertices, %d indices\n", vert.vertices.Size(), vert.indices.Size());
 		int j = 0;
 		for (auto &v : vert.vertices)
 		{
-			Printf(PRINT_LOG, "    %d: (%2.3f, %2.3f)\n", j++, v.vertex->fX(), v.vertex->fY());
+			Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "    %d: (%2.3f, %2.3f)\n", j++, v.vertex->fX(), v.vertex->fY());
 		}
 		for (unsigned i=0;i<vert.indices.Size();i+=3)
 		{
-			Printf(PRINT_LOG, "     %d, %d, %d\n", vert.indices[i], vert.indices[i + 1], vert.indices[i + 2]);
+			Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "     %d, %d, %d\n", vert.indices[i], vert.indices[i + 1], vert.indices[i + 2]);
 		}
 
 		i++;

--- a/src/rendering/swrenderer/scene/r_scene.cpp
+++ b/src/rendering/swrenderer/scene/r_scene.cpp
@@ -451,7 +451,7 @@ namespace swrenderer
 		FString out;
 		out.Format("frame=%04.1f ms  walls=%04.1f ms  planes=%04.1f ms  masked=%04.1f ms  %d counts",
 			f_acc / acc_c, w_acc / acc_c, p_acc / acc_c, m_acc / acc_c, acc_c);
-		Printf(PRINT_LOG, "%s\n", out.GetChars());
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%s\n", out.GetChars());
 		return out;
 	}
 

--- a/src/utility/nodebuilder/nodebuild.cpp
+++ b/src/utility/nodebuilder/nodebuild.cpp
@@ -146,7 +146,7 @@ int FNodeBuilder::CreateNode (uint32_t set, unsigned int count, fixed_t bbox[4])
 
 		SplitSegs (set, node, splitseg, set1, set2, count1, count2);
 		D(PrintSet (1, set1));
-		D(Printf (PRINT_LOG, "(%d,%d) delta (%d,%d) from seg %d\n", node.x>>16, node.y>>16, node.dx>>16, node.dy>>16, splitseg));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "(%d,%d) delta (%d,%d) from seg %d\n", node.x>>16, node.y>>16, node.dx>>16, node.dy>>16, splitseg));
 		D(PrintSet (2, set2));
 		node.intchildren[0] = CreateNode (set1, count1, node.nb_bbox[0]);
 		node.intchildren[1] = CreateNode (set2, count2, node.nb_bbox[1]);
@@ -169,7 +169,7 @@ int FNodeBuilder::CreateSubsector (uint32_t set, fixed_t bbox[4])
 	bbox[BOXTOP] = bbox[BOXRIGHT] = INT_MIN;
 	bbox[BOXBOTTOM] = bbox[BOXLEFT] = INT_MAX;
 
-	D(Printf (PRINT_LOG, "Subsector from set %d\n", set));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Subsector from set %d\n", set));
 
 	assert (set != UINT_MAX);
 
@@ -190,7 +190,7 @@ int FNodeBuilder::CreateSubsector (uint32_t set, fixed_t bbox[4])
 
 	SegsStuffed += count;
 
-	D(Printf (PRINT_LOG, "bbox (%d,%d)-(%d,%d)\n", bbox[BOXLEFT]>>16, bbox[BOXBOTTOM]>>16, bbox[BOXRIGHT]>>16, bbox[BOXTOP]>>16));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "bbox (%d,%d)-(%d,%d)\n", bbox[BOXLEFT]>>16, bbox[BOXBOTTOM]>>16, bbox[BOXRIGHT]>>16, bbox[BOXTOP]>>16));
 
 	return ssnum;
 }
@@ -226,10 +226,10 @@ void FNodeBuilder::CreateSubsectorsForReal ()
 		qsort (&SegList[firstline], sub.numlines, sizeof(USegPtr), SortSegs);
 
 		// Convert seg pointers into indices
-		D(Printf (PRINT_LOG, "Output subsector %d:\n", Subsectors.Size()));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Output subsector %d:\n", Subsectors.Size()));
 		for (unsigned int i = firstline; i < SegList.Size(); ++i)
 		{
-			D(Printf (PRINT_LOG, "  Seg %5d%c%d(%5d,%5d)-%d(%5d,%5d)  [%08x,%08x]-[%08x,%08x]\n", SegList[i].SegPtr - &Segs[0],
+			D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "  Seg %5d%c%d(%5d,%5d)-%d(%5d,%5d)  [%08x,%08x]-[%08x,%08x]\n", SegList[i].SegPtr - &Segs[0],
 				SegList[i].SegPtr->linedef == -1 ? '+' : ' ',
 				SegList[i].SegPtr->v1,
 				Vertices[SegList[i].SegPtr->v1].x>>16,
@@ -320,7 +320,7 @@ bool FNodeBuilder::CheckSubsector (uint32_t set, node_t &node, uint32_t &splitse
 
 	do
 	{
-		D(Printf (PRINT_LOG, " - seg %d%c(%d,%d)-(%d,%d) line %d front %d back %d\n", seg,
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, " - seg %d%c(%d,%d)-(%d,%d) line %d front %d back %d\n", seg,
 			Segs[seg].linedef == -1 ? '+' : ' ',
 			Vertices[Segs[seg].v1].x>>16, Vertices[Segs[seg].v1].y>>16,
 			Vertices[Segs[seg].v2].x>>16, Vertices[Segs[seg].v2].y>>16,
@@ -360,7 +360,7 @@ bool FNodeBuilder::CheckSubsector (uint32_t set, node_t &node, uint32_t &splitse
 		return false;
 	}
 
-	D(Printf(PRINT_LOG, "Need to synthesize a splitter for set %d on seg %d\n", set, seg));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Need to synthesize a splitter for set %d on seg %d\n", set, seg));
 	splitseg = UINT_MAX;
 
 	// This is a very simple and cheap "fix" for subsectors with segs
@@ -394,7 +394,7 @@ bool FNodeBuilder::CheckSubsectorOverlappingSegs (uint32_t set, node_t &node, ui
 				{ // Do not put minisegs into a new subsector.
 					std::swap (seg1, seg2);
 				}
-				D(Printf(PRINT_LOG, "Need to synthesize a splitter for set %d on seg %d (ov)\n", set, seg2));
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Need to synthesize a splitter for set %d on seg %d (ov)\n", set, seg2));
 				splitseg = UINT_MAX;
 
 				return ShoveSegBehind (set, node, seg2, seg1);
@@ -454,7 +454,7 @@ int FNodeBuilder::SelectSplitter (uint32_t set, node_t &node, uint32_t &splitseg
 
 	memset (&PlaneChecked[0], 0, PlaneChecked.Size());
 
-	D(Printf (PRINT_LOG, "Processing set %d\n", set));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Processing set %d\n", set));
 
 	while (seg != UINT_MAX)
 	{
@@ -477,7 +477,7 @@ int FNodeBuilder::SelectSplitter (uint32_t set, node_t &node, uint32_t &splitseg
 
 				int value = Heuristic (node, set, nosplit);
 
-				D(Printf (PRINT_LOG, "Seg %5d, ld %d (%5d,%5d)-(%5d,%5d) scores %d\n", seg, Segs[seg].linedef, node.x>>16, node.y>>16,
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Seg %5d, ld %d (%5d,%5d)-(%5d,%5d) scores %d\n", seg, Segs[seg].linedef, node.x>>16, node.y>>16,
 					(node.x+node.dx)>>16, (node.y+node.dy)>>16, value));
 
 				if (value > bestvalue)
@@ -497,11 +497,11 @@ int FNodeBuilder::SelectSplitter (uint32_t set, node_t &node, uint32_t &splitseg
 
 	if (bestseg == UINT_MAX)
 	{ // No lines split any others into two sets, so this is a convex region.
-	D(Printf (PRINT_LOG, "set %d, step %d, nosplit %d has no good splitter (%d)\n", set, step, nosplit, nosplitters));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "set %d, step %d, nosplit %d has no good splitter (%d)\n", set, step, nosplit, nosplitters));
 		return nosplitters ? -1 : 0;
 	}
 
-	D(Printf (PRINT_LOG, "split seg %u in set %d, score %d, step %d, nosplit %d\n", bestseg, set, bestvalue, step, nosplit));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "split seg %u in set %d, score %d, step %d, nosplit %d\n", bestseg, set, bestvalue, step, nosplit));
 
 	splitseg = bestseg;
 	SetNodeFromSeg (node, &Segs[bestseg]);
@@ -610,7 +610,7 @@ int FNodeBuilder::Heuristic (node_t &node, uint32_t set, bool honorNoSplit)
 			{
 				if (honorNoSplit)
 				{
-					D(Printf (PRINT_LOG, "Splits seg %d\n", i));
+					D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Splits seg %d\n", i));
 					return -1;
 				}
 				else
@@ -677,7 +677,7 @@ int FNodeBuilder::Heuristic (node_t &node, uint32_t set, bool honorNoSplit)
 	// determine which sector it lies inside.
 	if (realSegs[0] == 0 || realSegs[1] == 0)
 	{
-		D(Printf (PRINT_LOG, "Leaves a side with only mini segs\n"));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Leaves a side with only mini segs\n"));
 		return -1;
 	}
 
@@ -686,7 +686,7 @@ int FNodeBuilder::Heuristic (node_t &node, uint32_t set, bool honorNoSplit)
 	// is not neccesarily bad, just undesirable.
 	if (honorNoSplit && (specialSegs[0] == realSegs[0] || specialSegs[1] == realSegs[1]))
 	{
-		D(Printf (PRINT_LOG, "Leaves a side with only special segs\n"));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Leaves a side with only special segs\n"));
 		return -1;
 	}
 
@@ -978,7 +978,7 @@ uint32_t FNodeBuilder::SplitSeg (uint32_t segnum, int splitvert, int v1InFront)
 
 	Segs.Push (newseg);
 
-	D(Printf (PRINT_LOG, "Split seg %d to get seg %d\n", segnum, newnum));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Split seg %d to get seg %d\n", segnum, newnum));
 
 	return newnum;
 }
@@ -1058,15 +1058,15 @@ double FNodeBuilder::InterceptVector (const node_t &splitter, const FPrivSeg &se
 
 void FNodeBuilder::PrintSet (int l, uint32_t set)
 {
-	Printf (PRINT_LOG, "set %d:\n", l);
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "set %d:\n", l);
 	for (; set != UINT_MAX; set = Segs[set].next)
 	{
-		Printf (PRINT_LOG, "\t%u(%d)%c%d(%d,%d)-%d(%d,%d)\n", set, Segs[set].frontsector->sectornum,
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\t%u(%d)%c%d(%d,%d)-%d(%d,%d)\n", set, Segs[set].frontsector->sectornum,
 			Segs[set].linedef == -1 ? '+' : ':',
 			Segs[set].v1,
 			Vertices[Segs[set].v1].x>>16, Vertices[Segs[set].v1].y>>16,
 			Segs[set].v2,
 			Vertices[Segs[set].v2].x>>16, Vertices[Segs[set].v2].y>>16);
 	}
-	Printf (PRINT_LOG, "*\n");
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "*\n");
 }

--- a/src/utility/nodebuilder/nodebuild_events.cpp
+++ b/src/utility/nodebuilder/nodebuild_events.cpp
@@ -220,7 +220,7 @@ void FEventTree::PrintTree (const FEvent *event) const
 		PrintTree(event->Left);
 		sprintf(buff, " Distance %g, vertex %d, seg %u\n",
 			g_sqrt(event->Distance/4294967296.0), event->Info.Vertex, (unsigned)event->Info.FrontSeg);
-		Printf(PRINT_LOG, "%s", buff);
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%s", buff);
 		PrintTree(event->Right);
 	}
 }

--- a/src/utility/nodebuilder/nodebuild_extract.cpp
+++ b/src/utility/nodebuilder/nodebuild_extract.cpp
@@ -77,7 +77,7 @@ void FNodeBuilder::Extract (FLevelLocals &theLevel)
 	memcpy (&outNodes[0], &Nodes[0], nodeCount*sizeof(node_t));
 	for (unsigned i = 0; i < nodeCount; ++i)
 	{
-		D(Printf(PRINT_LOG, "Node %d:  Splitter[%08x,%08x] [%08x,%08x]\n", i,
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Node %d:  Splitter[%08x,%08x] [%08x,%08x]\n", i,
 			outNodes[i].x, outNodes[i].y, outNodes[i].dx, outNodes[i].dy));
 		// Go backwards because on 64-bit systems, both of the intchildren are
 		// inside the first in-game child.
@@ -85,12 +85,12 @@ void FNodeBuilder::Extract (FLevelLocals &theLevel)
 		{
 			if (outNodes[i].intchildren[j] & 0x80000000)
 			{
-				D(Printf(PRINT_LOG, "  subsector %d\n", outNodes[i].intchildren[j] & 0x7FFFFFFF));
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "  subsector %d\n", outNodes[i].intchildren[j] & 0x7FFFFFFF));
 				outNodes[i].children[j] = (uint8_t *)(&outSubs[(outNodes[i].intchildren[j] & 0x7fffffff)]) + 1;
 			}
 			else
 			{
-				D(Printf(PRINT_LOG, "  node %d\n", outNodes[i].intchildren[j]));
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "  node %d\n", outNodes[i].intchildren[j]));
 				outNodes[i].children[j] = &outNodes[outNodes[i].intchildren[j]];
 			}
 		}
@@ -143,7 +143,7 @@ void FNodeBuilder::Extract (FLevelLocals &theLevel)
 			const FPrivSeg *org = &Segs[SegList[i].SegNum];
 			seg_t *out = &outSegs[i];
 
-			D(Printf(PRINT_LOG, "Seg %d: v1(%d) -> v2(%d)\n", i, org->v1, org->v2));
+			D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Seg %d: v1(%d) -> v2(%d)\n", i, org->v1, org->v2));
 
 			out->v1 = &outVerts[org->v1];
 			out->v2 = &outVerts[org->v2];
@@ -186,19 +186,19 @@ void FNodeBuilder::ExtractMini (FMiniBSP *bsp)
 	memcpy(&bsp->Nodes[0], &Nodes[0], Nodes.Size()*sizeof(node_t));
 	for (i = 0; i < Nodes.Size(); ++i)
 	{
-		D(Printf(PRINT_LOG, "Node %d:\n", i));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Node %d:\n", i));
 		// Go backwards because on 64-bit systems, both of the intchildren are
 		// inside the first in-game child.
 		for (int j = 1; j >= 0; --j)
 		{
 			if (bsp->Nodes[i].intchildren[j] & 0x80000000)
 			{
-				D(Printf(PRINT_LOG, "  subsector %d\n", bsp->Nodes[i].intchildren[j] & 0x7FFFFFFF));
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "  subsector %d\n", bsp->Nodes[i].intchildren[j] & 0x7FFFFFFF));
 				bsp->Nodes[i].children[j] = (uint8_t *)&bsp->Subsectors[bsp->Nodes[i].intchildren[j] & 0x7fffffff] + 1;
 			}
 			else
 			{
-				D(Printf(PRINT_LOG, "  node %d\n", bsp->Nodes[i].intchildren[j]));
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "  node %d\n", bsp->Nodes[i].intchildren[j]));
 				bsp->Nodes[i].children[j] = &bsp->Nodes[bsp->Nodes[i].intchildren[j]];
 			}
 		}
@@ -235,7 +235,7 @@ void FNodeBuilder::ExtractMini (FMiniBSP *bsp)
 			const FPrivSeg *org = &Segs[SegList[i].SegNum];
 			seg_t *out = &bsp->Segs[i];
 
-			D(Printf(PRINT_LOG, "Seg %d: v1(%d) -> v2(%d)\n", i, org->v1, org->v2));
+			D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Seg %d: v1(%d) -> v2(%d)\n", i, org->v1, org->v2));
 
 			out->v1 = &bsp->Verts[org->v1];
 			out->v2 = &bsp->Verts[org->v2];
@@ -305,12 +305,12 @@ int FNodeBuilder::CloseSubsector (TArray<glseg_t> &segs, int subsector, vertex_t
 	firstVert = seg->v1;
 
 #ifdef DD
-	Printf(PRINT_LOG, "--%d--\n", subsector);
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "--%d--\n", subsector);
 	for (j = first; j < max; ++j)
 	{
 		seg = &Segs[SegList[j].SegNum];
 		angle_t ang = PointToAngle (Vertices[seg->v1].x - midx, Vertices[seg->v1].y - midy);
-		Printf(PRINT_LOG, "%d%c %5d(%5d,%5d)->%5d(%5d,%5d) - %3.5f  %d,%d  [%08x,%08x]-[%08x,%08x]\n", j,
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%d%c %5d(%5d,%5d)->%5d(%5d,%5d) - %3.5f  %d,%d  [%08x,%08x]-[%08x,%08x]\n", j,
 			seg->linedef == -1 ? '+' : ':',
 			seg->v1, Vertices[seg->v1].x>>16, Vertices[seg->v1].y>>16,
 			seg->v2, Vertices[seg->v2].x>>16, Vertices[seg->v2].y>>16,
@@ -325,7 +325,7 @@ int FNodeBuilder::CloseSubsector (TArray<glseg_t> &segs, int subsector, vertex_t
 	{ // A well-behaved subsector. Output the segs sorted by the angle formed by connecting
 	  // the subsector's center to their first vertex.
 
-		D(Printf(PRINT_LOG, "Well behaved subsector\n"));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Well behaved subsector\n"));
 		for (i = first + 1; i < max; ++i)
 		{
 			angle_t bestdiff = ANGLE_MAX;
@@ -364,7 +364,7 @@ int FNodeBuilder::CloseSubsector (TArray<glseg_t> &segs, int subsector, vertex_t
 				count++;
 			}
 #ifdef DD
-			Printf(PRINT_LOG, "+%d\n", bestj);
+			Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "+%d\n", bestj);
 #endif
 			prevAngle -= bestdiff;
 			seg->storedseg = PushGLSeg (segs, seg, outVerts);
@@ -377,7 +377,7 @@ int FNodeBuilder::CloseSubsector (TArray<glseg_t> &segs, int subsector, vertex_t
 			}
 		}
 #ifdef DD
-		Printf(PRINT_LOG, "\n");
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "\n");
 #endif
 	}
 	else
@@ -390,7 +390,7 @@ int FNodeBuilder::CloseSubsector (TArray<glseg_t> &segs, int subsector, vertex_t
 	  //          to the start seg.
 	  // A dot product serves to determine distance from the start seg.
 
-		D(Printf(PRINT_LOG, "degenerate subsector\n"));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "degenerate subsector\n"));
 
 		// Stage 1. Go forward.
 		count += OutputDegenerateSubsector (segs, subsector, true, 0, prev, outVerts);
@@ -408,10 +408,10 @@ int FNodeBuilder::CloseSubsector (TArray<glseg_t> &segs, int subsector, vertex_t
 		count++;
 	}
 #ifdef DD
-	Printf(PRINT_LOG, "Output GL subsector %d:\n", subsector);
+	Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Output GL subsector %d:\n", subsector);
 	for (i = segs.Size() - count; i < (int)segs.Size(); ++i)
 	{
-		Printf(PRINT_LOG, "  Seg %5d%c(%5d,%5d)-(%5d,%5d)  [%08x,%08x]-[%08x,%08x]\n", i,
+		Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "  Seg %5d%c(%5d,%5d)-(%5d,%5d)  [%08x,%08x]-[%08x,%08x]\n", i,
 			segs[i].linedef == NULL ? '+' : ' ',
 			segs[i].v1->fixX()>>16,
 			segs[i].v1->fixY()>>16,

--- a/src/utility/nodebuilder/nodebuild_gl.cpp
+++ b/src/utility/nodebuilder/nodebuild_gl.cpp
@@ -83,7 +83,7 @@ double FNodeBuilder::AddIntersection (const node_t &node, int vertex)
 // seg information will be messed up in the generated tree.
 void FNodeBuilder::FixSplitSharers (const node_t &node)
 {
-	D(Printf(PRINT_LOG, "events:\n"));
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "events:\n"));
 	D(Events.PrintTree());
 	for (unsigned int i = 0; i < SplitSharers.Size(); ++i)
 	{
@@ -107,7 +107,7 @@ void FNodeBuilder::FixSplitSharers (const node_t &node)
 			Vertices[Segs[seg].v2].x>>16,
 			Vertices[Segs[seg].v2].y>>16,
 			SplitSharers[i].Distance, event->Distance));
-		D(Printf(PRINT_LOG, "%s", buff));
+		D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "%s", buff));
 
 		if (SplitSharers[i].Forward)
 		{
@@ -130,7 +130,7 @@ void FNodeBuilder::FixSplitSharers (const node_t &node)
 
 		while (event != NULL && next != NULL && event->Info.Vertex != v2)
 		{
-			D(Printf(PRINT_LOG, "Forced split of seg %d(%d->%d) at %d(%d,%d)\n", seg,
+			D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Forced split of seg %d(%d->%d) at %d(%d,%d)\n", seg,
 				Segs[seg].v1, Segs[seg].v2,
 				event->Info.Vertex,
 				Vertices[event->Info.Vertex].x>>16,
@@ -222,7 +222,7 @@ void FNodeBuilder::AddMinisegs (const node_t &node, uint32_t splitseg, uint32_t 
 						);
 				}
 
-				D(Printf (PRINT_LOG, "**Minisegs** %d/%d added %d(%d,%d)->%d(%d,%d)\n", fnseg, bnseg,
+				D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "**Minisegs** %d/%d added %d(%d,%d)->%d(%d,%d)\n", fnseg, bnseg,
 					prev->Info.Vertex,
 					Vertices[prev->Info.Vertex].x>>16, Vertices[prev->Info.Vertex].y>>16,
 					event->Info.Vertex,

--- a/src/utility/nodebuilder/nodebuild_utility.cpp
+++ b/src/utility/nodebuilder/nodebuild_utility.cpp
@@ -183,7 +183,7 @@ int FNodeBuilder::CreateSeg (int linenum, int sidenum)
 	segnum = (int)Segs.Push (seg);
 	Vertices[seg.v1].segs = segnum;
 	Vertices[seg.v2].segs2 = segnum;
-	D(Printf(PRINT_LOG, "Seg %4d: From line %d, side %s (%5d,%5d)-(%5d,%5d)  [%08x,%08x]-[%08x,%08x]\n", segnum, linenum, sidenum ? "back " : "front",
+	D(Printf(PRINT_DEFAULT, PRINTF_LOGONLY, "Seg %4d: From line %d, side %s (%5d,%5d)-(%5d,%5d)  [%08x,%08x]-[%08x,%08x]\n", segnum, linenum, sidenum ? "back " : "front",
 		Vertices[seg.v1].x>>16, Vertices[seg.v1].y>>16, Vertices[seg.v2].x>>16, Vertices[seg.v2].y>>16,
 		Vertices[seg.v1].x, Vertices[seg.v1].y, Vertices[seg.v2].x, Vertices[seg.v2].y));
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -128,16 +128,21 @@ enum EMonospacing
 
 enum EPrintLevel
 {
-	PRINT_LOW,		// pickup messages
+	PRINT_DEFAULT,	// Default to PRINT_LOW
+	PRINT_LOW = 0,	// pickup messages
 	PRINT_MEDIUM,	// death messages
 	PRINT_HIGH,		// critical messages
 	PRINT_CHAT,		// chat messages
 	PRINT_TEAMCHAT,	// chat messages from a teammate
-	PRINT_LOG,		// only to logfile
-	PRINT_BOLD = 200,				// What Printf_Bold used
-	PRINT_TYPES = 1023,		// Bitmask.
-	PRINT_NONOTIFY = 1024,	// Flag - do not add to notify buffer
-	PRINT_NOLOG = 2048,		// Flag - do not print to log file
+};
+
+enum EPrintFlags
+{
+	PRINTF_DEFAULT,			// Default to normal print
+	PRINTF_BOLD = 200,		// What Printf_Bold used
+	PRINTF_LOGONLY = 512,	// Flag - Only print to logfile
+	PRINTF_NONOTIFY = 1024,	// Flag - Do not add to notify buffer
+	PRINTF_NOLOG = 2048,	// Flag - Do not print to log file
 };
 
 struct _ native	// These are the global variables, the struct is only here to avoid extending the parser for this.
@@ -501,6 +506,7 @@ struct Console native
 {
 	native static void HideConsole();
 	native static vararg void Printf(string fmt, ...);
+	native static vararg void PrintString(int printlevel, int printflags, string fmt, ...);
 }
 
 struct CVar native

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -230,7 +230,7 @@ class BaseStatusBar : StatusBarCore native
 	virtual bool MustDrawLog(int state) { return true; }
 
 	// [MK] let the HUD handle notifications and centered print messages
-	virtual bool ProcessNotify(EPrintLevel printlevel, String outline) { return false; }
+	virtual bool ProcessNotify(EPrintLevel printlevel, String outline, EPrintFlags printflags = PRINTF_DEFAULT) { return false; }
 	virtual void FlushNotify() {}
 	virtual bool ProcessMidPrint(Font fnt, String msg, bool bold) { return false; }
 	// [MK] let the HUD handle drawing the chat prompt


### PR DESCRIPTION
Exposes print level functionality to ZScript.
- Split print flags into separate enumerator from print levels
- Updated PrintString function, notification buffer AddString function, and console buffer AddText function to take and handle print level and print flags as two separate variables
- Added new overload Printf and VPrintf functions that take print level and print flags as separate parameters
- Added Console.PrintString ZScript function that takes print level and flags as the first two parameters, then standard printf-style input after that
- Updated all instances in the code where a print flag was used to use the new syntax and flag enumerations.
- Updated a hard-coded flag value (PRINT_BOLD instead of 200 in console buffer)

Use:
`Console.PrintString(PRINT_HIGH, PRINTF_NOLOG, "Printing to screen and console without adding to log file");`

Basic demo file of the new ZScript call: [printlevel.zip](https://github.com/coelckers/gzdoom/files/6602034/printlevel.zip)
