### PR TITLE
Limit texture upload transfer buffers to roughly 64 MB

### DIFF
--- a/src/common/rendering/vulkan/system/vk_framebuffer.cpp
+++ b/src/common/rendering/vulkan/system/vk_framebuffer.cpp
@@ -209,15 +209,21 @@ void VulkanFrameBuffer::Update()
 	Super::Update();
 }
 
-void VulkanFrameBuffer::DeleteFrameObjects()
+void VulkanFrameBuffer::DeleteFrameObjects(bool uploadOnly)
 {
-	FrameDeleteList.Images.clear();
-	FrameDeleteList.ImageViews.clear();
-	FrameDeleteList.Framebuffers.clear();
-	FrameDeleteList.Buffers.clear();
-	FrameDeleteList.Descriptors.clear();
-	FrameDeleteList.DescriptorPools.clear();
-	FrameDeleteList.CommandBuffers.clear();
+	FrameTextureUpload.Buffers.clear();
+	FrameTextureUpload.TotalSize = 0;
+
+	if (!uploadOnly)
+	{
+		FrameDeleteList.Images.clear();
+		FrameDeleteList.ImageViews.clear();
+		FrameDeleteList.Framebuffers.clear();
+		FrameDeleteList.Buffers.clear();
+		FrameDeleteList.Descriptors.clear();
+		FrameDeleteList.DescriptorPools.clear();
+		FrameDeleteList.CommandBuffers.clear();
+	}
 }
 
 void VulkanFrameBuffer::FlushCommands(VulkanCommandBuffer **commands, size_t count, bool finish, bool lastsubmit)
@@ -251,11 +257,12 @@ void VulkanFrameBuffer::FlushCommands(VulkanCommandBuffer **commands, size_t cou
 	mNextSubmit++;
 }
 
-void VulkanFrameBuffer::FlushCommands(bool finish, bool lastsubmit)
+void VulkanFrameBuffer::FlushCommands(bool finish, bool lastsubmit, bool uploadOnly)
 {
-	mRenderState->EndRenderPass();
+	if (!uploadOnly)
+		mRenderState->EndRenderPass();
 
-	if (mDrawCommands || mTransferCommands)
+	if ((!uploadOnly && mDrawCommands) || mTransferCommands)
 	{
 		VulkanCommandBuffer *commands[2];
 		size_t count = 0;
@@ -267,7 +274,7 @@ void VulkanFrameBuffer::FlushCommands(bool finish, bool lastsubmit)
 			FrameDeleteList.CommandBuffers.push_back(std::move(mTransferCommands));
 		}
 
-		if (mDrawCommands)
+		if (!uploadOnly && mDrawCommands)
 		{
 			mDrawCommands->end();
 			commands[count++] = mDrawCommands.get();
@@ -280,7 +287,7 @@ void VulkanFrameBuffer::FlushCommands(bool finish, bool lastsubmit)
 	}
 }
 
-void VulkanFrameBuffer::WaitForCommands(bool finish)
+void VulkanFrameBuffer::WaitForCommands(bool finish, bool uploadOnly)
 {
 	if (finish)
 	{
@@ -292,7 +299,7 @@ void VulkanFrameBuffer::WaitForCommands(bool finish)
 			mPostprocess->DrawPresentTexture(mOutputLetterbox, true, false);
 	}
 
-	FlushCommands(finish, true);
+	FlushCommands(finish, true, uploadOnly);
 
 	if (finish)
 	{
@@ -310,7 +317,7 @@ void VulkanFrameBuffer::WaitForCommands(bool finish)
 		vkResetFences(device->device, numWaitFences, mSubmitWaitFences);
 	}
 
-	DeleteFrameObjects();
+	DeleteFrameObjects(uploadOnly);
 	mNextSubmit = 0;
 
 	if (finish)

--- a/src/common/rendering/vulkan/system/vk_framebuffer.h
+++ b/src/common/rendering/vulkan/system/vk_framebuffer.h
@@ -37,7 +37,7 @@ public:
 	VkRenderBuffers *GetBuffers() { return mActiveRenderBuffers; }
 	FRenderState* RenderState() override;
 
-	void FlushCommands(bool finish, bool lastsubmit = false);
+	void FlushCommands(bool finish, bool lastsubmit = false, bool uploadOnly = false);
 
 	unsigned int GetLightBufferBlockSize() const;
 
@@ -63,6 +63,12 @@ public:
 		std::vector<std::unique_ptr<VulkanDescriptorPool>> DescriptorPools;
 		std::vector<std::unique_ptr<VulkanCommandBuffer>> CommandBuffers;
 	} FrameDeleteList;
+
+	struct
+	{
+		std::vector<std::unique_ptr<VulkanBuffer>> Buffers;
+		size_t TotalSize = 0;
+	} FrameTextureUpload;
 
 	VulkanFrameBuffer(void *hMonitor, bool fullscreen, VulkanDevice *dev);
 	~VulkanFrameBuffer();
@@ -103,7 +109,8 @@ public:
 
 	void Draw2D() override;
 
-	void WaitForCommands(bool finish) override;
+	void WaitForCommands(bool finish) override { WaitForCommands(finish, false); }
+	void WaitForCommands(bool finish, bool uploadOnly);
 
 	void PushGroup(const FString &name);
 	void PopGroup();
@@ -116,7 +123,7 @@ private:
 	void PrintStartupLog();
 	void CreateFanToTrisIndexBuffer();
 	void CopyScreenToBuffer(int w, int h, uint8_t *data) override;
-	void DeleteFrameObjects();
+	void DeleteFrameObjects(bool uploadOnly = false);
 	void FlushCommands(VulkanCommandBuffer **commands, size_t count, bool finish, bool lastsubmit);
 
 	std::unique_ptr<VkShaderManager> mShaderManager;


### PR DESCRIPTION
This limits the texture transfer buffers during a frame to never be more than 64 MB (plus the size of the texture that made it go over the limit).