### PR TITLE
gles: look for libGLESv2.so.2

### DIFF
--- a/src/common/rendering/gles/gles_system.cpp
+++ b/src/common/rendering/gles/gles_system.cpp
@@ -32,6 +32,10 @@ static void* LoadGLES2Proc(const char* name)
 		{
 			glesLib = dlopen("libGLESv2.so", flags);
 		}
+		if(!glesLib)
+		{
+			glesLib = dlopen("libGLESv2.so.2", flags);
+		}
 	}
 
 	void * ret = NULL;


### PR DESCRIPTION
Distros do not have the .so files at all times, because those are
counted as development and not runtime.