### PR TITLE
Service Expansion - More virtuals

### DIFF
--- a/wadsrc/static/zscript/engine/service.zs
+++ b/wadsrc/static/zscript/engine/service.zs
@@ -3,42 +3,42 @@
  */
 class Service abstract
 {
-	virtual play String Get(String request)
+	virtual play String Get(String request, String str1 = "", String str2 = "", String str3 = "")
 	{
 		return "";
 	}
 
-	virtual ui String UiGet(String request)
+	virtual ui String UiGet(String request, String str1 = "", String str2 = "", String str3 = "")
 	{
 		return "";
 	}
 
-	virtual play int GetInt(String request, int num = 0)
+	virtual play int GetInt(String request, int num1 = 0, int num2 = 0, int num3 = 0)
 	{
 		return 0;
 	}
 
-	virtual ui int UIGetInt(String request, int num = 0)
+	virtual ui int UIGetInt(String request, int num1 = 0, int num2 = 0, int num3 = 0)
 	{
 		return 0;
 	}
 
-	virtual play double GetDouble(String request, double num = 0.0)
+	virtual play double GetDouble(String request, double num1 = 0.0, double num2 = 0.0, double num3 = 0.0)
 	{
 		return 0.0;
 	}
 
-	virtual ui double UIGetDouble(String request, double num = 0.0)
+	virtual ui double UIGetDouble(String request, double num1 = 0.0, double num2 = 0.0, double num3 = 0.0)
 	{
 		return 0.0;
 	}
 
-	virtual play Object GetObject(String request, Object ob = null)
+	virtual play Object GetObject(String request, Object ob1 = null, Object ob2 = null, Object ob3 = null)
 	{
 		return null;
 	}
 
-	virtual ui Object UIGetObject(String request, Object ob = null)
+	virtual ui Object UIGetObject(String request, Object ob1 = null, Object ob2 = null, Object ob3 = null)
 	{
 		return null;
 	}

--- a/wadsrc/static/zscript/engine/service.zs
+++ b/wadsrc/static/zscript/engine/service.zs
@@ -12,6 +12,26 @@ class Service abstract
 	{
 		return "";
 	}
+
+	virtual play int GetInt(String request, int num = 0)
+	{
+		return 0;
+	}
+
+	virtual ui int UIGetInt(String request, int num = 0)
+	{
+		return 0;
+	}
+
+	virtual play double GetDouble(String request, double num = 0.0)
+	{
+		return 0.0;
+	}
+
+	virtual ui double UIGetDouble(String request, double num = 0.0)
+	{
+		return 0.0;
+	}
 }
 
 /**

--- a/wadsrc/static/zscript/engine/service.zs
+++ b/wadsrc/static/zscript/engine/service.zs
@@ -3,12 +3,22 @@
  */
 class Service abstract
 {
-	virtual play String Get(String request, String str1 = "", String str2 = "", String str3 = "")
+	deprecated("4.6", "Use GetString() instead") virtual play String Get(String request)
 	{
 		return "";
 	}
 
-	virtual ui String UiGet(String request, String str1 = "", String str2 = "", String str3 = "")
+	deprecated("4.6", "Use UIGetString() instead") virtual ui String UiGet(String request)
+	{
+		return "";
+	}
+
+	virtual play String GetString(String request, String str1 = "", String str2 = "", String str3 = "")
+	{
+		return "";
+	}
+
+	virtual ui String UiGetString(String request, String str1 = "", String str2 = "", String str3 = "")
 	{
 		return "";
 	}

--- a/wadsrc/static/zscript/engine/service.zs
+++ b/wadsrc/static/zscript/engine/service.zs
@@ -32,6 +32,16 @@ class Service abstract
 	{
 		return 0.0;
 	}
+
+	virtual play Object GetObject(String request, Object ob = null)
+	{
+		return null;
+	}
+
+	virtual ui Object UIGetObject(String request, Object ob = null)
+	{
+		return null;
+	}
 }
 
 /**


### PR DESCRIPTION
Added (UI)GetInt/Double/Object virtuals to Service and expanded their parameters.

Several reasons for this:
- If Service is being used often, these virtuals can be used to reduce the number of translations from strings to numbers.
- Secures against potential typing errors if returning just numbers (anyone remember 0.L?) to prevent bad number translations
- When used to construct functions (see example below), the extra parameters are provided to reduce function calls.

-----
EXAMPLE

Currently I'm working on a global damage system where the damage is set up and calculated before a player is damaged without needing to override the player actor's DamageMobj function. For that, the Service class is set up to construct a damage function, and return the result.

```
// Begin call and set up the service provider, in order. 
serv.Get("DamageMobj", DamageType); // Sets it up and gives the damage type.
serv.GetObject("Pointers", target, src, inf); // Passes in the 3 essential pointers.
serv.GetDouble("Angle", dmgAngle); // Passes in the angle
return serv.GetInt("Result", damage, flags); // Passes in the damage & flags. Then gets the result.
```

