### PR TITLE
Fix co-op softlock in Heretic E4M8 due to multiplayer teleporter

### DIFF
--- a/wadsrc/static/zscript/level_compatibility.zs
+++ b/wadsrc/static/zscript/level_compatibility.zs
@@ -987,6 +987,13 @@ class LevelCompatibility : LevelPostProcessor
 				break;
 			}
 
+			case '30D1480A6D4F3A3153739D4CCF659C4E': // heretic.wad E4M8
+			{
+				// multiplayer teleporter prevents exit on cooperative
+				SetThingFlags(78,MTF_DEATHMATCH);
+				break;
+			}
+
 			case '6CDA2721AA1076F063557CF89D88E92B': // hexen.wad map08
 			{
 				// Amulet of warding accidentally shifted outside of map


### PR DESCRIPTION
A teleporter right before the level exit is flagged as "multiplayer-only", which means it also exists in cooperative play, preventing players from finishing the map without cheating.

This small compat patch flags the teleport destination as deathmatch-only specifically.