### PR TITLE
Add cvars to control automap line alpha and thickness

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -131,6 +131,8 @@ struct islope_t
 //=============================================================================
 
 CVAR(Bool, am_textured, false, CVAR_ARCHIVE)
+CVAR(Float, am_linealpha, 1.0f, CVAR_ARCHIVE)
+CVAR(Int, am_linethickness, 1, CVAR_ARCHIVE)
 CVAR(Bool, am_thingrenderstyles, true, CVAR_ARCHIVE)
 CVAR(Int, am_showsubsector, -1, 0);
 
@@ -1735,7 +1737,16 @@ void DAutomap::drawMline (mline_t *ml, const AMColor &color)
 
 	if (clipMline (ml, &fl))
 	{
-		twod->AddLine (f_x + fl.a.x, f_y + fl.a.y, f_x + fl.b.x, f_y + fl.b.y, -1, -1, INT_MAX, INT_MAX, color.RGB);
+		const int x1 = f_x + fl.a.x;
+		const int y1 = f_y + fl.a.y;
+		const int x2 = f_x + fl.b.x;
+		const int y2 = f_y + fl.b.y;
+		if (am_linethickness >= 2) {
+			twod->AddThickLine(x1, y1, x2, y2, am_linethickness, color.RGB, uint8_t(am_linealpha * 255));
+		} else {
+			// Use more efficient thin line drawing routine.
+			twod->AddLine(x1, y1, x2, y2, -1, -1, INT_MAX, INT_MAX, color.RGB, uint8_t(am_linealpha * 255));
+		}
 	}
 }
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1346,9 +1346,11 @@ OptionMenu AutomapOptions protected
 
 	StaticText ""
 	Option "$AUTOMAPMNU_ROTATE",				"am_rotate", "RotateTypes"
+	Option "$AUTOMAPMNU_FOLLOW",				"am_followplayer", "OnOff"
 	Option "$AUTOMAPMNU_OVERLAY",				"am_overlay", "OverlayTypes"
 	Option "$AUTOMAPMNU_TEXTURED",				"am_textured", "OnOff"
-	Option "$AUTOMAPMNU_FOLLOW",				"am_followplayer", "OnOff"
+	Slider "$AUTOMAPMNU_LINEALPHA",				"am_linealpha", 0.1, 1.0, 0.1, 1
+	Slider "$AUTOMAPMNU_LINETHICKNESS",			"am_linethickness", 1, 8, 1, 0
 
 	StaticText ""
 	Option "$AUTOMAPMNU_SHOWITEMS",				"am_showitems", "OnOff"


### PR DESCRIPTION
This can be used to improve automap readability on high-resolution displays.

Some automap options in the menu were reordered to follow a more logical order.

**Edit:** This PR now uses `DrawThickLine`, which results in more correct lines but antialiasing was lost in the process. If we want antialiasing back, we'll have to add antialiasing to `DrawThickLine` in a future PR.

## Preview

*Line alpha is set to 0.6 and line thickness is set to 5.*

### Normal

![Normal](https://user-images.githubusercontent.com/180032/125063773-31d76e00-e0b0-11eb-933a-118df38d356c.png)

### Overlay

![Overlay](https://user-images.githubusercontent.com/180032/125063769-300daa80-e0b0-11eb-89be-826b13e99232.png)

<details>
<summary>Old version based on multiple thin line draws</summary>

*Line thickness is set to 5.*

### Normal

![Normal](https://user-images.githubusercontent.com/180032/125062492-b923e200-e0ae-11eb-81d9-4918c31ff7cf.png)

### Overlay

![Overlay](https://user-images.githubusercontent.com/180032/125062476-b4f7c480-e0ae-11eb-8260-deb6ff338cf9.png)
</details>