### PR TITLE
Expose Print Flags to ZScript

### DIFF
--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -1009,6 +1009,16 @@ DEFINE_ACTION_FUNCTION(_Console, Printf)
 	return 0;
 }
 
+DEFINE_ACTION_FUNCTION(_Console, PrintString)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(printlevel);
+	PARAM_STRING(str);
+
+	Printf(printlevel,"%s\n", str.GetChars());
+	return 0;
+}
+
 static void StopAllSounds()
 {
 	soundEngine->StopAllChannels();

--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -1009,13 +1009,15 @@ DEFINE_ACTION_FUNCTION(_Console, Printf)
 	return 0;
 }
 
-DEFINE_ACTION_FUNCTION(_Console, PrintString)
+DEFINE_ACTION_FUNCTION(_Console, PrintfEx)
 {
 	PARAM_PROLOGUE;
 	PARAM_INT(printlevel);
-	PARAM_STRING(str);
+	PARAM_VA_POINTER(va_reginfo)	// Get the hidden type information array
 
-	Printf(printlevel,"%s\n", str.GetChars());
+	FString s = FStringFormat(VM_ARGS_NAMES,1);
+
+	Printf(printlevel,"%s\n", s.GetChars());
 	return 0;
 }
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -615,7 +615,7 @@ struct Console native
 		PRINT_NOTIFY = 4096,	// Flag - add to game-native notify display - messages without this only go to the generic notification buffer.
 	};
 
-	native static void PrintString(int printlevel, string str);
+	native static vararg void PrintfEx(int printlevel, string fmt, ...);
 }
 
 struct CVar native

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -600,6 +600,22 @@ struct Console native
 {
 	native static void HideConsole();
 	native static vararg void Printf(string fmt, ...);
+	
+	enum EPrintLevel {
+		PRINT_LOW,				// pickup messages
+		PRINT_MEDIUM,			// death messages
+		PRINT_HIGH,				// critical messages
+		PRINT_CHAT,				// chat messages
+		PRINT_TEAMCHAT,			// chat messages from a teammate
+		PRINT_LOG,				// only to logfile
+		PRINT_BOLD = 200,		// What Printf_Bold used
+		PRINT_TYPES = 1023,		// Bitmask.
+		PRINT_NONOTIFY = 1024,	// Flag - do not add to notify buffer
+		PRINT_NOLOG = 2048,		// Flag - do not print to log file
+		PRINT_NOTIFY = 4096,	// Flag - add to game-native notify display - messages without this only go to the generic notification buffer.
+	};
+
+	native static void PrintString(int printlevel, string str);
 }
 
 struct CVar native


### PR DESCRIPTION
What the tile says: it exposes print flags to ZScript.

(inspired by #1408 , but much simpler -- does not change how printing works internally, just exposes what's already there to ZScript)

[Simple Example](https://github.com/coelckers/gzdoom/files/9079935/flagstest.zip)
