### PR TITLE
SMF array on a per actor basis

### DIFF
--- a/src/common/models/model.cpp
+++ b/src/common/models/model.cpp
@@ -133,7 +133,7 @@ int ModelFrameHash(FSpriteModelFrame * smf)
 	const uint32_t *table = GetCRCTable ();
 	uint32_t hash = 0xffffffff;
 
-	const char * s = (const char *)(&smf->type);	// this uses type, sprite and frame for hashing
+	const char* s = (const char*)(&smf->sprite);	// this uses sprite and frame for hashing
 	const char * se= (const char *)(&smf->hashnext);
 
 	for (; s<se; s++)

--- a/src/common/models/model.h
+++ b/src/common/models/model.h
@@ -33,7 +33,6 @@ struct FSpriteModelFrame
 	float rotationCenterX, rotationCenterY, rotationCenterZ;
 	float rotationSpeed;
 	unsigned int flags;
-	const void* type;	// used for hashing, must point to something usable as identifier for the model's owner.
 	short sprite;
 	short frame;
 	int hashnext;

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -47,6 +47,7 @@
 #include "g_level.h"
 #include "tflags.h"
 #include "portal.h"
+#include <common/models/model.h>
 
 struct subsector_t;
 struct FBlockNode;
@@ -1050,6 +1051,9 @@ public:
 	DVector2		SpriteOffset;
 	double			Speed;
 	double			FloatSpeed;
+
+	TArray<FSpriteModelFrame> SpriteModelFrames;
+	TArray<int> SpriteModelHash;
 
 // interaction info
 	FBlockNode		*BlockNode;			// links in blocks (if needed)


### PR DESCRIPTION
- Each actor now has a SpriteModelFrames and SpriteModelHash array. This is important for allowing proper modeldef inheritance, and causes less bloat in an array with potentially millions of sprite model frames. In the future, it may be possible to manipulate models in more direct ways just by doing this.
- The global SMF and hashes are preserved for voxels since they aren't parsed the same way and are independent of actors.