### PR TITLE
Fix broken text input when SDL2 is using Wayland

### DIFF
--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -147,6 +147,8 @@ namespace Priv
 		{
 			// Enforce minimum size limit
 			SDL_SetWindowMinimumSize(Priv::window, VID_MIN_WIDTH, VID_MIN_HEIGHT);
+			// Tell SDL to start sending text input on Wayland.
+			if (strncasecmp(SDL_GetCurrentVideoDriver(), "wayland", 7) == 0) SDL_StartTextInput();
 		}
 	}
 


### PR DESCRIPTION
This PR fixes broken text input when SDL2 is using the Wayland video backend.