### PR TITLE
- make `m_quickexit` a global CVAR

### DIFF
--- a/src/common/menu/messagebox.cpp
+++ b/src/common/menu/messagebox.cpp
@@ -43,7 +43,7 @@
 void M_StartControlPanel(bool makeSound, bool scaleoverride = false);
 FName MessageBoxClass = NAME_MessageBoxMenu;
 
-CVAR(Bool, m_quickexit, false, CVAR_ARCHIVE)
+CVAR(Bool, m_quickexit, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 typedef void(*hfunc)();
 DEFINE_ACTION_FUNCTION(DMessageBoxMenu, CallHandler)


### PR DESCRIPTION
I'm testing a mod I'm working on with the supported games (IWADs), and I find it a little inconvenient having to enable this option for each game (when launched for the first time, that is).