### PR TITLE
- look outside the app bundle for iwads on mac

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -110,6 +110,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", user_app_support, true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 		SetValueForKey ("Path", local_app_support, true);
+		SetValueForKey ("Path", "$PROGDIR/../../..", true); // look outside the app bundle
 #elif !defined(__unix__)
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);


### PR DESCRIPTION
Not sure if this would be useful with GZDoom or not. Sometimes GZDoom might be found outside the Applications folder on Mac, particularly with IWAD redistributions and stand-alones. This just adds a /../.. to the search paths to look for iwads there.