### PR TITLE
Fix 3d floor-related crash in software renderer

### DIFF
--- a/src/rendering/swrenderer/things/r_visiblesprite.cpp
+++ b/src/rendering/swrenderer/things/r_visiblesprite.cpp
@@ -289,6 +289,9 @@ namespace swrenderer
 			hzt = min(hzt, clip3DFloor.sclipTop);
 		}
 
+		// Make sure bottom clipping stays within the view size
+		botclip = min<short>(botclip, viewheight);
+
 		if (topclip >= botclip)
 		{
 			spr->Light.BaseColormap = colormap;


### PR DESCRIPTION
3d floors can cause the software renderer to set incorrect
sprite clipping values that trigger a buffer overflow (and
a subsequent crash) when rendering sprites. 

Here's a small test wad made by Da Spadger that replicates this crash:
[3dfloor-sprite-clip-crash.zip](https://github.com/coelckers/gzdoom/files/8103400/3dfloor-sprite-clip-crash.zip)

Slowly walking towards the tall red sprite so that it covers the entire screen while facing the dark wall will crash GZDoom.

This PR makes sure that the clipping range stays within the view area before rendering the sprite.

This does not fix the underlying issue that causes the clipping values to go out of range in the first place, not sure if it's worth the effort since clipping looks fine otherwise.

