### PR TITLE
Compat patch for misplaced items in Hexen MAP08

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -987,6 +987,15 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case '6CDA2721AA1076F063557CF89D88E92B': // hexen.wad map08
+			{
+				// Amulet of warding accidentally shifted outside of map
+				SetThingXY(256,-1632,2352);
+				// Icon of the defender outside of map
+				SetThingSkills(261,0);
+				break;
+			}
+
 			case '39C594CAC07EE51C80F757DA465FCC94': // strife1.wad map10
 			{
 				// fix the shooting range by matching sector 138 and 145 properties together


### PR DESCRIPTION
Amulet of Warding (thing 256) apparently being shifted outside of the map between IWAD versions, restored to its original position.
Icon of the Defender (thing 261) always out of bounds, removed entirely.