### PR TITLE
gus timidity+ and wildmidi emulation fix

### DIFF
--- a/src/common/audio/music/i_music.cpp
+++ b/src/common/audio/music/i_music.cpp
@@ -200,7 +200,8 @@ static void SetupWgOpn()
 
 static void SetupDMXGUS()
 {
-	int lump = fileSystem.CheckNumForFullName("DMXGUS");
+	int lump = fileSystem.CheckNumForName("DMXGUSC", ns_global);
+	if (lump < 0) lump = fileSystem.CheckNumForName("DMXGUS", ns_global);
 	if (lump < 0)
 	{
 		return;

--- a/src/common/audio/music/music_config.cpp
+++ b/src/common/audio/music/music_config.cpp
@@ -278,7 +278,7 @@ CUSTOM_CVAR(String, opn_custom_bank, "", CVAR_ARCHIVE | CVAR_VIRTUAL)
 //==========================================================================
 
 
-CUSTOM_CVAR(String, midi_config, GAMENAMELOWERCASE, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
+CUSTOM_CVAR(String, midi_config, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_VIRTUAL)
 {
 	FORWARD_STRING_CVAR(gus_config);
 }

--- a/src/common/menu/menudef.cpp
+++ b/src/common/menu/menudef.cpp
@@ -1496,7 +1496,7 @@ static void InitMusicMenus()
 {
 	DMenuDescriptor **advmenu = MenuDescriptors.CheckKey("AdvSoundOptions");
 	auto soundfonts = sfmanager.GetList();
-	std::tuple<const char *, int, const char *> sfmenus[] = { std::make_tuple("GusConfigMenu", SF_SF2 | SF_GUS, "midi_config"),
+	std::tuple<const char *, int, const char *> sfmenus[] = { std::make_tuple("GusConfigMenu", SF_GUS, "midi_config"),
 																std::make_tuple("WildMidiConfigMenu", SF_GUS, "wildmidi_config"),
 																std::make_tuple("TimidityConfigMenu", SF_SF2 | SF_GUS, "timidity_config"),
 																std::make_tuple("FluidPatchsetMenu", SF_SF2, "fluid_patchset"),

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2103,7 +2103,7 @@ OptionMenu ModReplayerOptions protected
 	Title "$ADVSNDMNU_TIMIDITY"
 	LabeledSubMenu "$ADVSNDMNU_SELCONFIG",		"timidity_config", "TimidityConfigMenu"
 	Option "$ADVSNDMNU_REVERB", 			"timidity_reverb", "TimidityReverb"
-	Slider "$ADVSNDMNU_REVERB_LEVEL", 		"timidity_reverb_level", 9, 127, 1, 0
+	Slider "$ADVSNDMNU_REVERB_LEVEL", 		"timidity_reverb_level", 0, 127, 1, 0
 	Option "$ADVSNDMNU_CHORUS", 			"timidity_chorus", "OnOff"
 	// other CVARs need to be revieved for usefulness
  }


### PR DESCRIPTION
**This PR is linked to the following PR https://github.com/coelckers/ZMusic/pull/36**

Fixes for gus, timidity+ and wildmidi emulation
- fixed gus emulation not working with `DMXGUS` and `DMXGUSC` lump
- removed sf2 files from midi_config items for gus emulation (when using sf2 with gus emulation the sound is distorted), only resource files will be listed to be used with gus emulation.
- fixed `SetupDMXGUS` not loading lump correctly, wrong use of CheckNumForFullName, both DMXGUS and DMXGUSC will be recognized correctly
- added absolute paths to `FZipPatReader` so we can add custom patches along with the patches present in the resource file by using `gus_patchdir` and/or `ULTRADIR` variable (some custom maps has custom patches that can be added this way without putting them inside the resource file or in the same folder of the configuration file)
- `midi_config` default to empty string, since `gzdoom.sf2` doesn't seem supported (distorted sound)
- changed the order in which the configuration is read; the value of `midi_config`, `wildmidi_config` and `timidity_config` has precedence over the SoundFont collection built by SoundfontSearch.Directories. Now is possible to point the config property to a timidity configuration file inside a folder with GUS patches without it being overridden by the first valid SoundFont from the collection.

To properly test the DMXGUS configuration the `gus_memsize` can be tweaked so the sound will listen differently depending on the memory selected (256 / unlimited sounds way different).

Also to test the `midi_config` and `wildmidi_config` is better to remove paths from the section `SoundfontSearch.Directories` since a valid item is picked from the collection if no value has been set for these options.

A good example of custom `DMXGUSC` lump with custom patches is the map d2xtreme, where the music will sound quiet different whether you use the lump as configuration or the fallback timidity configuration
https://www.doomworld.com/idgames/levels/doom2/d-f/d2xtreme