### PR TITLE
Use RDTSC on Linux if possible for stats

### DIFF
--- a/src/common/engine/stats.h
+++ b/src/common/engine/stats.h
@@ -78,13 +78,15 @@ inline uint64_t rdtsc()
 #elif defined __aarch64__
 	// TODO: Implement and test on ARM64
 	return 0;
-#else // i386
+#elif defined __i386__
 	if (CPU.bRDTSC)
 	{
 		uint64_t tsc;
 		asm volatile ("\trdtsc\n" : "=A" (tsc));
 		return tsc;
 	}
+	return 0;
+#else
 	return 0;
 #endif // __amd64__
 }

--- a/src/common/engine/stats.h
+++ b/src/common/engine/stats.h
@@ -54,6 +54,42 @@ public:
 
 #include <time.h>
 
+// [MK] try to use RDTSC on linux if possible
+// avoids excess latency of clock_gettime() on some platforms
+#ifdef __linux__
+extern bool PerfAvailable;
+extern double PerfToSec, PerfToMillisec;
+
+inline uint64_t rdtsc()
+{
+#ifdef __amd64__
+	uint64_t tsc;
+	asm volatile("rdtsc; shlq $32, %%rdx; orq %%rdx, %%rax":"=a"(tsc)::"%rdx");
+	return tsc;
+#elif defined __ppc__
+	unsigned int lower, upper, temp;
+	do
+	{
+		asm volatile ("mftbu %0 \n mftb %1 \n mftbu %2 \n"
+			: "=r"(upper), "=r"(lower), "=r"(temp));
+	}
+	while (upper != temp);
+	return (static_cast<unsigned long long>(upper) << 32) | lower;
+#elif defined __aarch64__
+	// TODO: Implement and test on ARM64
+	return 0;
+#else // i386
+	if (CPU.bRDTSC)
+	{
+		uint64_t tsc;
+		asm volatile ("\trdtsc\n" : "=A" (tsc));
+		return tsc;
+	}
+	return 0;
+#endif // __amd64__
+}
+#endif
+
 class cycle_t
 {
 public:
@@ -64,6 +100,14 @@ public:
 
 	void Clock()
 	{
+#ifdef __linux__
+		if ( PerfAvailable )
+		{
+			int64_t time = rdtsc();
+			Sec -= time * PerfToSec;
+			return;
+		}
+#endif
 		timespec ts;
 
 		clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -72,6 +116,14 @@ public:
 
 	void Unclock()
 	{
+#ifdef __linux__
+		if ( PerfAvailable )
+		{
+			int64_t time = rdtsc();
+			Sec += time * PerfToSec;
+			return;
+		}
+#endif
 		timespec ts;
 
 		clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/src/common/platform/posix/sdl/i_system.cpp
+++ b/src/common/platform/posix/sdl/i_system.cpp
@@ -146,15 +146,14 @@ void CalculateCPUSpeed()
 	PerfToMillisec = PerfToSec = 0.;
 #ifdef __linux__
 	// [MK] read from perf values if we can
-	struct perf_event_attr pe =
-	{
-		.type = PERF_TYPE_HARDWARE,
-		.size = sizeof(struct perf_event_attr),
-		.config = PERF_COUNT_HW_INSTRUCTIONS,
-		.disabled = 1,
-		.exclude_kernel = 1,
-		.exclude_hv = 1
-	};
+	struct perf_event_attr pe;
+	memset(&pe,0,sizeof(struct perf_event_attr));
+	pe.type = PERF_TYPE_HARDWARE;
+	pe.size = sizeof(struct perf_event_attr);
+	pe.config = PERF_COUNT_HW_INSTRUCTIONS;
+	pe.disabled = 1;
+	pe.exclude_kernel = 1;
+	pe.exclude_hv = 1;
 	int fd = syscall(__NR_perf_event_open, &pe, 0, -1, -1, 0);
 	if (fd == -1)
 	{


### PR DESCRIPTION
After some research I figured how to implement this. So far, all seems good, but it should get some testing.

Puts the final nail in the coffin for issue #1479, as it will avoid clock_gettime whenever possible.