### PR TITLE
Add MF8_SEEFRIENDLYMONSTERS.

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -423,7 +423,8 @@ enum ActorFlag8
 	MF8_MAP07BOSS2		= 0x00800000,	// MBF21 boss death.
 	MF8_AVOIDHAZARDS	= 0x01000000,	// MBF AI enhancement.
 	MF8_STAYONLIFT		= 0x02000000,	// MBF AI enhancement.
-	MF8_DONTFOLLOWPLAYERS	= 0x04000000,	// [inkoalwetrust] Friendly monster will not follow players.
+	MF8_DONTFOLLOWPLAYERS	= 0x04000000,	// [inkoalawetrust] Friendly monster will not follow players.
+	MF8_SEEFRIENDLYMONSTERS	= 0X08000000,	// [inkoalawetrust] Hostile monster can see friendly monsters.
 };
 
 // --- mobj.renderflags ---

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -339,6 +339,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(MF8, AVOIDHAZARDS, AActor, flags8),
 	DEFINE_FLAG(MF8, STAYONLIFT, AActor, flags8),
 	DEFINE_FLAG(MF8, DONTFOLLOWPLAYERS, AActor, flags8),
+	DEFINE_FLAG(MF8, SEEFRIENDLYMONSTERS, AActor, flags8),
 
 	// Effect flags
 	DEFINE_FLAG(FX, VISIBILITYPULSE, AActor, effects),


### PR DESCRIPTION
This PR adds a new flag for actors. That allows non-friendly monsters to be able to see and attack friendly monsters on sight.

It uses most of the same code as friendly monster sight, sans the check to find what particular player a friendly monster is allied to, as that's irrelevant for a monster hostile to all players. The PR reuses the FriendlySeeBlocks property for specifying how far away hostile monsters can see friendly ones.

I've also checked and made sure that the PR didn't interfere or break the existing monster seeing code that friendly monsters use.