### PR TITLE
typo 'Yea' instead of 'Yes'

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1776,7 +1776,7 @@ OptionMenu "CompatMapMenu" protected
 	Option "$CMPTMNU_PUSHWINDOW",					"compat_pushwindow", "YesNo"
 	Option "$CMPTMNU_CHECKSWITCHRANGE",				"compat_checkswitchrange", "YesNo"
 	Option "$CMPTMNU_RAILINGHACK",					"compat_railing", "YesNo"
-	Option "$CMPTMNU_NOMBF21",						"compat_nombf21", "YeaNo"
+	Option "$CMPTMNU_NOMBF21",						"compat_nombf21", "YesNo"
 	Class "CompatibilityMenu"
 }
 


### PR DESCRIPTION
There is a typo in menudef which results in the NOMBF21 being 'Unknown' in the menu.