### PR TITLE
Fix off-by-one in Vulkan multisample sample count selection

### DIFF
--- a/src/common/rendering/vulkan/renderer/vk_renderbuffers.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_renderbuffers.cpp
@@ -48,7 +48,7 @@ VkSampleCountFlagBits VkRenderBuffers::GetBestSampleCount()
 	int samples = 1;
 	VkSampleCountFlags bit = VK_SAMPLE_COUNT_1_BIT;
 	VkSampleCountFlags best = bit;
-	while (samples < requestedSamples)
+	while (samples <= requestedSamples)
 	{
 		if (deviceSampleCounts & bit)
 		{


### PR DESCRIPTION
Fixes getting half of the requested samples (and no MSAA if 2x was requested)