### PR TITLE
Fixed an old regression with printing map char arrays in ACS.

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -8570,7 +8570,7 @@ scriptwait:
 				int capacity, offset, a, c;
 				if (CharArrayParms(capacity, offset, a, Stack, sp, pcd == PCD_PRINTMAPCHRANGE))
 				{
-					while (capacity-- && (c = activeBehavior->GetArrayVal (a, offset)) != '\0')
+					while (capacity-- && (c = activeBehavior->GetArrayVal (*activeBehavior->MapVars[a], offset)) != '\0')
 					{
 						work += (char)c;
 						offset++;


### PR DESCRIPTION
This patch fixes an over seven year old regression introduced with 4c6edd5, when script array support was added to ZDoom. The regression exists in the handling of `PCD_PRINTMAPCHARARRAY`/`PCD_PRINTMAPCHRANGE`, which is given a map variable from the stack, and this map variable acts as a pointer to an array. When script arrays were added, the code for char arrays was genericised into `CharArrayParms`, with the reference parameter `a` returning the number currently at the top of the stack. For map char arrays, the code incorrectly treats this number from the stack as the index of the array, not a map variable pointing to the array. This patch corrects this so the map array is once again dereferenced from this map variable's value.

This bug was discovered because Zandronum recently backported this change, and a Zandronum mod which uses map char arrays for some stuff was suddenly rendering nothing instead of the text that was supposed to be there. After a little while of analysis the commit that introduced this, I noticed what was missing...

----

For good measure, a WAD I used to test this bug has been attached, and here's its ACS source:
```c
#include "zcommon.acs"

int garbage1 = 1; // the mere presence of this seemingly useless variable causes it to break
int testarray[100];

Script "setup char array" OPEN {
	str val = "world!!!";

	// copy val into testarray
	for (int i = 0; i < StrLen(val); i++) {
		testarray[i] = GetChar(val, i);
	}
}

Script "test char array" (void) {
	Print(s: "hello ", a: testarray);
}
```
[chararraytest.zip](https://github.com/coelckers/gzdoom/files/7614689/chararraytest.zip)
