### PR TITLE
Resolve build failure on i686-linux (g4.8.0)

### DIFF
--- a/src/common/engine/stats.h
+++ b/src/common/engine/stats.h
@@ -35,6 +35,9 @@
 #define __STATS_H__
 
 #include "zstring.h"
+#if defined __i386__
+#include "x86.h"
+#endif
 
 #if !defined _WIN32 && !defined __APPLE__
 


### PR DESCRIPTION
gcc had to say:

```
gzdoom-g4.8.0/src/common/engine/stats.h:83:13: error: 'CPU' was not declared in this scope
   83 |         if (CPU.bRDTSC)
```