### PR TITLE
Fix some issues with DStatusBarCore::DrawString

### DIFF
--- a/src/common/statusbar/base_sbar.cpp
+++ b/src/common/statusbar/base_sbar.cpp
@@ -754,7 +754,7 @@ void DStatusBarCore::DrawString(FFont* font, const FString& cstring, double x, d
 	{
 		if (ch == ' ')
 		{
-			x += monospaced ? spacing : font->GetSpaceWidth() + spacing;
+			x += (monospaced ? spacing : font->GetSpaceWidth() + spacing) * scaleX;
 			continue;
 		}
 		else if (ch == TEXTCOLOR_ESCAPE)
@@ -774,7 +774,7 @@ void DStatusBarCore::DrawString(FFont* font, const FString& cstring, double x, d
 		width += font->GetDefaultKerning();
 
 		if (!monospaced) //If we are monospaced lets use the offset
-			x += (c->GetDisplayLeftOffset() + 1); //ignore x offsets since we adapt to character size
+			x += c->GetDisplayLeftOffset() * scaleX + 1; //ignore x offsets since we adapt to character size
 
 		double rx, ry, rw, rh;
 		rx = x + drawOffset.X;
@@ -825,12 +825,12 @@ void DStatusBarCore::DrawString(FFont* font, const FString& cstring, double x, d
 			DTA_LegacyRenderStyle, ERenderStyle(style),
 			TAG_DONE);
 
-		dx = monospaced
-			? spacing
-			: width + spacing - (c->GetDisplayLeftOffset() + 1);
-
 		// Take text scale into account
-		x += dx * scaleX;
+		dx = monospaced
+			? spacing * scaleX
+			: (double(width) + spacing - c->GetDisplayLeftOffset()) * scaleX - 1;
+
+		x += dx;
 	}
 }
 


### PR DESCRIPTION
See [here](https://forum.zdoom.org/viewtopic.php?f=2&t=73669) for details.

This fixes two issues with the current scaling implementation of ```DStatusBarCore::DrawString```:

1. Scale didn't apply to spaces.
2. Fonts with offsets did not display correctly (glyphs were erroneously shifted to the side).

No idea how I didn't notice issue no. 1 back then, sorry about that.

Note that font offsets don't actually seem to work at this time, and this is not related to scaling at all. I can see in the debugger that the X-coordinates are being calculated correctly for glyphs that have offsets, but they always get drawn as if they didn't have one regardless - not sure if a bug or a missing feature.