### PR TITLE
Splash pointer assignments

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6271,6 +6271,7 @@ foundone:
 		if (smallsplash && splash->SmallSplash)
 		{
 			mo = Spawn(sec->Level, splash->SmallSplash, pos, ALLOW_REPLACE);
+			mo->target = thing;
 			if (mo) mo->Floorclip += splash->SmallSplashClip;
 		}
 		else
@@ -6292,6 +6293,7 @@ foundone:
 			if (splash->SplashBase)
 			{
 				mo = Spawn(sec->Level, splash->SplashBase, pos, ALLOW_REPLACE);
+				mo->target = thing;
 			}
 			if (thing->player && !splash->NoAlert && alert)
 			{


### PR DESCRIPTION
Terrain small splashes and splash bases now set their target to the thing that spawned them, allowing for extra customization.

In particular, I have an actor that has a variable size. I'd like to be able to adjust the effect based on its size, but that can only happen with the chunk. This PR resolves that issue.