### PR TITLE
Fix lzma compile error on musl-based distributions

### DIFF
--- a/libraries/lzma/CMakeLists.txt
+++ b/libraries/lzma/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required( VERSION 3.1.0 )
 
 make_release_only()
 
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_7ZIP_PPMD_SUPPPORT" )
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_GNU_SOURCE -D_7ZIP_PPMD_SUPPPORT -D _7ZIP_AFFINITY_DISABLE" )
 
 find_package(Threads)
 


### PR DESCRIPTION
This commit fixes lzma compiler error when building GZDoom 4.8.1 and/or 4.8.2 in Alpine Linux and musl-based Linux distributions.

When compiling GZDoom 4.8.1 and/or 4.8.2 in Alpine Linux, `_GNU_SOURCE` is needed for `cpu_set_t`, and affinity disable is needed to work around lack of `pthread_attr_setaffinity_np` .

See also: [Merge Request discussion in aports](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/35711#note_243848).