### PR TITLE
`D_ProcessEvents()`: Delay `EV_KeyUp` events until any `EV_KeyDown` event have been processed.

### DIFF
--- a/src/common/engine/d_event.cpp
+++ b/src/common/engine/d_event.cpp
@@ -68,7 +68,7 @@ CVAR(Bool, m_filter, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 void D_ProcessEvents (void)
 {
 	bool keywasdown[NUM_KEYS] = { false };
-	TArray<event_t*> delayedevents;
+	TArray<event_t> delayedevents;
 
 	while (eventtail != eventhead)
 	{
@@ -77,7 +77,7 @@ void D_ProcessEvents (void)
 
 		if (ev->type == EV_KeyUp && keywasdown[ev->data1])
 		{
-			delayedevents.Push(ev);
+			delayedevents.Push(*ev);
 			continue;
 		}
 
@@ -99,7 +99,7 @@ void D_ProcessEvents (void)
 
 	for (auto& ev: delayedevents)
 	{
-		D_PostEvent(ev);
+		D_PostEvent(&ev);
 	}
 }
 


### PR DESCRIPTION
Presenting this here for linking through to the forum for testing. This fixes a lot of issues under the SDL interface where mouse button input could appear not to be registered. This should also make mouse wheel operations across all platforms better as well.