### PR TITLE
NoTrim TEXTURES definition

### DIFF
--- a/src/common/textures/formats/multipatchtexture.h
+++ b/src/common/textures/formats/multipatchtexture.h
@@ -120,6 +120,7 @@ struct BuildInfo
 	bool bComplex = false;
 	bool textual = false;
 	bool bNoDecals = false;
+	bool bNoTrim = false;
 	int LeftOffset[2] = {};
 	int TopOffset[2] = {};
 	FGameTexture *texture = nullptr;

--- a/src/common/textures/gametexture.cpp
+++ b/src/common/textures/gametexture.cpp
@@ -311,7 +311,7 @@ void FGameTexture::SetupSpriteData()
 
 		if (i == 1 && ShouldExpandSprite())
 		{
-			spi.mTrimResult = Base->TrimBorders(spi.trim);	// get the trim size before adding the empty frame
+			spi.mTrimResult = Base->TrimBorders(spi.trim) && !GetNoTrimming();	// get the trim size before adding the empty frame
 			spi.spriteWidth += 2;
 			spi.spriteHeight += 2;
 		}

--- a/src/common/textures/gametexture.h
+++ b/src/common/textures/gametexture.h
@@ -59,6 +59,7 @@ enum EGameTexFlags
 	GTexf_BrightmapChecked = 128,			// Check for a colormap-based brightmap was already done.
 	GTexf_AutoMaterialsAdded = 256,			// AddAutoMaterials has been called on this texture.
 	GTexf_OffsetsNotForFont = 512,			// The offsets must be ignored when using this texture in a font.
+	GTexf_NoTrim = 1024,					// Don't perform trimming on this texture.
 };
 
 // Refactoring helper to allow piece by piece adjustment of the API
@@ -155,6 +156,8 @@ public:
 	bool expandSprites() { return expandSprite == -1? ShouldExpandSprite() : !!expandSprite; }
 	bool useWorldPanning() const { return !!(flags & GTexf_WorldPanning);  }
 	void SetWorldPanning(bool on) { if (on) flags |= GTexf_WorldPanning; else flags &= ~GTexf_WorldPanning; }
+	void SetNoTrimming(bool on) { if (on) flags |= GTexf_NoTrim; else flags &= ~GTexf_NoTrim; }
+	bool GetNoTrimming() { return !!(flags & GTexf_NoTrim); }
 	bool allowNoDecals() const { return !!(flags & GTexf_NoDecals);	}
 	void SetNoDecals(bool on) { if (on) flags |= GTexf_NoDecals; else flags &= ~GTexf_NoDecals; }
 	void SetOffsetsNotForFont() { flags |= GTexf_OffsetsNotForFont; }

--- a/src/common/textures/multipatchtexturebuilder.cpp
+++ b/src/common/textures/multipatchtexturebuilder.cpp
@@ -144,6 +144,7 @@ void FMultipatchTextureBuilder::MakeTexture(BuildInfo &buildinfo, ETextureType u
 	buildinfo.texture->SetScale((float)buildinfo.Scale.X, (float)buildinfo.Scale.Y);
 	buildinfo.texture->SetWorldPanning(buildinfo.bWorldPanning);
 	buildinfo.texture->SetNoDecals(buildinfo.bNoDecals);
+	buildinfo.texture->SetNoTrimming(buildinfo.bNoTrim);
 	TexMan.AddGameTexture(buildinfo.texture);
 }
 
@@ -668,6 +669,10 @@ void FMultipatchTextureBuilder::ParseTexture(FScanner &sc, ETextureType UseType,
 			else if (sc.Compare("NoDecals"))
 			{
 				buildinfo.bNoDecals = true;
+			}
+			else if (sc.Compare("NoTrim"))
+			{
+				buildinfo.bNoTrim = true;
 			}
 			else if (sc.Compare("Patch"))
 			{

--- a/src/common/textures/texturemanager.cpp
+++ b/src/common/textures/texturemanager.cpp
@@ -811,6 +811,22 @@ void FTextureManager::ParseTextureDef(int lump, FMultipatchTextureBuilder &build
 			}				
 			//else Printf("Unable to define hires texture '%s'\n", tex->Name);
 		}
+		else if (sc.Compare("notrim"))
+		{
+			sc.MustGetString();
+
+			FTextureID id = TexMan.CheckForTexture(sc.String, ETextureType::Sprite);
+			if (id.isValid())
+			{
+				FGameTexture *tex = TexMan.GetGameTexture(id);
+
+				if (tex)	tex->SetNoTrimming(true);
+				else		sc.ScriptError("NoTrim: %s not found", sc.String);
+			}
+			else
+				sc.ScriptError("NoTrim: %s is not a sprite", sc.String);
+
+		}
 		else if (sc.Compare("texture"))
 		{
 			build.ParseTexture(sc, ETextureType::Override, lump);

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -455,6 +455,17 @@ void FTextureAnimator::ParseAnim (FScanner &sc, ETextureType usetype)
 			defined = 1;
 			ani = ParseRangeAnim (sc, picnum, usetype, missing);
 		}
+		else if (sc.Compare("notrim"))
+		{
+			if (picnum.isValid())
+			{
+				auto tex = TexMan.GetGameTexture(picnum);
+
+				if (tex)	tex->SetNoTrimming(true);
+				else		sc.ScriptError("NoTrim: %s not found", sc.String);
+			}
+			else sc.ScriptError("NoTrim: %s is not a sprite", sc.String);
+		}
 		else if (sc.Compare ("pic"))
 		{
 			if (defined == 1)


### PR DESCRIPTION
Added NoTrim for TEXTURES.

- This can be applied either in or outside of a definition of a texture.
- Simply adding "NoTrim" inside a definition will apply it.
- Syntax outside of a sprite is `NoTrim <SpriteName>`.