### PR TITLE
- dim the icon of depleted inventory items on the status bar and full…

### DIFF
--- a/wadsrc/static/zscript/ui/statusbar/doom_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/doom_sbar.zs
@@ -66,7 +66,7 @@ class DoomStatusBar : BaseStatusBar
 		
 		if (CPlayer.mo.InvSel != null && !Level.NoInventoryBar)
 		{
-			DrawInventoryIcon(CPlayer.mo.InvSel, (160, 198));
+			DrawInventoryIcon(CPlayer.mo.InvSel, (160, 198), DI_DIMDEPLETED);
 			if (CPlayer.mo.InvSel.Amount > 1)
 			{
 				DrawString(mAmountFont, FormatNumber(CPlayer.mo.InvSel.Amount), (175, 198-mIndexFont.mFont.GetHeight()), DI_TEXT_ALIGN_RIGHT, Font.CR_GOLD);

--- a/wadsrc/static/zscript/ui/statusbar/heretic_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/heretic_sbar.zs
@@ -127,7 +127,7 @@ class HereticStatusBar : BaseStatusBar
 			//inventory box
 			if (CPlayer.mo.InvSel != null)
 			{
-				DrawInventoryIcon(CPlayer.mo.InvSel, (194, 175), DI_ARTIFLASH|DI_ITEM_CENTER, boxsize:(28, 28));
+				DrawInventoryIcon(CPlayer.mo.InvSel, (194, 175), DI_ARTIFLASH|DI_ITEM_CENTER|DI_DIMDEPLETED, boxsize:(28, 28));
 				if (CPlayer.mo.InvSel.Amount > 1)
 				{
 					DrawString(mIndexFont, FormatNumber(CPlayer.mo.InvSel.Amount, 3), (209, 182), DI_TEXT_ALIGN_RIGHT);
@@ -205,7 +205,7 @@ class HereticStatusBar : BaseStatusBar
 			// This code was changed to always fit the item into the box, regardless of alignment or sprite size.
 			// Heretic's ARTIBOX is 30x30 pixels. 
 			DrawImage("ARTIBOX", (-46, -1), 0, HX_SHADOW);
-			DrawInventoryIcon(CPlayer.mo.InvSel, (-46, -15), DI_ARTIFLASH|DI_ITEM_CENTER, boxsize:(28, 28));
+			DrawInventoryIcon(CPlayer.mo.InvSel, (-46, -15), DI_ARTIFLASH|DI_ITEM_CENTER|DI_DIMDEPLETED, boxsize:(28, 28));
 			if (CPlayer.mo.InvSel.Amount > 1)
 			{
 				DrawString(mIndexFont, FormatNumber(CPlayer.mo.InvSel.Amount, 3), (-32, -2 - mIndexFont.mFont.GetHeight()), DI_TEXT_ALIGN_RIGHT);

--- a/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/hexen_sbar.zs
@@ -83,7 +83,7 @@ class HexenStatusBar : BaseStatusBar
 			// This code was changed to always fit the item into the box, regardless of alignment or sprite size.
 			// Heretic's ARTIBOX is 30x30 pixels. 
 			DrawImage("ARTIBOX", (-66, -1), 0, HX_SHADOW);
-			DrawInventoryIcon(CPlayer.mo.InvSel, (-66, -15), DI_ARTIFLASH|DI_ITEM_CENTER, boxsize:(28, 28));
+			DrawInventoryIcon(CPlayer.mo.InvSel, (-66, -15), DI_ARTIFLASH|DI_ITEM_CENTER|DI_DIMDEPLETED, boxsize:(28, 28));
 			if (CPlayer.mo.InvSel.Amount > 1)
 			{
 				DrawString(mIndexFont, FormatNumber(CPlayer.mo.InvSel.Amount, 3), (-52, -2 - mIndexFont.mFont.GetHeight()), DI_TEXT_ALIGN_RIGHT);
@@ -146,7 +146,7 @@ class HexenStatusBar : BaseStatusBar
 				//inventory box
 				if (CPlayer.mo.InvSel != null)
 				{
-					DrawInventoryIcon(CPlayer.mo.InvSel, (159.5, 177), DI_ARTIFLASH|DI_ITEM_CENTER, boxsize:(28, 28));
+					DrawInventoryIcon(CPlayer.mo.InvSel, (159.5, 177), DI_ARTIFLASH|DI_ITEM_CENTER|DI_DIMDEPLETED, boxsize:(28, 28));
 					if (CPlayer.mo.InvSel.Amount > 1)
 					{
 						DrawString(mIndexFont, FormatNumber(CPlayer.mo.InvSel.Amount, 3), (174, 184), DI_TEXT_ALIGN_RIGHT);

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -981,7 +981,7 @@ class BaseStatusBar : StatusBarCore native
 				}
 				else
 				{
-					DrawInventoryIcon(item, itempos + (boxsize.X * i, 0), flags | DI_ITEM_CENTER );
+					DrawInventoryIcon(item, itempos + (boxsize.X * i, 0), flags | DI_ITEM_CENTER | DI_DIMDEPLETED);
 				}
 			}
 			


### PR DESCRIPTION
…screen HUD

This PR addresses [this bug report](https://forum.zdoom.org/viewtopic.php?f=2&t=72714).

Note that I left Doom's fullscreen HUD alone, since unlike the other games, it always draws the counter.