### PR TITLE
Make sprite shadows ignore float bob

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -800,9 +800,8 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		z = thing->floorz;
 	}
-
 	// [RH] Make floatbobbing a renderer-only effect.
-	if (thing->flags2 & MF2_FLOATBOB)
+	else if (thing->flags2 & MF2_FLOATBOB)
 	{
 		float fz = thing->GetBobOffset(vp.TicFrac);
 		z += fz;


### PR DESCRIPTION
Fixes sprite shadows bobbing up and down, clipping into the ground if their parent actor has float bob enabled.