### PR TITLE
MBF21 DEHACKED Bugfixes

### DIFF
--- a/src/common/engine/namedef.h
+++ b/src/common/engine/namedef.h
@@ -943,6 +943,7 @@ xx(A_FirePlasma)
 xx(A_FireBFG)
 xx(A_FireOldBFG)
 xx(A_FireRailgun)
+xx(A_ConsumeAmmo)
 
 // color channels
 xx(a)

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -886,12 +886,12 @@ static void CreateWeaponBulletAttackFunc(FunctionCallEmitter &emitters, int valu
 
 static void CreateWeaponMeleeAttackFunc(FunctionCallEmitter &emitters, int value1, int value2, MBFParamState* state)
 {
-	state->ValidateArgCount(5, "A_WeaponBulletAttack");
+	state->ValidateArgCount(5, "A_WeaponMeleeAttack");
 	emitters.AddParameterIntConst(state->GetIntArg(0, 2));
 	emitters.AddParameterIntConst(state->GetIntArg(1, 10));
 	emitters.AddParameterFloatConst(state->GetFloatArg(2, 1));
-	emitters.AddParameterIntConst(state->GetIntArg(3));
-	emitters.AddParameterIntConst(state->GetIntArg(4));
+	emitters.AddParameterIntConst(state->GetSoundArg(3));
+	emitters.AddParameterFloatConst(state->GetFloatArg(4));
 }
 
 static void CreateWeaponSoundFunc(FunctionCallEmitter &emitters, int value1, int value2, MBFParamState* state)

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -184,7 +184,7 @@ struct MBFParamState
 	int GetSoundArg(int i, int def = 0)
 	{
 		int num = argsused & (1 << i) ? (int)args[i] : def;
-		if (num > 0 && num < int(SoundMap.Size())) return SoundMap[num];
+		if (num > 0 && num <= int(SoundMap.Size())) return SoundMap[num-1];
 		return 0;
 	}
 

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -237,6 +237,7 @@ static AmmoPerAttack AmmoPerAttacks[] = {
 	{ NAME_A_FireBFG, -1},	// uses deh.BFGCells
 	{ NAME_A_FireOldBFG, 1},
 	{ NAME_A_FireRailgun, 1},
+	{ NAME_A_ConsumeAmmo, 1}, // MBF21
 	{ NAME_None, 0}
 };
 

--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -994,7 +994,7 @@ class Weapon : StateProvider
 	//
 	//===========================================================================
 
-	virtual bool DepleteAmmo(bool altFire, bool checkEnough = true, int ammouse = -1)
+	virtual bool DepleteAmmo(bool altFire, bool checkEnough = true, int ammouse = -1, bool forceammouse = false)
 	{
 		if (!(sv_infiniteammo || (Owner.FindInventory ('PowerInfiniteAmmo', true) != null)))
 		{
@@ -1006,7 +1006,7 @@ class Weapon : StateProvider
 			{
 				if (Ammo1 != null)
 				{
-					if (ammouse >= 0 && bDehAmmo)
+					if (ammouse >= 0 && (bDehAmmo || forceammouse))
 					{
 						Ammo1.Amount -= ammouse;
 					}

--- a/wadsrc/static/zscript/actors/mbf21.zs
+++ b/wadsrc/static/zscript/actors/mbf21.zs
@@ -503,9 +503,9 @@ extend class Weapon
 
 	// needed to call A_SeekerMissile with proper defaults.
 	deprecated("2.3", "for Dehacked use only")
-	void MBF21_SeekTracer(int threshold, int turnmax)
+	void MBF21_SeekTracer(double threshold, double turnmax)
 	{
-		A_SeekerMissile(threshold, turnmax);
+		A_SeekerMissile(threshold, turnmax); // args get truncated to ints here, but it's close enough
 	}
 
 }

--- a/wadsrc/static/zscript/actors/mbf21.zs
+++ b/wadsrc/static/zscript/actors/mbf21.zs
@@ -198,7 +198,9 @@ extend class Actor
 	//
 	void A_FindTracer(double fov, int dist)
 	{
-		if (!tracer) tracer = RoughMonsterSearch(dist, fov: fov);
+		// note: mbf21 fov is the angle of the entire cone, while
+		// zdoom fov is defined as 1/2 of the cone, so halve it.
+		if (!tracer) tracer = RoughMonsterSearch(dist, fov: fov/2);
 	}
 
 	//

--- a/wadsrc/static/zscript/actors/mbf21.zs
+++ b/wadsrc/static/zscript/actors/mbf21.zs
@@ -505,7 +505,7 @@ extend class Weapon
 	deprecated("2.3", "for Dehacked use only")
 	void MBF21_SeekTracer(double threshold, double turnmax)
 	{
-		A_SeekerMissile(threshold, turnmax); // args get truncated to ints here, but it's close enough
+		A_SeekerMissile(threshold, turnmax, flags: SMF_PRECISE); // args get truncated to ints here, but it's close enough
 	}
 
 }

--- a/wadsrc/static/zscript/actors/mbf21.zs
+++ b/wadsrc/static/zscript/actors/mbf21.zs
@@ -316,11 +316,9 @@ extend class Weapon
 		FTranslatedLineTarget t;
 
 		angle += self.angle;
-		double x = Spawnofs_xy * cos(angle);
-		double y = Spawnofs_xy * sin(angle);
-		let pos = self.Vec3Offset(x, y, Spawnofs_z);
+		Vector2 ofs = AngleToVector(self.Angle - 90, spawnofs_xy);
 
-		let mo = SpawnPlayerMissile(type, angle, pos.X, pos.Y, pos.Z, pLineTarget: t);
+		let mo = SpawnPlayerMissile(type, angle, ofs.x, ofs.y, Spawnofs_z, pLineTarget: t);
 		if (!mo) return;
 
 		Pitch += mo.PitchFromVel();

--- a/wadsrc/static/zscript/actors/mbf21.zs
+++ b/wadsrc/static/zscript/actors/mbf21.zs
@@ -430,7 +430,7 @@ extend class Weapon
 		if (!weap) return;
 
 		if (consume == 0) consume = -1;
-		weap.DepleteAmmo(weap.bAltFire, false, consume);
+		weap.DepleteAmmo(weap.bAltFire, false, consume, true);
 	}
 
 	//


### PR DESCRIPTION
This PR is a big collection of MBF21 DEHACKED bugfixes, taking care of the following:
- The various A_*Sound functions had their indices off-by-one -- blame Killough for this bit of weirdness. :P
- A_WeaponProjectile was spawning projectiles at the origin, rather than the player's position.
- A_WeaponMeleeAttack's definition function had some copy+paste oopses (wrong name & arg types)
- A_ConsumeAmmo should take 1 ammo, not 0, if the `ammo per shot` field on the weapon is not set.
  - This one's my bad -- the spec doesn't say what to do here :( -- I'll need to amend it at some point, but this change brings it in line with the desired behavior (which is what all other implementing ports do currently), so everyone will be compliant-in-advance of the new change. :P
- A_ConsumeAmmo was ignoring the arg in favor of the `ammo per shot` field if the latter was set.
- A_SeekTracer was non-functional due to an arg type mismatch (I think? changing the args to double fixed it.)
- Added SMF_PRECISE flag to A_SeekTracer (MBF21 seekers target the center of the monster and always do z-tracking, as Satan intended ;)
- A_FindTracer's cone was twice as big as intended (GZD's "fov" field appears to define _half_ the size of the cone, i.e. angle from center, rather than the full FOV angle. In MBF21 it's the latter. Should probably clarify this in the spec while I'm there.)

Somewhat selfishly, this is just enough to get [Vesper](https://www.doomworld.com/forum/topic/123800-v100-vesper-mbf21-showcase-mod) up and running, so I haven't fully audited the entire feature-set just yet. I'm planning on doing a set of monsters for Vesper at some point vaguely-soonish though, so I'll be taking a look at all the actor/monster pointers around then.