### PR TITLE
Fixed impassable exit line in 007ltsd.wad E4M7

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -2120,7 +2120,14 @@ class LevelCompatibility : LevelPostProcessor
 				// fix broken switch to raise the exit bridge
 				SetLineSpecial(1248, Floor_RaiseByValue, 39, 8, 512);
 				break;
-			}			
+			}
+
+			case '1C35384B22BD805F51B3B2C9D17D62E4': // 007ltsd.wad E4M7
+			{
+				// Fix impassable exit line
+				SetLineFlags(6842, 0, Line.ML_BLOCKING); 
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?p=1191903#p1191903) for details. The only exit line in the map is marked as impassable and cannot be triggered. I have no idea how it could've worked before, but apparently it did somehow, since I didn't find any complaints about this issue.