### PR TITLE
AActor::Tick separation to dedicated functions

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -771,6 +771,8 @@ public:
 	// Tosses an item out of the inventory.
 	AActor *DropInventory (AActor *item, int amt = -1);
 
+	void ApplyPowerups();
+
 	// Removes all items from the inventory.
 	void ClearInventory();
 

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -717,6 +717,8 @@ public:
 
 	void BotThink();
 
+	void SlopedFloorHandling();
+
 	// Called when actor dies
 	virtual void Die (AActor *source, AActor *inflictor, int dmgflags = 0, FName MeansOfDeath = NAME_None);
 	void CallDie(AActor *source, AActor *inflictor, int dmgflags = 0, FName MeansOfDeath = NAME_None);

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -964,7 +964,7 @@ public:
 	const char *GetCharacterName() const;
 
 	DVector2 CarryingSectorsHandling();
-
+	void RespawnHandling();
 	// Triggers SECSPAC_Exit/SECSPAC_Enter and related events if oldsec != current sector
 	void CheckSectorTransition(sector_t *oldsec);
 	void UpdateRenderSectorList();

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -715,6 +715,8 @@ public:
 	virtual void Deactivate(AActor *activator);
 	void CallDeactivate(AActor *activator);
 
+	void BotThink();
+
 	// Called when actor dies
 	virtual void Die (AActor *source, AActor *inflictor, int dmgflags = 0, FName MeansOfDeath = NAME_None);
 	void CallDie(AActor *source, AActor *inflictor, int dmgflags = 0, FName MeansOfDeath = NAME_None);

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1234,6 +1234,7 @@ public:
 	bool IsMapActor();
 	int GetTics(FState * newstate);
 	bool SetState (FState *newstate, bool nofunction=false);
+	bool AdvanceState();
 	virtual void SplashCheck();
 	virtual bool UpdateWaterLevel (bool splash=true);
 	bool isFast();

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -963,6 +963,8 @@ public:
 	void SetTag(const char *def);
 	const char *GetCharacterName() const;
 
+	DVector2 CarryingSectorsHandling();
+
 	// Triggers SECSPAC_Exit/SECSPAC_Enter and related events if oldsec != current sector
 	void CheckSectorTransition(sector_t *oldsec);
 	void UpdateRenderSectorList();

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -718,6 +718,8 @@ public:
 	void BotThink();
 
 	void SlopedFloorHandling();
+	//carry offset is additional velocity produced from standing in carrying sectors
+	void FullAxisMovement(DVector2 carryoffset = DVector2(0.0, 0.0) );
 
 	// Called when actor dies
 	virtual void Die (AActor *source, AActor *inflictor, int dmgflags = 0, FName MeansOfDeath = NAME_None);

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -816,6 +816,41 @@ void AActor::ClearInventory()
 
 //============================================================================
 //
+// AActor :: ApplyPowerups
+//
+// Iterate through actors inventory, calling each item DoEffect function
+//
+//============================================================================
+
+void AActor::ApplyPowerups()
+{
+	if (!player || !(player->cheats & CF_PREDICTING))
+	{
+		// Handle powerup effects here so that the order is controlled
+		// by the order in the inventory, not the order in the thinker table
+		AActor *item = Inventory;
+		
+		while (item != NULL)
+		{
+			IFVIRTUALPTRNAME(item, NAME_Inventory, DoEffect)
+			{
+				VMValue params[1] = { item };
+				VMCall(func, params, 1, nullptr, 0);
+			}
+			item = item->Inventory;
+		}
+	}
+}
+
+DEFINE_ACTION_FUNCTION(AActor, ApplyPowerups)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	self->ApplyPowerups();
+	return 0;
+}
+
+//============================================================================
+//
 // AActor :: CopyFriendliness
 //
 // Makes this actor hate (or like) the same things another actor does.
@@ -3667,22 +3702,7 @@ void AActor::Tick ()
 	else
 	{
 
-		if (!player || !(player->cheats & CF_PREDICTING))
-		{
-			// Handle powerup effects here so that the order is controlled
-			// by the order in the inventory, not the order in the thinker table
-			AActor *item = Inventory;
-			
-			while (item != NULL)
-			{
-				IFVIRTUALPTRNAME(item, NAME_Inventory, DoEffect)
-				{
-					VMValue params[1] = { item };
-					VMCall(func, params, 1, nullptr, 0);
-				}
-				item = item->Inventory;
-			}
-		}
+		ApplyPowerups();
 
 		if (flags & MF_UNMORPHED)
 		{

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3857,6 +3857,23 @@ DEFINE_ACTION_FUNCTION(AActor, RespawnHandling)
 	return 0;
 }
 
+void AActor::BotThink()
+{
+	if (Level->BotInfo.botnum && !demoplayback &&
+	((flags & (MF_SPECIAL|MF_MISSILE)) || (flags3 & MF3_ISMONSTER)))
+	{
+		Level->BotInfo.BotTick(this);
+	}
+}
+
+DEFINE_ACTION_FUNCTION(AActor, BotThink)
+{
+	PARAM_SELF_PROLOGUE(AActor);
+	self->BotThink();
+	return 0;
+}
+
+
 //
 // P_MobjThinker
 //
@@ -4020,11 +4037,7 @@ void AActor::Tick ()
 			}
 		}
 
-		if (Level->BotInfo.botnum && !demoplayback &&
-			((flags & (MF_SPECIAL|MF_MISSILE)) || (flags3 & MF3_ISMONSTER)))
-		{
-			Level->BotInfo.BotTick(this);
-		}
+		BotThink();
 
 		// [RH] Consider carrying sectors here
 		DVector2 cumm = CarryingSectorsHandling();

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -3753,8 +3753,6 @@ void AActor::Tick ()
 			}
 		}
 
-		double oldz = Z();
-
 		// [RH] Give the pain elemental vertical friction
 		// This used to be in APainElemental::Tick but in order to use
 		// A_PainAttack with other monsters it has to be here

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -744,6 +744,7 @@ class Actor : Thinker native
 	native void RandomChaseDir();
 	native bool CheckMissileRange();
 	native bool SetState(state st, bool nofunction = false);
+	native bool AdvanceState();
 	clearscope native state FindState(statelabel st, bool exact = false) const;
 	bool SetStateLabel(statelabel st, bool nofunction = false) { return SetState(FindState(st), nofunction); }
 	native action state ResolveState(statelabel st);	// this one, unlike FindState, is context aware.

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -787,6 +787,7 @@ class Actor : Thinker native
 	native clearscope double GetGravity() const;
 	native void DoMissileDamage(Actor target);
 	native void RespawnHandling();
+	native void BotThink();
 	//==========================================================================
 	//
 	// AActor :: GetLevelSpawnTime

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -740,6 +740,7 @@ class Actor : Thinker native
 	
 	native bool TryMove(vector2 newpos, int dropoff, bool missilecheck = false, FCheckPosition tm = null);
 	native bool CheckMove(vector2 newpos, int flags = 0, FCheckPosition tm = null);
+	native vector2 CarryingSectorsHandling();
 	native void NewChaseDir();
 	native void RandomChaseDir();
 	native bool CheckMissileRange();

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -786,7 +786,7 @@ class Actor : Thinker native
 	native clearscope double GetCameraHeight() const;
 	native clearscope double GetGravity() const;
 	native void DoMissileDamage(Actor target);
-
+	native void RespawnHandling();
 	//==========================================================================
 	//
 	// AActor :: GetLevelSpawnTime

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -788,6 +788,7 @@ class Actor : Thinker native
 	native void DoMissileDamage(Actor target);
 	native void RespawnHandling();
 	native void BotThink();
+	native void SlopedFloorHandling();
 	//==========================================================================
 	//
 	// AActor :: GetLevelSpawnTime

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -822,6 +822,7 @@ class Actor : Thinker native
 	protected native void DestroyAllInventory();	// This is not supposed to be called by user code!
 	native clearscope Inventory FindInventory(class<Inventory> itemtype, bool subclass = false) const;
 	native Inventory GiveInventoryType(class<Inventory> itemtype);
+	native void ApplyPowerups();
 	native bool UsePuzzleItem(int PuzzleItemType);
 
 	action native void SetCamera(Actor cam, bool revert = false);

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -789,6 +789,8 @@ class Actor : Thinker native
 	native void RespawnHandling();
 	native void BotThink();
 	native void SlopedFloorHandling();
+	native void FullAxisMovement(vector2 carryoffset);
+
 	//==========================================================================
 	//
 	// AActor :: GetLevelSpawnTime


### PR DESCRIPTION
Set of commits that move logic, like movement, state progression, etc., from AActor::Tick into dedicated function. It also exposes new functions to zscript, to allow easy overriding of a tick on zscript side.

On additional note, it also slightly improve performance of a Gzdoom, comparing to a current (250fac5) master version. Tested CPU consumption on release version, on okuplok map. Okuplok are here
http://www.mediafire.com/file/dy98536fxa79az7/oku2v31.wad/file

Update: look like my Visual Studio trying to Volkswagen me, because now, after I tried to make performance report screenshots, my version works worse than master.
