### PR TITLE
Bethesda.net support

### DIFF
--- a/src/common/platform/posix/i_system.h
+++ b/src/common/platform/posix/i_system.h
@@ -46,6 +46,8 @@ TArray<FString> I_GetSteamPath();
 
 TArray<FString> I_GetGogPaths();
 
+TArray<FString> I_GetBethesdaPath();
+
 // The ini could not be saved at exit
 bool I_WriteIniFailed ();
 

--- a/src/common/platform/posix/i_system_posix.cpp
+++ b/src/common/platform/posix/i_system_posix.cpp
@@ -50,3 +50,9 @@ TArray<FString> I_GetGogPaths()
 	// GOG's Doom games are Windows only at the moment
 	return TArray<FString>();
 }
+
+TArray<FString> I_GetBethesdaPath()
+{
+	// Bethesda.net Launcher is Windows only at the moment
+	return TArray<FString>();
+}

--- a/src/common/platform/win32/i_system.h
+++ b/src/common/platform/win32/i_system.h
@@ -53,6 +53,9 @@ TArray<FString> I_GetSteamPath();
 // [GZ] Same deal for GOG paths
 TArray<FString> I_GetGogPaths();
 
+// Again for the Bethesda.net Launcher path
+TArray<FString> I_GetBethesdaPath();
+
 // Damn Microsoft for doing Get/SetWindowLongPtr half-assed. Instead of
 // giving them proper prototypes under Win32, they are just macros for
 // Get/SetWindowLong, meaning they take LONGs and not LONG_PTRs.

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -420,6 +420,7 @@ void FIWadManager::CollectSearchPaths()
 	}
 	mSearchPaths.Append(I_GetGogPaths());
 	mSearchPaths.Append(I_GetSteamPath());
+	mSearchPaths.Append(I_GetBethesdaPath());
 
 	// Unify and remove trailing slashes
 	for (auto &str : mSearchPaths)

--- a/src/win32/i_steam.cpp
+++ b/src/win32/i_steam.cpp
@@ -241,3 +241,68 @@ TArray<FString> I_GetSteamPath()
 
 	return result;
 }
+
+//==========================================================================
+//
+// I_GetBethesdaPath
+//
+// Check the registry for the path to the Bethesda.net Launcher, so that we
+// can search for IWADs that were bought from Bethesda.net.
+//
+//==========================================================================
+
+TArray<FString> I_GetBethesdaPath()
+{
+	TArray<FString> result;
+	static const char* const bethesda_dirs[] =
+	{
+		"DOOM_Classic_2019/base",
+		"DOOM_Classic_2019/rerelease/DOOM_Data/StreamingAssets",
+		"DOOM_II_Classic_2019/base",
+		"DOOM_II_Classic_2019/rerelease/DOOM II_Data/StreamingAssets",
+		"DOOM 3 BFG Edition/base/wads",
+		"Heretic Shadow of the Serpent Riders/base",
+		"Hexen/base",
+		"Hexen Deathkings of the Dark Citadel/base"
+
+		// Alternate DOS versions of Doom and Doom II (referred to as "Original" in the
+		// Bethesda Launcher). While the DOS versions that come with the Unity ports are
+		// unaltered, these use WADs from the European PSN versions. These WADs are currently
+		// misdetected by GZDoom: DOOM.WAD is detected as the Unity version (which it's not),
+		// while DOOM2.WAD is detected as the original DOS release despite having Doom 3: BFG
+		// Edition's censored secret level titles (albeit only in the title patches, not in
+		// the automap). Unfortunately, these WADs have exactly the same lump names as the WADs
+		// they're misdetected as, so it's not currently possible to distinguish them using
+		// GZDoom's current IWAD detection system. To prevent them from possibly overriding the
+		// real Unity DOOM.WAD and DOS DOOM2.WAD, these paths have been commented out.
+		//"Ultimate DOOM/base",
+		//"DOOM II/base",
+
+		// Doom Eternal includes DOOM.WAD and DOOM2.WAD, but they're the same misdetected
+		// PSN versions used by the alternate DOS releases above.
+		//"Doom Eternal/base/classicwads"
+	};
+
+#ifdef _WIN64
+	const wchar_t *bethesdaregistrypath = L"Software\\Wow6432Node\\Bethesda Softworks\\Bethesda.net";
+#else
+	// If a 32-bit ZDoom runs on a 64-bit Windows, this will be transparently and
+	// automatically redirected to the Wow6432Node address instead, so this address
+	// should be safe to use in all cases.
+	const wchar_t *bethesdaregistrypath = L"Software\\Bethesda Softworks\\Bethesda.net";
+#endif
+
+	FString path;
+	if (!QueryPathKey(HKEY_LOCAL_MACHINE, bethesdaregistrypath, L"installLocation", path))
+	{
+		return result;
+	}
+	path += "/games/";
+
+	for (unsigned int i = 0; i < countof(bethesda_dirs); ++i)
+	{
+		result.Push(path + bethesda_dirs[i]);
+	}
+
+	return result;
+}


### PR DESCRIPTION
This adds detection for Doom-engine games downloaded via the Bethesda.net Launcher. The process works like it does for Steam, where a certain registry key containing the Bethesda.net Launcher install location is read, and then the default location of each supported game is checked. The following games are currently detected:

* Doom - Unity version and the included DOS version
* Doom II - Unity version and the included DOS version
* Doom 3: BFG Edition
* Heretic
* Hexen
* Hexen: Deathkings of the Dark Citadel

The Bethesda.net Launcher also provides stand-alone DOS versions of Doom and Doom II, separate from the Unity versions; I added these to the code but commented them out. My comment in the source code explains why:

> Alternate DOS versions of Doom and Doom II (referred to as "Original" in the Bethesda Launcher). While the DOS versions that come with the Unity ports are unaltered, these use WADs from the European PSN versions. These WADs are currently misdetected by GZDoom: DOOM.WAD is detected as the Unity version (which it's not), while DOOM2.WAD is detected as the original DOS release despite having Doom 3: BFG Edition's censored secret level titles (albeit only in the title patches, not in the automap). Unfortunately, these WADs have exactly the same lump names as the WADs they're misdetected as, so it's not currently possible to distinguish them using GZDoom's current IWAD detection system. To prevent them from possibly overriding the real Unity DOOM.WAD and DOS DOOM2.WAD, these paths have been commented out.

I also added and commented out the path to Doom Eternal's DOOM.WAD and DOOM2.WAD; these are identical to the misdetected PSN WADs mentioned in the comment.

(And Blzut3, if you're reading this and are interested in adding Bethesda.net support to ECWolf, the game data for Wolfenstein 3D is located in **Wolfenstein 3D\base**.)