### PR TITLE
Allow map markers to scale relative to automap zoom

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -3130,11 +3130,20 @@ void DAutomap::drawAuthorMarkers ()
 		auto it = Level->GetActorIterator(mark->args[0]);
 		AActor *marked = mark->args[0] == 0 ? mark : it.Next();
 
+		double xscale = mark->Scale.X;
+		double yscale = mark->Scale.Y;
+		// [MK] scale with automap zoom if args[2] is 1, otherwise keep a constant scale
+		if (mark->args[2] == 1)
+		{
+			xscale = MTOF(xscale);
+			yscale = MTOF(yscale);
+		}
+
 		while (marked != nullptr)
 		{
 			if (mark->args[1] == 0 || (mark->args[1] == 1 && (marked->subsector->flags & SSECMF_DRAWN)))
 			{
-				DrawMarker (tex, marked->X(), marked->Y(), 0, flip, mark->Scale.X, mark->Scale.Y, mark->Translation,
+				DrawMarker (tex, marked->X(), marked->Y(), 0, flip, xscale, yscale, mark->Translation,
 					mark->Alpha, mark->fillcolor, mark->RenderStyle);
 			}
 			marked = mark->args[0] != 0 ? it.Next() : nullptr;

--- a/wadsrc/static/zscript/actors/shared/mapmarker.zs
+++ b/wadsrc/static/zscript/actors/shared/mapmarker.zs
@@ -7,6 +7,9 @@
 //   args[1] == 0, show the sprite always
 //           == 1, show the sprite only after its sector has been drawn
 //
+//   args[2] == 0, show the sprite with a constant scale
+//           == 1, show the sprite with a scale relative to automap zoom
+//
 // To enable display of the sprite, activate it. To turn off the sprite,
 // deactivate it.
 //


### PR DESCRIPTION
When `args[2] == 1`, map markers will scale relative to the automap zoom, rather than keep a constant scale.

Example usage here: [mapmarkers_test.zip](https://github.com/coelckers/gzdoom/files/7302739/mapmarkers_test.zip)

This example automatically marks uncollected ammo in the automap and displays it once it has been first seen by the player. Without relative scaling, this would easily make the automap become too cluttered, but with it, the sprites zoom out appropriately.
