### PR TITLE
Trim Sprite Border Option

### DIFF
--- a/src/common/textures/texture.cpp
+++ b/src/common/textures/texture.cpp
@@ -439,16 +439,24 @@ TArray<uint8_t> FTexture::Get8BitPixels(bool alphatex)
 // 
 //  Finds empty space around the texture. 
 //  Used for sprites that got placed into a huge empty frame.
+//	Disabled if r_trimspriteborders is 0
 //
 //===========================================================================
 
+CUSTOM_CVAR(Bool, r_trimspriteborders, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	Printf("An engine restart is required for this to take effect.\n");
+}
+
 bool FTexture::TrimBorders(uint16_t* rect)
 {
-
 	auto texbuffer = CreateTexBuffer(0);
 	int w = texbuffer.mWidth;
 	int h = texbuffer.mHeight;
 	auto Buffer = texbuffer.mBuffer;
+	
+	if (!r_trimspriteborders)
+		return false;
 
 	if (texbuffer.mBuffer == nullptr)
 	{

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -938,6 +938,7 @@ OptionMenu "VideoOptions" protected
 	StaticText " "
 	Slider "$DSPLYMNU_FOV",						"fov",							75.0, 120.0, 0.1, 1
 	StaticText " "
+	Option "$DSPLYMNU_TRIMSPRITEBORDERS",		"r_trimspriteborders", "YesNo"
 	Option "$DSPLYMNU_SPRITESHADOW",			"r_actorspriteshadow", "SpriteShadowModes"
 	Option "$DSPLYMNU_CUSTOMINVERTMAP",			"cl_customizeinvulmap", "OnOff"
 	ColorPicker "$DSPLYMNU_CUSTOMINVERTC1",		"cl_custominvulmapcolor1"


### PR DESCRIPTION
Useful for mods that rely on large canvases for sprite positions. Defaults to off.

Note:
**$DSPLYMNU_TRIMSPRITEBORDERS** needs a language definition: `Trim Sprite Borders`