### PR TITLE
Allow customization of pause screen

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1026,18 +1026,31 @@ void D_Display ()
 		// draw pause pic
 		if ((paused || pauseext) && menuactive == MENU_Off)
 		{
-			auto tex = TexMan.GetGameTextureByName(gameinfo.PauseSign, true);
-			double x = (SCREENWIDTH - tex->GetDisplayWidth() * CleanXfac)/2 +
-				tex->GetDisplayLeftOffset() * CleanXfac;
-			DrawTexture(twod, tex, x, 4, DTA_CleanNoMove, true, TAG_DONE);
-			if (paused && multiplayer)
+			// [MK] optionally let the status bar handle this
+			bool skip = false;
+			IFVIRTUALPTR(StatusBar, DBaseStatusBar, DrawPaused)
 			{
-				FFont *font = generic_ui? NewSmallFont : SmallFont;
-				FString pstring = GStrings("TXT_BY");
-				pstring.Substitute("%s", players[paused - 1].userinfo.GetName());
-				DrawText(twod, font, CR_RED,
-					(twod->GetWidth() - font->StringWidth(pstring)*CleanXfac) / 2,
-					(tex->GetDisplayHeight() * CleanYfac) + 4, pstring, DTA_CleanNoMove, true, TAG_DONE);
+				VMValue params[] { (DObject*)StatusBar, paused-1 };
+				int rv;
+				VMReturn ret(&rv);
+				VMCall(func, params, countof(params), &ret, 1);
+				skip = !!rv;
+			}
+			if ( !skip )
+			{
+				auto tex = TexMan.GetGameTextureByName(gameinfo.PauseSign, true);
+				double x = (SCREENWIDTH - tex->GetDisplayWidth() * CleanXfac)/2 +
+					tex->GetDisplayLeftOffset() * CleanXfac;
+				DrawTexture(twod, tex, x, 4, DTA_CleanNoMove, true, TAG_DONE);
+				if (paused && multiplayer)
+				{
+					FFont *font = generic_ui? NewSmallFont : SmallFont;
+					FString pstring = GStrings("TXT_BY");
+					pstring.Substitute("%s", players[paused - 1].userinfo.GetName());
+					DrawText(twod, font, CR_RED,
+						(twod->GetWidth() - font->StringWidth(pstring)*CleanXfac) / 2,
+						(tex->GetDisplayHeight() * CleanYfac) + 4, pstring, DTA_CleanNoMove, true, TAG_DONE);
+				}
 			}
 		}
 

--- a/wadsrc/static/zscript/ui/statusbar/statusbar.zs
+++ b/wadsrc/static/zscript/ui/statusbar/statusbar.zs
@@ -235,6 +235,8 @@ class BaseStatusBar : StatusBarCore native
 	virtual bool ProcessMidPrint(Font fnt, String msg, bool bold) { return false; }
 	// [MK] let the HUD handle drawing the chat prompt
 	virtual bool DrawChat(String txt) { return false; }
+	// [MK] let the HUD handle drawing the pause graphics
+	virtual bool DrawPaused(int player) { return false; }
 
 	native TextureID GetMugshot(int accuracy, int stateflags=MugShot.STANDARD, String default_face = "STF");
 	native int GetTopOfStatusBar();


### PR DESCRIPTION
I admit I did this one on a whim. Just like with previous customization features, this goes through a virtual function in the status bar.

Example showing an UT-style pause screen: [custompause_test.zip](https://github.com/coelckers/gzdoom/files/7357225/custompause_test.zip)