### PR TITLE
- Added 'ScaleWeaponFOV' flag to MODELDEF. Affects weapon models only…

### DIFF
--- a/src/g_cvars.cpp
+++ b/src/g_cvars.cpp
@@ -161,3 +161,5 @@ CUSTOM_CVAR(String, language, "auto", CVAR_ARCHIVE | CVAR_NOINITCALL | CVAR_GLOB
 	UpdateGenericUI(ui_generic);
 	I_UpdateWindowTitle();
 }
+
+CVAR(Float, cl_scaleweaponfov, 1.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -193,8 +193,16 @@ void RenderHUDModel(FModelRenderer *renderer, DPSprite *psp, float ofsX, float o
 	// but we need to position it correctly in the world for light to work properly.
 	VSMatrix objectToWorldMatrix = renderer->GetViewToWorldMatrix();
 
+	// [Nash] Optional scale weapon FOV
+	float fovscale = 1.0f;
+	if (smf->flags & MDL_SCALEWEAPONFOV)
+	{
+		fovscale = tan(players[consoleplayer].DesiredFOV * (0.5f * M_PI / 180.f));
+		fovscale = 1.f + (fovscale - 1.f) * cl_scaleweaponfov;
+	}
+
 	// Scaling model (y scale for a sprite means height, i.e. z in the world!).
-	objectToWorldMatrix.scale(smf->xscale, smf->zscale, smf->yscale);
+	objectToWorldMatrix.scale(smf->xscale, smf->zscale, smf->yscale / fovscale);
 
 	// Aplying model offsets (model offsets do not depend on model scalings).
 	objectToWorldMatrix.translate(smf->xoffset / smf->xscale, smf->zoffset / smf->zscale, smf->yoffset / smf->yscale);
@@ -527,6 +535,10 @@ static void ParseModelDefLump(int Lump)
 				else if (sc.Compare("noperpixellighting"))
 				{
 					smf.flags |= MDL_NOPERPIXELLIGHTING;
+				}
+				else if (sc.Compare("scaleweaponfov"))
+				{
+					smf.flags |= MDL_SCALEWEAPONFOV;
 				}
 				else if (sc.Compare("rotating"))
 				{

--- a/src/r_data/models.h
+++ b/src/r_data/models.h
@@ -56,6 +56,7 @@ enum
 	MDL_DONTCULLBACKFACES			= 256,
 	MDL_USEROTATIONCENTER			= 512,
 	MDL_NOPERPIXELLIGHTING			= 1024, // forces a model to not use per-pixel lighting. useful for voxel-converted-to-model objects.
+	MDL_SCALEWEAPONFOV				= 2048,	// scale weapon view model with higher user FOVs
 };
 
 FSpriteModelFrame * FindModelFrame(const PClass * ti, int sprite, int frame, bool dropped);
@@ -108,5 +109,7 @@ void BSPWalkCircle(FLevelLocals *Level, float x, float y, float radiusSquared, c
 
 void RenderModel(FModelRenderer* renderer, float x, float y, float z, FSpriteModelFrame* smf, AActor* actor, double ticFrac);
 void RenderHUDModel(FModelRenderer* renderer, DPSprite* psp, float ofsX, float ofsY);
+
+EXTERN_CVAR(Float, cl_scaleweaponfov)
 
 #endif


### PR DESCRIPTION
…; will scale the model along with the user's FOV to reduce distortion.

- Additionally, a 'cl_scaleweaponfov' CVar has been added to allow users to further fine-tune the weapon model scale with higher FOVs

Image comparison without and with:

![Screenshot_Disdain_20220308_044943](https://user-images.githubusercontent.com/4926156/157116007-63c91427-9864-4c82-9263-3ef44a759bcc.png)
![Screenshot_Disdain_20220308_044959](https://user-images.githubusercontent.com/4926156/157116016-bbc0e7eb-3fb1-4368-98f4-1055e67ae830.png)
.