### PR TITLE
Exported the "paused" global variable to ZScript

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -3140,3 +3140,4 @@ DEFINE_GLOBAL(demoplayback)
 DEFINE_GLOBAL(automapactive);
 DEFINE_GLOBAL(Net_Arbitrator);
 DEFINE_GLOBAL(netgame);
+DEFINE_GLOBAL(paused);

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -183,6 +183,7 @@ struct _ native	// These are the global variables, the struct is only here to av
 	native MenuDelegateBase menuDelegate;
 	native readonly int consoleplayer;
 	native readonly double NotifyFontScale;
+	native readonly int paused;
 }
 
 struct System native
@@ -202,7 +203,6 @@ struct System native
 		}
 		return false;
 	}
-	 	
 }
 
 struct MusPlayingInfo native


### PR DESCRIPTION
This PR exports the ```paused``` global variable to ZScript to detect if the game is currently paused and also the number of the player who paused the game (calculated by subtracting 1 from the value). Original feature request is [here](https://forum.zdoom.org/viewtopic.php?f=15&t=71467).

Note that I've decided not to expose the ```pauseext``` flag, which, as far I can tell, is only raised when the game is on pause due to focus loss. The reasoning behind this decision is that user code need not be aware of this state because when the game is out of focus it is suspended entirely. If I was mistaken and ```pauseext``` actually does more than that, please correct me (and then I will make appropriate modifications to this PR).