### PR TITLE
Add FOV slider to the display options menu

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -947,6 +947,8 @@ OptionMenu "VideoOptions" protected
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
 	StaticText " "
+	Slider "$DSPLYMNU_FOV",						"fov",							75.0, 120.0, 0.1, 1
+	StaticText " "
 	Option "$DSPLYMNU_SPRITESHADOW",			"r_actorspriteshadow", "SpriteShadowModes"
 	Option "$DSPLYMNU_CUSTOMINVERTMAP",			"cl_customizeinvulmap", "OnOff"
 	ColorPicker "$DSPLYMNU_CUSTOMINVERTC1",		"cl_custominvulmapcolor1"

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -69,7 +69,8 @@ OptionMenu VideoOptionsSimple protected
 	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
-
+	StaticText " "
+	Slider "$DSPLYMNU_FOV",						"fov",							75.0, 120.0, 0.1, 1
 	// commenting this out for now, this menu is so general purpose I am not sure it makes sense, but I'm leaving it here just in case
 	// the "full" menu doesn't have some of the options that are in this one.
 	//StaticText " "


### PR DESCRIPTION
This is a very highly sought-after setting, especially for casual players (and also requested by a few let's players). The placement of the slider is intentionally made to stand out from the rest... to make it very easy to find.