### PR TITLE
implement jumps in option menus

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
@@ -218,6 +218,11 @@ class OptionMenu : Menu
 					break;
 				}
 			}
+			if (mDesc.mSelectedItem <= mDesc.mScrollTop + mDesc.mScrollPos
+				|| mDesc.mSelectedItem >= VisBottom)
+			{
+				mDesc.mScrollPos = MAX(mDesc.mSelectedItem - mDesc.mScrollTop - 1, 0);
+			}
 		}
 		return Super.OnUIEvent(ev);
 	}

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
@@ -201,6 +201,24 @@ class OptionMenu : Menu
 			}
 			return true;
 		}
+		else if (ev.type == UIEvent.Type_Char)
+		{
+			String key = String.Format("%c", ev.keyChar).MakeLower();
+			int itemsNumber = mDesc.mItems.Size();
+			int direction = ev.IsAlt ? -1 : 1;
+			for (int i = 0; i < itemsNumber; ++i)
+			{
+				int index = (mDesc.mSelectedItem + direction * (i + 1) + itemsNumber) % itemsNumber;
+				if (!mDesc.mItems[index].Selectable()) continue;
+				String label = StringTable.Localize(mDesc.mItems[index].mLabel);
+				String firstLabelCharacter = String.Format("%c", label.GetNextCodePoint(0)).MakeLower();
+				if (firstLabelCharacter == key)
+				{
+					mDesc.mSelectedItem = index;
+					break;
+				}
+			}
+		}
 		return Super.OnUIEvent(ev);
 	}
 

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
@@ -203,7 +203,7 @@ class OptionMenu : Menu
 		}
 		else if (ev.type == UIEvent.Type_Char)
 		{
-			String key = String.Format("%c", ev.keyChar).MakeLower();
+			int key = String.CharLower(ev.keyChar);
 			int itemsNumber = mDesc.mItems.Size();
 			int direction = ev.IsAlt ? -1 : 1;
 			for (int i = 0; i < itemsNumber; ++i)
@@ -211,7 +211,7 @@ class OptionMenu : Menu
 				int index = (mDesc.mSelectedItem + direction * (i + 1) + itemsNumber) % itemsNumber;
 				if (!mDesc.mItems[index].Selectable()) continue;
 				String label = StringTable.Localize(mDesc.mItems[index].mLabel);
-				String firstLabelCharacter = String.Format("%c", label.GetNextCodePoint(0)).MakeLower();
+				int firstLabelCharacter = String.CharLower(label.GetNextCodePoint(0));
 				if (firstLabelCharacter == key)
 				{
 					mDesc.mSelectedItem = index;


### PR DESCRIPTION
Enables shortcuts for option menus for easier navigation using the keyboard.

Press a key to immediately jump to the next option menu entry which starts with this key. Hold Alt to jump backwards.

Compatible with localized menus (checked on Russian).

Forum topic: https://forum.zdoom.org/viewtopic.php?f=59&t=72682