### PR TITLE
Manage Shape2D vertex buffers lifetime with RefCountedPtr

### DIFF
--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -124,7 +124,7 @@ static void Shape2D_Clear(DShape2D* self, int which)
 	if (which & C_Verts) self->mVertices.Clear();
 	if (which & C_Coords) self->mCoords.Clear();
 	if (which & C_Indices) self->mIndices.Clear();
-	self->needsVertexUpload = true;
+	self->bufferInfo->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, Clear, Shape2D_Clear)
@@ -138,7 +138,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, Clear, Shape2D_Clear)
 static void Shape2D_PushVertex(DShape2D* self, double x, double y)
 {
 	self->mVertices.Push(DVector2(x, y));
-	self->needsVertexUpload = true;
+	self->bufferInfo->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushVertex, Shape2D_PushVertex)
@@ -153,7 +153,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushVertex, Shape2D_PushVertex)
 static void Shape2D_PushCoord(DShape2D* self, double u, double v)
 {
 	self->mCoords.Push(DVector2(u, v));
-	self->needsVertexUpload = true;
+	self->bufferInfo->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushCoord, Shape2D_PushCoord)
@@ -170,7 +170,7 @@ static void Shape2D_PushTriangle(DShape2D* self, int a, int b, int c)
 	self->mIndices.Push(a);
 	self->mIndices.Push(b);
 	self->mIndices.Push(c);
-	self->needsVertexUpload = true;
+	self->bufferInfo->needsVertexUpload = true;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DShape2D, PushTriangle, Shape2D_PushTriangle)
@@ -534,7 +534,7 @@ void DShape2D::OnDestroy() {
 	mIndices.Reset();
 	mVertices.Reset();
 	mCoords.Reset();
-	buffers.Reset();
+	bufferInfo.reset();
 }
 
 //==========================================================================
@@ -567,11 +567,11 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 		shape->lastParms = new DrawParms(parms);
 	}
 	else if (shape->lastParms->vertexColorChange(parms)) {
-		shape->needsVertexUpload = true;
-		if (!shape->uploadedOnce) {
-			shape->bufIndex = -1;
-			shape->buffers.Clear();
-			shape->lastCommand = -1;
+		shape->bufferInfo->needsVertexUpload = true;
+		if (!shape->bufferInfo->uploadedOnce) {
+			shape->bufferInfo->bufIndex = -1;
+			shape->bufferInfo->buffers.Clear();
+			shape->bufferInfo->lastCommand = -1;
 		}
 		delete shape->lastParms;
 		shape->lastParms = new DrawParms(parms);
@@ -583,7 +583,7 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	auto osave = offset;
 	if (parms.nooffset) offset = { 0,0 };
 
-	if (shape->needsVertexUpload)
+	if (shape->bufferInfo->needsVertexUpload)
 	{
 		shape->minx = 16383;
 		shape->miny = 16383;
@@ -622,15 +622,15 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 	dg.transform = shape->transform;
 	dg.transform.Cells[0][2] += offset.X;
 	dg.transform.Cells[1][2] += offset.Y;
-	dg.shape2D = shape;
+	dg.shape2DBufInfo = shape->bufferInfo;
 	dg.shape2DIndexCount = shape->mIndices.Size();
-	if (shape->needsVertexUpload)
+	if (shape->bufferInfo->needsVertexUpload)
 	{
-		shape->bufIndex += 1;
+		shape->bufferInfo->bufIndex += 1;
 
-		shape->buffers.Reserve(1);
+		shape->bufferInfo->buffers.Reserve(1);
 
-		auto buf = &shape->buffers[shape->bufIndex];
+		auto buf = &shape->bufferInfo->buffers[shape->bufferInfo->bufIndex];
 
 		auto verts = TArray<TwoDVertex>(dg.mVertCount, true);
 		for ( int i=0; i<dg.mVertCount; i++ )
@@ -649,12 +649,12 @@ void F2DDrawer::AddShape(FGameTexture* img, DShape2D* shape, DrawParms& parms)
 		}
 
 		buf->UploadData(&verts[0], dg.mVertCount, &shape->mIndices[0], shape->mIndices.Size());
-		shape->needsVertexUpload = false;
-		shape->uploadedOnce = true;
+		shape->bufferInfo->needsVertexUpload = false;
+		shape->bufferInfo->uploadedOnce = true;
 	}
-	dg.shape2DBufIndex = shape->bufIndex;
-	shape->lastCommand += 1;
-	dg.shape2DCommandCounter = shape->lastCommand;
+	dg.shape2DBufIndex = shape->bufferInfo->bufIndex;
+	shape->bufferInfo->lastCommand += 1;
+	dg.shape2DCommandCounter = shape->bufferInfo->lastCommand;
 	AddCommand(&dg);
 	offset = osave;
 }

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -528,13 +528,15 @@ void F2DDrawer::AddTexture(FGameTexture* img, DrawParms& parms)
 	offset = osave;
 }
 
+static TArray<RefCountedPtr<DShape2DBufferInfo>> buffersToDestroy;
+
 void DShape2D::OnDestroy() {
 	if (lastParms) delete lastParms;
 	lastParms = nullptr;
 	mIndices.Reset();
 	mVertices.Reset();
 	mCoords.Reset();
-	bufferInfo = nullptr;
+	buffersToDestroy.Push(std::move(bufferInfo));
 }
 
 //==========================================================================
@@ -1080,6 +1082,17 @@ void F2DDrawer::Clear()
 		mIsFirstPass = true;
 	}
 	screenFade = 1.f;
+}
+
+//==========================================================================
+//
+//
+//
+//==========================================================================
+
+void F2DDrawer::OnFrameDone()
+{
+	buffersToDestroy.Clear();
 }
 
 F2DVertexBuffer::F2DVertexBuffer()

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -534,7 +534,7 @@ void DShape2D::OnDestroy() {
 	mIndices.Reset();
 	mVertices.Reset();
 	mCoords.Reset();
-	bufferInfo.reset();
+	bufferInfo = nullptr;
 }
 
 //==========================================================================

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -216,6 +216,7 @@ public:
 	void Begin(int w, int h) { isIn2D = true; Width = w; Height = h; }
 	void End() { isIn2D = false; }
 	bool HasBegun2D() { return isIn2D; }
+	void OnFrameDone();
 
 	void ClearClipRect() { clipleft = cliptop = 0; clipwidth = clipheight = -1; }
 	void SetClipRect(int x, int y, int w, int h);

--- a/src/common/2d/v_2ddrawer.h
+++ b/src/common/2d/v_2ddrawer.h
@@ -7,7 +7,7 @@
 #include "textures.h"
 #include "renderstyle.h"
 #include "dobject.h"
-#include <memory>
+#include "refcounted.h"
 
 struct DrawParms;
 struct FColormap;
@@ -50,7 +50,7 @@ struct F2DPolygons
 };
 
 class DShape2D;
-class DShape2DBufferInfo;
+struct DShape2DBufferInfo;
 
 class F2DDrawer
 {
@@ -125,7 +125,7 @@ public:
 		bool useTransform;
 		DMatrix3x3 transform;
 
-		std::shared_ptr<DShape2DBufferInfo> shape2DBufInfo;
+		RefCountedPtr<DShape2DBufferInfo> shape2DBufInfo;
 		int shape2DBufIndex;
 		int shape2DIndexCount;
 		int shape2DCommandCounter;
@@ -133,7 +133,6 @@ public:
 		RenderCommand()
 		{
 			memset(this, 0, sizeof(*this));
-			shape2DBufInfo.reset();
 		}
 
 		// If these fields match, two draw commands can be batched.
@@ -243,9 +242,8 @@ public:
 	bool mIsFirstPass = true;
 };
 
-class DShape2DBufferInfo
+struct DShape2DBufferInfo : NoVirtualRefCountedBase
 {
-public:
 	TArray<F2DVertexBuffer> buffers;
 	bool needsVertexUpload = true;
 	int bufIndex = -1;
@@ -259,8 +257,8 @@ class DShape2D : public DObject
 	DECLARE_CLASS(DShape2D,DObject)
 public:
 	DShape2D()
+	: bufferInfo(new DShape2DBufferInfo)
 	{
-		bufferInfo = std::make_shared<DShape2DBufferInfo>();
 		transform.Identity();
 	}
 
@@ -275,7 +273,7 @@ public:
 
 	DMatrix3x3 transform;
 
-	std::shared_ptr<DShape2DBufferInfo> bufferInfo;
+	RefCountedPtr<DShape2DBufferInfo> bufferInfo;
 
 	DrawParms* lastParms;
 

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -178,22 +178,22 @@ void Draw2D(F2DDrawer *drawer, FRenderState &state)
 			state.EnableTexture(false);
 		}
 
-		if (cmd.shape2D != nullptr)
+		if (cmd.shape2DBufInfo != nullptr)
 		{
-			state.SetVertexBuffer(&cmd.shape2D->buffers[cmd.shape2DBufIndex]);
+			state.SetVertexBuffer(&cmd.shape2DBufInfo->buffers[cmd.shape2DBufIndex]);
 			state.DrawIndexed(DT_Triangles, 0, cmd.shape2DIndexCount);
 			state.SetVertexBuffer(&vb);
-			if (cmd.shape2DCommandCounter == cmd.shape2D->lastCommand)
+			if (cmd.shape2DCommandCounter == cmd.shape2DBufInfo->lastCommand)
 			{
-				cmd.shape2D->lastCommand = -1;
-				if (cmd.shape2D->bufIndex > 0)
+				cmd.shape2DBufInfo->lastCommand = -1;
+				if (cmd.shape2DBufInfo->bufIndex > 0)
 				{
-					cmd.shape2D->needsVertexUpload = true;
-					cmd.shape2D->buffers.Clear();
-					cmd.shape2D->bufIndex = -1;
+					cmd.shape2DBufInfo->needsVertexUpload = true;
+					cmd.shape2DBufInfo->buffers.Clear();
+					cmd.shape2DBufInfo->bufIndex = -1;
 				}
 			}
-			cmd.shape2D->uploadedOnce = false;
+			cmd.shape2DBufInfo->uploadedOnce = false;
 		}
 		else
 		{

--- a/src/common/utility/refcounted.h
+++ b/src/common/utility/refcounted.h
@@ -1,20 +1,29 @@
 #pragma once
 
 // Simple lightweight reference counting pointer alternative for std::shared_ptr which stores the reference counter in the handled object itself.
- 
- // Base class for handled objects
+
+// Base classes for handled objects
+class NoVirtualRefCountedBase
+{
+public:
+	void IncRef() { refCount++; }
+	void DecRef() { if (--refCount <= 0) delete this; }
+private:
+	int refCount = 0;
+};
+
 class RefCountedBase
 {
 public:
-    void IncRef() { refCount++; }
-    void DecRef() { if (--refCount <= 0) delete this; }
+	void IncRef() { refCount++; }
+	void DecRef() { if (--refCount <= 0) delete this; }
 private:
-    int refCount = 0;
+	int refCount = 0;
 protected:
-    virtual ~RefCountedBase() = default;
+	virtual ~RefCountedBase() = default;
 };
- 
- // The actual pointer object
+
+// The actual pointer object
 template<class T> 
 class RefCountedPtr
 {

--- a/src/common/utility/refcounted.h
+++ b/src/common/utility/refcounted.h
@@ -31,10 +31,20 @@ public:
     {
         if (ptr) ptr->IncRef();
     }
- 
+
+	RefCountedPtr(const RefCountedPtr& r) : ptr(r.ptr)
+	{
+		if (ptr) ptr->IncRef();
+	}
+
+	RefCountedPtr(RefCountedPtr&& r) : ptr(r.ptr)
+	{
+		r.ptr = nullptr;
+	}
+
     RefCountedPtr & operator=(const RefCountedPtr& r) 
     {
-		if (ptr != r.ptr)
+		if (this != &r)
 		{
             if (ptr) ptr->DecRef();
 			ptr = r.ptr;
@@ -54,11 +64,14 @@ public:
         return *this;
     }
 
-    RefCountedPtr & operator=(const RefCountedPtr&& r)
+    RefCountedPtr & operator=(RefCountedPtr&& r)
     {
-        if (ptr) ptr->DecRef();
-        ptr = r.ptr;
-		r.ptr = nullptr;
+		if (this != &r)
+		{
+			if (ptr) ptr->DecRef();
+			ptr = r.ptr;
+			r.ptr = nullptr;
+		}
         return *this;
     }
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -903,6 +903,7 @@ static void End2DAndUpdate()
 	twod->End();
 	CheckBench();
 	screen->Update();
+	twod->OnFrameDone();
 }
 
 //==========================================================================


### PR DESCRIPTION
What's included:
- #1446 squashed to a single commit
- `RefCountedPtr` follows rule of five
- `RefCountedBase` without virtual destructor
- `RefCountedPtr` manages 2D shape buffer infos