### PR TITLE
- Initialize some variables in FModelVertex::Set

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_modelvertexbuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_modelvertexbuffer.cpp
@@ -50,7 +50,7 @@ FModelVertexBuffer::FModelVertexBuffer(bool needindex, bool singleframe)
 		{ 1, VATTR_VERTEX2, VFmt_Float3, (int)myoffsetof(FModelVertex, x) },
 		{ 1, VATTR_NORMAL2, VFmt_Packed_A2R10G10B10, (int)myoffsetof(FModelVertex, packedNormal) }
 	};
-	mVertexBuffer->SetFormat(2, 5, sizeof(FModelVertex), format);
+	mVertexBuffer->SetFormat(2, 6, sizeof(FModelVertex), format);
 }
 
 //===========================================================================

--- a/src/common/rendering/i_modelvertexbuffer.h
+++ b/src/common/rendering/i_modelvertexbuffer.h
@@ -17,6 +17,8 @@ struct FModelVertex
 		z = zz;
 		u = uu;
 		v = vv;
+		lu = 0.0f;
+		lv = 0.0f;
 		lindex = -1.0f;
 	}
 


### PR DESCRIPTION
- Fix wrong normal vector in the FModelVertexBuffer constructor

This fixes models having strange flickering when the model animation frame changes