### PR TITLE
Fix Relative Include for Folders

### DIFF
--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -425,7 +425,7 @@ PNamespace *ParseOneScript(const int baselump, ZCCParseState &state)
 		{
 			FString fullPath = IncludeLocs[i].FileName.GetChars(); // get full path, format 'wad:filepath/filename'
 			
-			auto start = fullPath.IndexOf(":"); // find first ':'
+			auto start = fullPath.LastIndexOf(":"); // find find separator between wad and path
 
 			auto end = fullPath.LastIndexOf("/"); // find last '/'
 


### PR DESCRIPTION
Relative includes for folders on windows fails due to the use `IndexOf`, because of the drive name (ex. C:\...), changing it to `LastIndexOf` fixes that.