### PR TITLE
Add 'BF_ONLYVISIBLETHINGS' flag to A_Blast

### DIFF
--- a/wadsrc/static/zscript/actors/hexen/blastradius.zs
+++ b/wadsrc/static/zscript/actors/hexen/blastradius.zs
@@ -148,6 +148,11 @@ extend class Actor
 				// in another region and cannot be seen.
 				continue;
 			}
+			if ((blastflags & BF_ONLYVISIBLETHINGS) && !isVisible(mo, true)) 
+			{
+				//only blast if target can bee seen by calling actor
+				continue;
+			}
 			BlastActor (mo, strength, speed, blasteffect, !!(blastflags & BF_NOIMPACTDAMAGE));
 		}
 	}

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -285,6 +285,7 @@ enum EBlastFlags
 	BF_DONTWARN = 2,
 	BF_AFFECTBOSSES = 4,
 	BF_NOIMPACTDAMAGE = 8,
+	BF_ONLYVISIBLETHINGS = 16;
 };
 
 // Flags for A_SeekerMissile


### PR DESCRIPTION
Adds 'BF_ONLYVISIBLETHINGS' flag to A_Blast, and enables A_Blast to only affect actors that have a line of sight to calling actor.