### PR TITLE
Fix vulkan "out of memory" errors for zero sized buffers

### DIFF
--- a/src/common/rendering/vulkan/system/vk_builders.h
+++ b/src/common/rendering/vulkan/system/vk_builders.h
@@ -571,7 +571,7 @@ inline BufferBuilder::BufferBuilder()
 
 inline void BufferBuilder::setSize(size_t size)
 {
-	bufferInfo.size = size;
+	bufferInfo.size = std::max(size, (size_t)16);
 }
 
 inline void BufferBuilder::setUsage(VkBufferUsageFlags bufferUsage, VmaMemoryUsage memoryUsage, VmaAllocationCreateFlags allocFlags)


### PR DESCRIPTION
This fixes the vulkan error for when the hardware renderer decides it absolutely must have a buffer of zero bytes!