### PR TITLE
Stop "Bad state label.." error if system puts memory at very high addresses.

### DIFF
--- a/src/scripting/thingdef.cpp
+++ b/src/scripting/thingdef.cpp
@@ -318,7 +318,7 @@ static void CheckLabel(PClassActor *obj, FStateLabel *slb, int useflag, FName st
 	auto state = slb->State;
 	if (state != nullptr)
 	{
-		if (intptr_t(state) <= 0xffff)
+		if (uintptr_t(state) <= 0xffff)
 		{
 			// can't do much here aside from printing a message and aborting.
 			I_Error("Bad state label %s in actor %s", slb->Label.GetChars(), obj->TypeName.GetChars());


### PR DESCRIPTION
If the system uses memory addresses above 0x8000000000000000 on 64bit or 0x80000000 on 32bit systems then this check will erroneously be hit as the number turns negative. 
Found on 32bit system (which isn't supported) so may not be relevant.