### PR TITLE
Link zipdir against fts in order to build on musl-based distributions

### DIFF
--- a/tools/zipdir/CMakeLists.txt
+++ b/tools/zipdir/CMakeLists.txt
@@ -4,6 +4,6 @@ if( NOT CMAKE_CROSSCOMPILING )
 	include_directories( "${ZLIB_INCLUDE_DIR}" "${BZIP2_INCLUDE_DIR}" "${LZMA_INCLUDE_DIR}" )
 	add_executable( zipdir
 		zipdir.c )
-	target_link_libraries( zipdir ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} lzma )
+	target_link_libraries( zipdir ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} lzma fts )
 	set( CROSS_EXPORTS ${CROSS_EXPORTS} zipdir PARENT_SCOPE )
 endif()


### PR DESCRIPTION
Zipdir tool needs to be linked against fts in order to build on musl-based distributions