### PR TITLE
Toggleable player following.

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -423,6 +423,7 @@ enum ActorFlag8
 	MF8_MAP07BOSS2		= 0x00800000,	// MBF21 boss death.
 	MF8_AVOIDHAZARDS	= 0x01000000,	// MBF AI enhancement.
 	MF8_STAYONLIFT		= 0x02000000,	// MBF AI enhancement.
+	MF8_DONTFOLLOWPLAYERS	= 0x04000000,	// [inkoalwetrust] Friendly monster will not follow players.
 };
 
 // --- mobj.renderflags ---

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1092,7 +1092,7 @@ void P_RandomChaseDir (AActor *actor)
 	int turndir;
 
 	// Friendly monsters like to head toward a player
-	if (!(actor->flags8 & MF8_DONTFOLLOWPLAYERS) && actor->flags & MF_FRIENDLY)
+	if (actor->flags & MF_FRIENDLY && !(actor->flags8 & MF8_DONTFOLLOWPLAYERS))
 	{
 		AActor *player;
 		DVector2 delta;

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1092,7 +1092,7 @@ void P_RandomChaseDir (AActor *actor)
 	int turndir;
 
 	// Friendly monsters like to head toward a player
-	if (actor->flags & MF_FRIENDLY)
+	if (!(actor->flags8 & MF8_DONTFOLLOWPLAYERS) && actor->flags & MF_FRIENDLY)
 	{
 		AActor *player;
 		DVector2 delta;

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -338,6 +338,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, MAP07BOSS2, AActor, flags8),
 	DEFINE_FLAG(MF8, AVOIDHAZARDS, AActor, flags8),
 	DEFINE_FLAG(MF8, STAYONLIFT, AActor, flags8),
+	DEFINE_FLAG(MF8, DONTFOLLOWPLAYERS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
This pull request adds a new DONTFOLLOWPLAYERS flag. Which makes monsters not follow their' friendplayer when they have no goal or target to go to, or are wandering. Allowing them to properly wander around when P_RandomChaseDir is called, like non-friendly monsters can when doing the same.