### PR TITLE
Expose I_nsTime() to ZScript

### DIFF
--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -493,6 +493,11 @@ DEFINE_ACTION_FUNCTION(DObject, MSTime)
 	ACTION_RETURN_INT((uint32_t)I_msTime());
 }
 
+DEFINE_ACTION_FUNCTION(DObject, NSTime)
+{
+	ACTION_RETURN_FLOAT((double)I_nsTime());
+}
+
 void *DObject::ScriptVar(FName field, PType *type)
 {
 	auto cls = GetClass();

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -587,6 +587,7 @@ class Object native
 	private native static Object BuiltinClassCast(Object inptr, Class<Object> test);
 	
 	native static uint MSTime();
+	native static double NSTime();
 	native vararg static void ThrowAbortException(String fmt, ...);
 
 	native virtualscope void Destroy();


### PR DESCRIPTION
Available as `NSTime()` in the `Object` class, returns the value as a double.

I do not have any small runnable examples of its use in action, but it's definitely helped make some profiling measurements in existing projects that previously used `MSTime()` far more accurate and useful.