### PR TITLE
Allow ZScript to change camera texture aspect ratio

### DIFF
--- a/src/common/textures/textures.h
+++ b/src/common/textures/textures.h
@@ -319,6 +319,8 @@ public:
 	void NeedUpdate() { bNeedsUpdate = true; }
 	void SetUpdated(bool rendertype) { bNeedsUpdate = false; bFirstUpdate = false; bLastUpdateType = rendertype; }
 
+	void SetAspectRatio(double aspectScale, bool useTextureRatio) { aspectRatio = aspectScale * (useTextureRatio? ((float)Width / Height) : 1); }
+
 protected:
 
 	bool bLastUpdateType = false;

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -78,6 +78,30 @@ DEFINE_ACTION_FUNCTION_NATIVE(_TexMan, SetCameraToTexture, SetCameraToTexture)
 	return 0;
 }
 
+static void SetCameraTextureAspectRatio(const FString &texturename, double aspectScale, bool useTextureRatio)
+{
+	FTextureID textureid = TexMan.CheckForTexture(texturename, ETextureType::Wall, FTextureManager::TEXMAN_Overridable);
+	if (textureid.isValid())
+	{
+		// Only proceed if the texture actually has a canvas.
+		auto tex = TexMan.GetGameTexture(textureid);
+		if (tex && tex->isHardwareCanvas())
+		{
+			static_cast<FCanvasTexture *>(tex->GetTexture())->SetAspectRatio(aspectScale, useTextureRatio);
+		}
+	}
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(_TexMan, SetCameraTextureAspectRatio, SetCameraTextureAspectRatio)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(texturename);
+	PARAM_FLOAT(aspect);
+	PARAM_BOOL(useTextureRatio);
+	SetCameraTextureAspectRatio(texturename, aspect, useTextureRatio);
+	return 0;
+}
+
 //=====================================================================================
 //
 // sector_t exports

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -26,6 +26,7 @@ extend struct _
 extend struct TexMan
 {
 	native static void SetCameraToTexture(Actor viewpoint, String texture, double fov);
+	native static void SetCameraTextureAspectRatio(String texture, double aspectScale, bool useTextureRatio = true);
 	deprecated("3.8", "Use Level.ReplaceTextures() instead") static void ReplaceTextures(String from, String to, int flags)
 	{
 		level.ReplaceTextures(from, to, flags);


### PR DESCRIPTION
Adds `TexMan.SetCameraTextureAspectRatio`, which lets ZScript modify the aspect ratio of camera textures.
Made primarily so camera textures drawn on the HUD can be made to match the level's pixel ratio without having to manually scale and clip them.