### PR TITLE
fix gzdoom.pk3 not found error

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3534,6 +3534,8 @@ static int D_DoomMain_Internal (void)
 	
 	std::set_new_handler(NewFailure);
 	const char *batchout = Args->CheckValue("-errorlog");
+
+	D_DoomInit();
 	
 	// [RH] Make sure zdoom.pk3 is always loaded,
 	// as it contains magic stuff we need.
@@ -3567,8 +3569,6 @@ static int D_DoomMain_Internal (void)
 	}
 
 	if (!batchrun) Printf(PRINT_LOG, "%s version %s\n", GAMENAME, GetVersionString());
-
-	D_DoomInit();
 
 	extern void D_ConfirmSendStats();
 	D_ConfirmSendStats();


### PR DESCRIPTION
This is an attempt at fixing #1615.

Move the initialization before BaseFileSearch is called, otherwise GameConfig is used not initialized and it doesn't find the gzdoom.pk3 file.

(GameConfig used uninitalized was spotted by @LoneFox78.)

I'm not familiar with the codebase, but looking at the code C_InitConsole depends on LoadHexFont, and thus on the wad being loaded.  I_DetectOS only looks at some hardcoded files and at uname, the rest of the code between the old D_DoomInit position and the new one are just printfs.  D_DoomInit doesn't seem to depend on C_InitConsole or I_DetectOS.

With this I'm finally able to run gzdoom 4.8.2 on OpenBSD and it correctly picks up `/usr/local/share/games/doom/gzdoom.pk3` 