### PR TITLE
Use RDTSC equivalent on AARCH64

### DIFF
--- a/src/common/engine/stats.h
+++ b/src/common/engine/stats.h
@@ -76,8 +76,9 @@ inline uint64_t rdtsc()
 	while (upper != temp);
 	return (static_cast<unsigned long long>(upper) << 32) | lower;
 #elif defined __aarch64__
-	// TODO: Implement and test on ARM64
-	return 0;
+	uint64_t vct;
+	asm volatile("mrs %0, cntvct_el0":"=r"(vct));
+	return vct;
 #elif defined __i386__
 	if (CPU.bRDTSC)
 	{
@@ -186,14 +187,15 @@ inline uint64_t rdtsc()
 	unsigned int lower, upper, temp;
 	do
 	{
-		asm volatile ("mftbu %0 \n mftb %1 \n mftbu %2 \n" 
+		asm volatile ("mftbu %0 \n mftb %1 \n mftbu %2 \n"
 			: "=r"(upper), "=r"(lower), "=r"(temp));
 	}
 	while (upper != temp);
 	return (static_cast<unsigned long long>(upper) << 32) | lower;
 #elif defined __aarch64__
-	// TODO: Implement and test on ARM64
-	return 0;
+	uint64_t vct;
+	asm volatile("mrs %0, cntvct_el0":"=r"(vct));
+	return vct;
 #elif defined __i386__ // i386
 	if (CPU.bRDTSC)
 	{

--- a/src/common/platform/posix/sdl/i_system.cpp
+++ b/src/common/platform/posix/sdl/i_system.cpp
@@ -144,7 +144,15 @@ void CalculateCPUSpeed()
 {
 	PerfAvailable = false;
 	PerfToMillisec = PerfToSec = 0.;
-#ifdef __linux__
+#ifdef __aarch64__
+	// [MK] on aarch64 rather than having to calculate cpu speed, there is
+	// already an independent frequency for the perf timer
+	uint64_t frq;
+	asm volatile("mrs %0, cntfrq_el0":"=r"(frq));
+	PerfAvailable = true;
+	PerfToSec = 1./frq;
+	PerfToMillisec = PerfToSec*1000.;
+#elif defined(__linux__)
 	// [MK] read from perf values if we can
 	struct perf_event_attr pe;
 	memset(&pe,0,sizeof(struct perf_event_attr));


### PR DESCRIPTION
I don't have the hardware to test this on fully, but at least I can verify that I've used the right inline asm for it.

Should be noted that the timers on ARM run at a separate frequency than the CPU itself, so this can't be used to calculate and print out the CPU speed on startup like in x86.