### PR TITLE
Quake 3D Distance Flag

### DIFF
--- a/src/playsim/a_sharedglobal.h
+++ b/src/playsim/a_sharedglobal.h
@@ -112,6 +112,7 @@ enum
 	QF_MAX =			1 << 3,
 	QF_FULLINTENSITY =	1 << 4,
 	QF_WAVE =			1 << 5,
+	QF_3D =				1 << 6,
 };
 
 struct FQuakeJiggers

--- a/src/playsim/mapthinkers/a_quake.cpp
+++ b/src/playsim/mapthinkers/a_quake.cpp
@@ -297,7 +297,11 @@ int DEarthquake::StaticGetQuakeIntensities(double ticFrac, AActor *victim, FQuak
 	{
 		if (quake->m_Spot != nullptr)
 		{
-			const double dist = quake->m_Spot->Distance2D(victim, true);
+			double dist;
+
+			if (quake->m_Flags & QF_3D)	dist = quake->m_Spot->Distance3D(victim, true);
+			else						dist = quake->m_Spot->Distance2D(victim, true);
+
 			if (dist < quake->m_TremorRadius)
 			{
 				++count;

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -633,6 +633,7 @@ enum EQuakeFlags
 	QF_MAX =			1 << 3,
 	QF_FULLINTENSITY =	1 << 4,
 	QF_WAVE =			1 << 5,
+	QF_3D =				1 << 6,
 };
 
 // A_CheckProximity flags


### PR DESCRIPTION
Added QF_3D flag for quakes. When used, the quake thinker will perform a 3D distance check instead of 2D.