### PR TITLE
GLES: Only use GPU sync if necessary and available.

### DIFF
--- a/src/common/rendering/gles/gles_buffers.cpp
+++ b/src/common/rendering/gles/gles_buffers.cpp
@@ -235,28 +235,34 @@ void GLBuffer::Resize(size_t newsize)
 void GLBuffer::GPUDropSync()
 {
 #if !(USE_GLES2)  // Only applicable when running on desktop for now
-	if (mGLSync != NULL)
+	if (gles.useMappedBuffers && glFenceSync && glClientWaitSync)
 	{
-		glDeleteSync(mGLSync);
-	}
+		if (mGLSync != NULL)
+		{
+			glDeleteSync(mGLSync);
+		}
 
-	mGLSync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+		mGLSync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+	}
 #endif
 }
 
 void GLBuffer::GPUWaitSync()
 {
 #if !(USE_GLES2)  // Only applicable when running on desktop for now
-	GLenum status = glClientWaitSync(mGLSync, GL_SYNC_FLUSH_COMMANDS_BIT, 1000 * 1000 * 50); // Wait for a max of 50ms...
-
-	if (status != GL_ALREADY_SIGNALED && status != GL_CONDITION_SATISFIED)
+	if (gles.useMappedBuffers && glFenceSync && glClientWaitSync)
 	{
-		//Printf("Error on glClientWaitSync: %d\n", status);
+		GLenum status = glClientWaitSync(mGLSync, GL_SYNC_FLUSH_COMMANDS_BIT, 1000 * 1000 * 50); // Wait for a max of 50ms...
+
+		if (status != GL_ALREADY_SIGNALED && status != GL_CONDITION_SATISFIED)
+		{
+			//Printf("Error on glClientWaitSync: %d\n", status);
+		}
+
+		glDeleteSync(mGLSync);
+
+		mGLSync = NULL;
 	}
-
-	glDeleteSync(mGLSync);
-
-	mGLSync = NULL;
 #endif
 }
 


### PR DESCRIPTION
If there are complaints of reduced performance, or visual artefacts compared to 4.6.1, it may be worth increasing HW_MAX_PIPELINE_BUFFERS to 4 again.