### PR TITLE
Fix crash when loading Strife dialog on newer Clang compiler

### DIFF
--- a/src/maploader/strifedialogue.cpp
+++ b/src/maploader/strifedialogue.cpp
@@ -345,7 +345,7 @@ FStrifeDialogueNode *MapLoader::ReadRetailNode (const char *name, FileReader &lu
 	for (j = 0; j < 3; ++j)
 	{
 		auto inv = GetStrifeType(speech.ItemCheck[j]);
-		if (!inv->IsDescendantOf(NAME_Inventory)) inv = nullptr;
+		if (inv == NULL || !inv->IsDescendantOf(NAME_Inventory)) inv = nullptr;
 		node->ItemCheck[j].Item = inv;
 		node->ItemCheck[j].Amount = -1;
 	}
@@ -516,7 +516,7 @@ void MapLoader::ParseReplies (const char *name, int pos, FStrifeDialogueReply **
 		for (k = 0; k < 3; ++k)
 		{
 			auto inv = GetStrifeType(rsp->Item[k]);
-			if (!inv->IsDescendantOf(NAME_Inventory)) inv = nullptr;
+			if (inv == NULL || !inv->IsDescendantOf(NAME_Inventory)) inv = nullptr;
 			reply->ItemCheck[k].Item = inv;
 			reply->ItemCheck[k].Amount = rsp->Count[k];
 		}


### PR DESCRIPTION
GetStrifeType can return NULL. 
Seems like a very old bug which only worked because IsDescendantOf essentially checks 'this' for NULL first, but interestingly the new Clang compiler with optimisation is probably doing something out of order now.