### PR TITLE
Fixed: opaque blood decals did not respect the GAMEINFO's blood color…

### DIFF
--- a/src/gamedata/decallib.cpp
+++ b/src/gamedata/decallib.cpp
@@ -479,6 +479,7 @@ void FDecalLib::ParseDecal (FScanner &sc)
 
 		case DECAL_OPAQUEBLOOD:
 			newdecal.RenderStyle = STYLE_Normal;
+			newdecal.Translation = TRANSLATION(TRANSLATION_Blood, CreateBloodTranslation(gameinfo.defaultbloodcolor));
 			newdecal.opaqueBlood = true;
 			break;
 		}


### PR DESCRIPTION
…. This fixes opaque blood decals not getting the correct color in Chex Quest, as an example.