### PR TITLE
Add Windows 11 detection

### DIFF
--- a/src/common/platform/win32/i_system.cpp
+++ b/src/common/platform/win32/i_system.cpp
@@ -199,7 +199,7 @@ void I_DetectOS(void)
 		}
 		else if (info.dwMajorVersion == 10)
 		{
-			osname = (info.wProductType == VER_NT_WORKSTATION) ? "10 (or higher)" : "Server 2016 (or higher)";
+			osname = (info.wProductType == VER_NT_WORKSTATION) ? (info.dwBuildNumber >= 22000 ? "11 (or higher)" : "10") : "Server 2016 (or higher)";
 			sys_ostype = 3; // modern OS
 		}
 		break;


### PR DESCRIPTION
I left out Server detection until Windows Server 2022 build 22000 or later releases.